### PR TITLE
retry keyspace and table creation, #4

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,5 +9,5 @@ target/
 .classpath
 .project
 .settings
-
+.tmpBin/
 /bin/

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -15,9 +15,6 @@ cassandra-journal {
   # Parameter indicating whether the journal keyspace should be auto created
   keyspace-autocreate = true
 
-  # In case that schema creation failed you can define a number of retries before giving up.
-  keyspace-autocreate-retries = 1
-
   # The number of retries when a write request returns a TimeoutException or an UnavailableException.
   write-retries = 3
 
@@ -29,7 +26,7 @@ cassandra-journal {
   connect-retries = 3
   
   # Delay between connection retries
-  connect-retry-delay = 5s
+  connect-retry-delay = 1s
 
   # Cassandra driver connection pool settings
   # Documented at https://datastax.github.io/java-driver/features/pooling/
@@ -160,14 +157,11 @@ cassandra-snapshot-store {
   # Parameter indicating whether the snapshot keyspace should be auto created
   keyspace-autocreate = true
 
-  # In case that schema creation failed you can define a number of retries before giving up.
-  keyspace-autocreate-retries = 1
-  
   # Number of retries before giving up connecting to the cluster
   connect-retries = 3
   
   # Delay between connection retries
-  connect-retry-delay = 5s
+  connect-retry-delay = 1s
 
   # Cassandra driver connection pool settings
   # Documented at https://datastax.github.io/java-driver/features/pooling/

--- a/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -9,7 +9,6 @@ import com.typesafe.config.Config
 import scala.collection.JavaConverters._
 import scala.concurrent.duration._
 
-
 class CassandraPluginConfig(config: Config) {
 
   import akka.persistence.cassandra.CassandraPluginConfig._
@@ -22,7 +21,6 @@ class CassandraPluginConfig(config: Config) {
   val tableCompactionStrategy: CassandraCompactionStrategy = CassandraCompactionStrategy(config.getConfig("table-compaction-strategy"))
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
-  val keyspaceAutoCreateRetries: Int = config.getInt("keyspace-autocreate-retries")
 
   val connectionRetries: Int = config.getInt("connect-retries")
   val connectionRetryDelay: FiniteDuration = config.getDuration("connect-retry-delay", TimeUnit.MILLISECONDS).millis

--- a/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigTest.scala
@@ -3,7 +3,7 @@ package akka.persistence.cassandra
 import java.net.InetSocketAddress
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.{ MustMatchers, WordSpec }
 import org.scalatest.prop.TableDrivenPropertyChecks._
 
 import scala.util.Random
@@ -15,7 +15,6 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
   lazy val defaultConfig = ConfigFactory.parseString(
     """
       |keyspace-autocreate = true
-      |keyspace-autocreate-retries = 1
       |keyspace = test-keyspace
       |connect-retries = 3
       |connect-retry-delay = 5s
@@ -45,38 +44,35 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
       |delete-retries = 4
     """.stripMargin)
 
-
   lazy val keyspaceNames = {
     // Generate a key that is the max acceptable length ensuring the first char is alpha
     def maxKey = Random.alphanumeric.dropWhile(_.toString.matches("[^a-zA-Z]")).take(48).mkString
 
-    Table (
+    Table(
       ("Keyspace", "isValid"),
-      ("test",        true),
-      ("_test_123",   false),
-      ("",            false),
-      ("test-space",  false),
-      ("'test'",      false),
-      ("a",           true),
-      ("a_",          true),
-      ("1",           false),
-      ("a1",          true),
-      ("_",           false),
-      ("asdf!",       false),
-      (maxKey,        true),
-      ("\"_asdf\"",   false),
-      ("\"_\"",       false),
-      ("\"a\"",       true),
-      ("\"a_sdf\"",   true),
-      ("\"\"",        false),
-      ("\"valid_with_quotes\"",       true),
-      ("\"missing_trailing_quote",    false),
-      ("missing_leading_quote\"",     false),
-      ('"' + maxKey + '"',            true),
-      (maxKey + "_",                  false)
-    )
+      ("test", true),
+      ("_test_123", false),
+      ("", false),
+      ("test-space", false),
+      ("'test'", false),
+      ("a", true),
+      ("a_", true),
+      ("1", false),
+      ("a1", true),
+      ("_", false),
+      ("asdf!", false),
+      (maxKey, true),
+      ("\"_asdf\"", false),
+      ("\"_\"", false),
+      ("\"a\"", true),
+      ("\"a_sdf\"", true),
+      ("\"\"", false),
+      ("\"valid_with_quotes\"", true),
+      ("\"missing_trailing_quote", false),
+      ("missing_leading_quote\"", false),
+      ('"' + maxKey + '"', true),
+      (maxKey + "_", false))
   }
-
 
   "A CassandraPluginConfig" should {
     "set the fetch size to the max result size" in {
@@ -90,26 +86,22 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
     }
 
     "parse config with host:port values as contact points" in {
-      val configWithHostPortPair = ConfigFactory.parseString( """contact-points = ["127.0.0.1:19142", "127.0.0.1:29142"]""").withFallback(defaultConfig)
+      val configWithHostPortPair = ConfigFactory.parseString("""contact-points = ["127.0.0.1:19142", "127.0.0.1:29142"]""").withFallback(defaultConfig)
       val config = new CassandraPluginConfig(configWithHostPortPair)
       config.contactPoints must be(
         List(
           new InetSocketAddress("127.0.0.1", 19142),
-          new InetSocketAddress("127.0.0.1", 29142)
-        )
-      )
+          new InetSocketAddress("127.0.0.1", 29142)))
 
     }
 
     "parse config with a list of contact points without port" in {
-      lazy val configWithHosts = ConfigFactory.parseString( """contact-points = ["127.0.0.1", "127.0.0.2"]""").withFallback(defaultConfig)
+      lazy val configWithHosts = ConfigFactory.parseString("""contact-points = ["127.0.0.1", "127.0.0.2"]""").withFallback(defaultConfig)
       val config = new CassandraPluginConfig(configWithHosts)
       config.contactPoints must be(
         List(
           new InetSocketAddress("127.0.0.1", 9142),
-          new InetSocketAddress("127.0.0.2", 9142)
-        )
-      )
+          new InetSocketAddress("127.0.0.2", 9142)))
     }
 
     "throw an exception when contact point list is empty" in {
@@ -156,7 +148,7 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
 
     "validate keyspace parameter" in {
       forAll(keyspaceNames) { (keyspace, isValid) =>
-        if(isValid) CassandraPluginConfig.validateKeyspaceName(keyspace) must be(keyspace)
+        if (isValid) CassandraPluginConfig.validateKeyspaceName(keyspace) must be(keyspace)
         else intercept[IllegalArgumentException] {
           CassandraPluginConfig.validateKeyspaceName(keyspace)
         }
@@ -165,16 +157,15 @@ class CassandraPluginConfigTest extends WordSpec with MustMatchers {
 
     "validate table name parameter" in {
       forAll(keyspaceNames) { (tableName, isValid) =>
-        if(isValid) CassandraPluginConfig.validateKeyspaceName(tableName) must be(tableName)
+        if (isValid) CassandraPluginConfig.validateKeyspaceName(tableName) must be(tableName)
         else intercept[IllegalArgumentException] {
           CassandraPluginConfig.validateKeyspaceName(tableName)
         }
       }
     }
 
-
     "parse keyspace-autocreate parameter" in {
-      val configWithFalseKeyspaceAutocreate = ConfigFactory.parseString( """keyspace-autocreate = false""").withFallback(defaultConfig)
+      val configWithFalseKeyspaceAutocreate = ConfigFactory.parseString("""keyspace-autocreate = false""").withFallback(defaultConfig)
 
       val config = new CassandraPluginConfig(configWithFalseKeyspaceAutocreate)
       config.keyspaceAutoCreate must be(false)

--- a/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -11,7 +11,6 @@ import org.scalatest.{ MustMatchers, WordSpec }
 class CassandraCompactionStrategySpec extends WordSpec with MustMatchers with CassandraLifecycle {
   val defaultConfigs = ConfigFactory.parseString(
     s"""keyspace-autocreate = true
-      |keyspace-autocreate-retries = 1
       |keyspace = test-keyspace
       |connect-retries = 3
       |connect-retry-delay = 5s


### PR DESCRIPTION
* The "Column family ID mismatch" exception
  seems to happen when two different sessions
  create the keyspace at the "same" time and then
  they create the same tables. The exception is thrown
  when creating the tables.
* This may happen when write and read-side journals are
  started at the same time
* Changed the retry logic to retry not only the connect and
  the keyspace creation, but the whole initialization including
  creation of tables
* Removed keyspace-autocreate-retries config, connect-retries
  is enough
* Changed connect-retry-delay to 1s
* Create of metadata table also from read journal
* Also placed the execute of creation of keyspace and tables in
  synchronized block to reduce the risk of "Column family ID mismatch"
  This is not important for correctness, but improves the "experience"
  because the error logging and retries are avoided when running on
  single machine (dev)