### PR TITLE
possibility to disable materialized view, #22

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -73,10 +73,14 @@ cassandra-journal {
 
   # Name of the table to be created/used for journal config
   config-table = "config"
+
+  # Possibility to disable the eventsByTag query and creation of
+  # the materialized view.
+  enable-events-by-tag-query = on
   
   # Name of the materialized view for eventsByTag query
   events-by-tag-view = "eventsbytag"
-
+  
   # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
   replication-strategy = "SimpleStrategy"
 

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -17,6 +17,7 @@ class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(confi
   val maxMessageBatchSize = config.getInt("max-message-batch-size")
   val deleteRetries: Int = config.getInt("delete-retries")
   val writeRetries: Int = config.getInt("write-retries")
+  val enableEventsByTagQuery = config.getBoolean("enable-events-by-tag-query")
   val eventsByTagView: String = config.getString("events-by-tag-view")
 
   val maxTagsPerEvent: Int = 3
@@ -35,7 +36,12 @@ class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(confi
     }(collection.breakOut)
   }
 
-  def maxTagId: Int = if (tags.isEmpty) 1 else tags.values.max
+  /**
+   * Will be 0 if [[#enableEventsByTagQuery]] is disabled,
+   * will be 1 if [[#tags]] is empty, otherwise the number of configured
+   * distinct tag identifiers.
+   */
+  def maxTagId: Int = if (!enableEventsByTagQuery) 0 else if (tags.isEmpty) 1 else tags.values.max
 }
 
 object CassandraJournalConfig {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -124,6 +124,8 @@ trait CassandraStatements {
    * when write and read-side plugins are started at the same time.
    * Those statements are retried, because that could happen across different
    * nodes also but synchronizing those statements gives a better "experience".
+   *
+   * The materialized view for eventsByTag query is not created if `maxTagId` is 0.
    */
   def executeCreateKeyspaceAndTables(session: Session, keyspaceAutoCreate: Boolean, maxTagId: Int): Unit =
     CassandraStatements.createKeyspaceAndTablesLock.synchronized {


### PR DESCRIPTION
I also had some thought about making the creation of the materialized view lazy, but I don't want to complicate the initialization logic, especially since we need to work on the [blocking](https://github.com/akka/akka-persistence-cassandra/issues/6) issue later.