### PR TITLE
mark local messages with NoSerializationVerificationNeeded

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/query/AllPersistenceIdsPublisher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/AllPersistenceIdsPublisher.scala
@@ -5,20 +5,20 @@ package akka.persistence.cassandra.query
 
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
-
 import akka.actor.Props
 import com.datastax.driver.core.{ Row, ResultSet, Session, PreparedStatement }
-
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.query.AllPersistenceIdsPublisher._
 import akka.persistence.cassandra.query.QueryActorPublisher._
+import akka.actor.NoSerializationVerificationNeeded
 
 private[query] object AllPersistenceIdsPublisher {
   private[query] final case class AllPersistenceIdsSession(
     selectDistinctPersistenceIds: PreparedStatement,
     session:                      Session
-  )
+  ) extends NoSerializationVerificationNeeded
   private[query] final case class ReplayDone(resultSet: Option[ResultSet])
+    extends NoSerializationVerificationNeeded
   private[query] final case class AllPersistenceIdsState(knownPersistenceIds: Set[String])
 
   def props(

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
@@ -21,10 +21,12 @@ import akka.actor.ActorLogging
 import scala.annotation.tailrec
 import akka.actor.DeadLetterSuppression
 import akka.persistence.cassandra.journal.TimeBucket
+import akka.actor.NoSerializationVerificationNeeded
 
 private[query] object EventsByTagFetcher {
 
-  private final case class InitResultSet(rs: ResultSet) extends DeadLetterSuppression
+  private final case class InitResultSet(rs: ResultSet)
+    extends DeadLetterSuppression with NoSerializationVerificationNeeded
   private case object Fetched extends DeadLetterSuppression
 
   def props(tag: String, timeBucket: TimeBucket, fromOffset: UUID, toOffset: UUID, limit: Int,

--- a/src/main/scala/akka/persistence/cassandra/query/QueryActorPublisher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/QueryActorPublisher.scala
@@ -21,10 +21,12 @@ object QueryActorPublisher {
   private[query] final case class ReplayFailed(cause: Throwable)
     extends DeadLetterSuppression with NoSerializationVerificationNeeded
 
-  sealed trait Action
+  sealed trait Action extends NoSerializationVerificationNeeded
   final case class NewResultSet(rs: ResultSet) extends Action
   final case class FetchedResultSet(rs: ResultSet) extends Action
   final case class Finished(resultSet: ResultSet) extends Action
+
+  private case object Continue
 }
 
 //TODO: Handle database timeout, retry and failure handling.
@@ -47,11 +49,9 @@ private[query] abstract class QueryActorPublisher[MessageType, State: ClassTag](
   extends ActorPublisher[MessageType]
   with ActorLogging {
 
-  private[this] sealed trait InitialAction
+  private[this] sealed trait InitialAction extends NoSerializationVerificationNeeded
   private[this] case class InitialNewResultSet(s: State, rs: ResultSet) extends InitialAction
   private[this] case class InitialFinished(s: State, rs: ResultSet) extends InitialAction
-
-  private[this] case object Continue
 
   import context.dispatcher
 

--- a/src/test/resources/reference.conf
+++ b/src/test/resources/reference.conf
@@ -1,2 +1,3 @@
 cassandra-journal.circuit-breaker.call-timeout = 30s
 akka.test.single-expect-default = 20s
+akka.actor.serialize-messages=on

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -21,6 +21,12 @@ object CassandraJournalConfiguration {
       |cassandra-journal.circuit-breaker.call-timeout = 20s
     """.stripMargin
   )
+
+  lazy val perfConfig = ConfigFactory.parseString(
+    """
+    akka.actor.serialize-messages=off
+    """
+  ).withFallback(config)
 }
 
 class CassandraJournalSpec extends JournalSpec(CassandraJournalConfiguration.config) with CassandraLifecycle {
@@ -29,7 +35,7 @@ class CassandraJournalSpec extends JournalSpec(CassandraJournalConfiguration.con
   override def supportsRejectingNonSerializableObjects = false
 }
 
-class CassandraJournalPerfSpec extends JournalPerfSpec(CassandraJournalConfiguration.config) with CassandraLifecycle {
+class CassandraJournalPerfSpec extends JournalPerfSpec(CassandraJournalConfiguration.perfConfig) with CassandraLifecycle {
   override def systemName: String = "CassandraJournalPerfSpec"
 
   override def awaitDurationMillis: Long = 20.seconds.toMillis

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
@@ -25,6 +25,7 @@ object CassandraLoadSpec {
       |cassandra-journal.replication-strategy = NetworkTopologyStrategy
       |cassandra-journal.data-center-replication-factors = ["dc1:1"]
       |cassandra-journal.circuit-breaker.call-timeout = 20s
+      |akka.actor.serialize-messages=off
     """.stripMargin
   )
 


### PR DESCRIPTION
* to support testing with akka.actor.serialize-messages=on
* our tests are now running with akka.actor.serialize-messages=on
  apart from perf tests, so that we detect this in the future