### PR TITLE
Poll early when journal has written a tagged event

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -64,6 +64,7 @@ val AkkaVersion = "2.4.1"
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.0.0-rc1",
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
+  "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query-experimental" % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion      % "test",
   "org.scalatest"          %% "scalatest"                           % "2.1.4"      % "test",

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -189,6 +189,17 @@ cassandra-journal {
   # but you cannot combine BlogPosts and Authors, since they have the same tag identifier.  
   tags {
   }
+  
+  # Minimum time between publishing messages to DistributedPubSub to announce events for a specific tag have
+  # been written. These announcements cause any ongoing getEventsByTag to immediately re-poll, rather than
+  # wait. In order enable this feature, make the following settings:
+  #  
+  #    - enable clustering for your actor system
+  #    - cassandra-journal.pubsub-minimum-interval = 1s              (send real-time announcements at most every sec)
+  #    - cassandra-query-journal.eventual-consistency-delay = 0s     (so it immediately tries to show changes)
+  #
+  # Setting pubsub-minimum-interval to "off" will disable the journal sending these announcements. 
+  pubsub-minimum-interval = off
 }
 
 cassandra-snapshot-store {

--- a/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.journal
+
+import scala.concurrent.duration.FiniteDuration
+
+import akka.actor.{ Actor, ActorRef }
+
+/**
+ * Proxies messages to another actor, only allowing identical messages through once every [interval].
+ */
+private[journal] class PubSubThrottler(delegate: ActorRef, interval: FiniteDuration) extends Actor {
+  import PubSubThrottler._
+  import context.dispatcher
+
+  /** The messages we've already seen during this interval */
+  val seen = collection.mutable.Set.empty[Any]
+
+  /** The messages we've seen more than once during this interval, and their sender(s). */
+  val repeated = collection.mutable.Map.empty[Any, Set[ActorRef]].withDefaultValue(Set.empty)
+
+  val timer = context.system.scheduler.schedule(interval, interval, self, Tick)
+
+  def receive = {
+    case Tick =>
+      for (
+        (msg, clients) <- repeated;
+        client <- clients
+      ) {
+        delegate.tell(msg, client)
+      }
+      seen.clear()
+      repeated.clear()
+
+    case msg =>
+      if (seen.contains(msg)) {
+        repeated += (msg -> (repeated(msg) + sender))
+      } else {
+        delegate forward msg
+        seen += msg
+      }
+
+  }
+
+  override def postStop() = {
+    timer.cancel()
+    super.postStop()
+  }
+}
+
+private[journal] object PubSubThrottler {
+  private case object Tick
+
+}

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -25,4 +25,5 @@ private[query] class CassandraReadJournalConfig(config: Config, writePluginConfi
   val keyspace: String = writePluginConfig.keyspace
   val targetPartitionSize: Int = writePluginConfig.targetPartitionSize
   val table: String = writePluginConfig.table
+  val pubsubMinimumInterval: Duration = writePluginConfig.pubsubMinimumInterval
 }

--- a/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -18,7 +18,7 @@ object CassandraLifecycle {
   def awaitPersistenceInit(system: ActorSystem): Unit = {
     val probe = TestProbe()(system)
     system.actorOf(Props[AwaitPersistenceInit]).tell("hello", probe.ref)
-    probe.expectMsg(25.seconds, "hello")
+    probe.expectMsg(35.seconds, "hello")
   }
 
   class AwaitPersistenceInit extends PersistentActor {

--- a/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
@@ -19,11 +19,12 @@ object MultiPluginSpec {
   val cassandraPort = CassandraLauncher.randomPort
   val config = ConfigFactory.parseString(
     s"""
-        |akka.test.single-expect-default = 10s
+        |akka.test.single-expect-default = 20s
         |
         |cassandra-journal.keyspace = $journalKeyspace
         |cassandra-journal.port=$cassandraPort
         |cassandra-journal.keyspace-autocreate=false
+        |cassandra-journal.circuit-breaker.call-timeout = 30s
         |cassandra-snapshot-store.keyspace=$snapshotKeyspace
         |cassandra-snapshot-store.port=$cassandraPort
         |cassandra-snapshot-store.keyspace-autocreate=false

--- a/src/test/scala/akka/persistence/cassandra/journal/PubSubThrottlerSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/PubSubThrottlerSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.journal
+
+import scala.concurrent.duration.DurationInt
+
+import org.scalatest.{ MustMatchers, WordSpecLike }
+
+import akka.actor.{ ActorSystem, Props }
+import akka.testkit.{ TestKit, TestProbe }
+
+class PubSubThrottlerSpec extends TestKit(ActorSystem("CassandraConfigCheckerSpec"))
+  with WordSpecLike with MustMatchers {
+  "PubSubThrottler" should {
+    "eat up duplicate messages that arrive within the same [interval] window" in {
+      val delegate = TestProbe()
+      val throttler = system.actorOf(Props(new PubSubThrottler(delegate.ref, 5.seconds)))
+
+      throttler ! "hello"
+      throttler ! "hello"
+      throttler ! "hello"
+      delegate.within(2.seconds) {
+        delegate.expectMsg("hello")
+      }
+      // Only first "hello" makes it through during the first interval.
+      delegate.expectNoMsg(2.seconds)
+
+      // Eventually, the interval will roll over and forward ONE further hello.
+      delegate.expectMsg("hello")
+      delegate.expectNoMsg(2.seconds)
+
+      throttler ! "hello"
+      delegate.within(2.seconds) {
+        delegate.expectMsg("hello")
+      }
+    }
+
+    "allow differing messages to pass through within the same [interval] window" in {
+      val delegate = TestProbe()
+      val throttler = system.actorOf(Props(new PubSubThrottler(delegate.ref, 5.seconds)))
+      throttler ! "hello"
+      throttler ! "world"
+      delegate.within(2.seconds) {
+        delegate.expectMsg("hello")
+        delegate.expectMsg("world")
+      }
+    }
+  }
+}

--- a/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
@@ -25,10 +25,11 @@ import scala.util.Try
 object AllPersistenceIdsSpec {
   val config = s"""
     akka.loglevel = INFO
-    akka.test.single-expect-default = 10s
+    akka.test.single-expect-default = 20s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
     cassandra-journal.keyspace=AllPersistenceIdsSpec
+    cassandra-journal.circuit-breaker.call-timeout = 30s
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 10

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -21,10 +21,11 @@ import akka.stream.testkit.scaladsl.TestSink
 object EventsByPersistenceIdSpec {
   val config = s"""
     akka.loglevel = DEBUG
-    akka.test.single-expect-default = 10s
+    akka.test.single-expect-default = 20s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
     cassandra-journal.keyspace=EventsByPersistenceIdSpec
+    cassandra-journal.circuit-breaker.call-timeout = 30s
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 2

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.query
+
+import java.nio.ByteBuffer
+import java.time.LocalDate
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.temporal.ChronoUnit
+import java.util.UUID
+import scala.concurrent.duration._
+import scala.util.Try
+import akka.actor.ActorSystem
+import akka.persistence.PersistentRepr
+import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.journal.CassandraJournalConfig
+import akka.persistence.cassandra.journal.CassandraStatements
+import akka.persistence.cassandra.journal.TimeBucket
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.cassandra.testkit.CassandraLauncher
+import akka.persistence.journal.Tagged
+import akka.persistence.journal.WriteEventAdapter
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.PersistenceQuery
+import akka.persistence.query.scaladsl.CurrentEventsByTagQuery
+import akka.persistence.query.scaladsl.EventsByTagQuery
+import akka.serialization.SerializationExtension
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.TestSubscriber
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.ImplicitSender
+import akka.testkit.TestKit
+import com.datastax.driver.core.utils.UUIDs
+import com.typesafe.config.ConfigFactory
+import org.scalatest.Matchers
+import org.scalatest.WordSpecLike
+import akka.cluster.Cluster
+
+object EventsByTagPubsubSpec {
+  val today = LocalDate.now(ZoneOffset.UTC)
+
+  val config = ConfigFactory.parseString(s"""
+    akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    cassandra-journal {
+      pubsub-minimum-interval = 1 millisecond      
+    }
+    cassandra-query-journal {
+      refresh-interval = 10s
+      eventual-consistency-delay = 0s
+    }
+    """).withFallback(EventsByTagSpec.config)
+}
+
+class EventsByTagPubsubSpec extends TestKit(ActorSystem("EventsByTagPubsubSpec", EventsByTagPubsubSpec.config))
+  with ImplicitSender with WordSpecLike with Matchers with CassandraLifecycle {
+  import EventsByTagSpec._
+
+  override def systemName: String = "EventsByTagPubsubSpec"
+  implicit val mat = ActorMaterializer()(system)
+  lazy val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+  val writePluginConfig = new CassandraJournalConfig(system.settings.config.getConfig("cassandra-journal"))
+  lazy val session = {
+    val cluster = writePluginConfig.clusterBuilder.build
+    cluster.connect()
+  }
+
+  override protected def beforeAll(): Unit = {
+    super.beforeAll()
+    Cluster(system).join(Cluster(system).selfAddress)
+  }
+
+  override protected def afterAll(): Unit = {
+    Try(session.close())
+    Try(session.getCluster.close())
+    super.afterAll()
+  }
+
+  "Cassandra query getEventsByTag when running clustered with pubsub enabled" must {
+    "present new events to an ongoing getEventsByTag stream long before polling would kick in" in {
+      val actor = system.actorOf(TestActor.props("EventsByTagPubsubSpec_a"))
+
+      val blackSrc = queries.eventsByTag(tag = "black", offset = 0L)
+      val probe = blackSrc.runWith(TestSink.probe[Any])
+      probe.request(2)
+
+      actor ! "a black car"
+      probe.within(2.seconds) { // long before refresh-interval, which is 10s
+        probe.expectNextPF { case e @ EventEnvelope(_, _, _, "a black car") => e }
+      }
+    }
+  }
+}
+

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -47,6 +47,9 @@ object EventsByTagSpec {
     akka.test.single-expect-default = 10s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal {
+      circuit-breaker {
+        call-timeout = 30s       # bringing up cassandra's unit test system can take a bit of time.
+      }
       #target-partition-size = 5
       port = ${CassandraLauncher.randomPort}
       keyspace=EventsByTagSpec

--- a/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
@@ -22,10 +22,11 @@ import akka.stream.testkit.scaladsl.TestSink
 object CassandraReadJournalSpec {
   val config = s"""
     akka.loglevel = INFO
-    akka.test.single-expect-default = 10s
+    akka.test.single-expect-default = 20s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
     cassandra-journal.keyspace=JavadslCassandraReadJournalSpec
+    cassandra-journal.circuit-breaker.call-timeout = 30s
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.eventual-consistency-delay = 1s

--- a/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -22,10 +22,11 @@ import akka.stream.testkit.scaladsl.TestSink
 object CassandraReadJournalSpec {
   val config = s"""
     akka.loglevel = INFO
-    akka.test.single-expect-default = 10s
+    akka.test.single-expect-default = 20s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
     cassandra-journal.keyspace=ScaladslCassandraReadJournalSpec
+    cassandra-journal.circuit-breaker.call-timeout = 30s
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.eventual-consistency-delay = 1s


### PR DESCRIPTION
We're applying akka-persistence-cassandra for a chat-like service, and would like emitted events to appear at an ongoing `getEventsByTag` stream as soon as possible. We're OK running with `eventual-consistency-delay = 0s`.

This PR signals any ongoing read queries whenever events matching a certain tag have been written to the journal. The query uses this information to do a cassandra poll ahead of time. This allows an ongoing stream to see that event almost immediately.

We do this using akka's clustered `DistributedPubSub` mechanism. When the application is not clustered, it will simply fall back to the existing polling.