### PR TITLE
optimize asyncDeleteMessagesTo, #7

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -73,9 +73,20 @@ cassandra-journal {
 
   # Name of the table to be created/used for journal config
   config-table = "config"
+  
+  # Set this to on to only use Cassandra 2.x compatible features,
+  # i.e. if you are using a Cassandra 2.x server.
+  # To run tests with Cassandra 2.x server you have to do the following:
+  # - start Cassandra 2.x server on default port 9042, with empty data directory
+  # - change CassandraLauncher.randomPort to 9042
+  # - change CassandraLauncher.start to do nothing
+  # - set this cassandra-2x-compat = on
+  # - note that you must delete all data between each test run
+  cassandra-2x-compat = off
 
   # Possibility to disable the eventsByTag query and creation of
-  # the materialized view.
+  # the materialized view. This will automatically be off when
+  # cassandra-2x-compat=on 
   enable-events-by-tag-query = on
   
   # Name of the materialized view for eventsByTag query

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -17,7 +17,8 @@ class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(confi
   val maxMessageBatchSize = config.getInt("max-message-batch-size")
   val deleteRetries: Int = config.getInt("delete-retries")
   val writeRetries: Int = config.getInt("write-retries")
-  val enableEventsByTagQuery = config.getBoolean("enable-events-by-tag-query")
+  val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
+  val enableEventsByTagQuery: Boolean = !cassandra2xCompat && config.getBoolean("enable-events-by-tag-query")
   val eventsByTagView: String = config.getString("events-by-tag-view")
 
   val maxTagsPerEvent: Int = 3

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -68,6 +68,23 @@ trait CassandraStatements {
         sequence_nr = ?
     """
 
+  def deleteMessages = {
+    if (config.cassandra2xCompat)
+      s"""
+      DELETE FROM ${tableName} WHERE
+        persistence_id = ? AND
+        partition_nr = ? AND
+        sequence_nr = ?
+    """
+    else
+      s"""
+      DELETE FROM ${tableName} WHERE
+        persistence_id = ? AND
+        partition_nr = ? AND
+        sequence_nr <= ?
+    """
+  }
+
   def selectMessages = s"""
       SELECT * FROM ${tableName} WHERE
         persistence_id = ? AND

--- a/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -22,6 +22,8 @@ object CassandraCompactionStrategySpec {
       |akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
       |cassandra-journal.port = ${CassandraLauncher.randomPort}
       |cassandra-snapshot-store.port = ${CassandraLauncher.randomPort}
+      |cassandra-journal.keyspace=CassandraCompactionStrategySpec
+      |cassandra-snapshot-store.keyspace=CassandraCompactionStrategySpecSnapshot
     """.stripMargin
   )
 }

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -30,6 +30,8 @@ object CassandraIntegrationSpec {
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.port = ${CassandraLauncher.randomPort}
       |cassandra-snapshot-store.port = ${CassandraLauncher.randomPort}
+      |cassandra-journal.keyspace=CassandraIntegrationSpec
+      |cassandra-snapshot-store.keyspace=CassandraIntegrationSpecSnapshot
       |cassandra-journal.circuit-breaker.call-timeout = 20s
     """.stripMargin
   )

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -18,6 +18,8 @@ object CassandraJournalConfiguration {
       |akka.test.single-expect-default = 20s
       |cassandra-journal.port = ${CassandraLauncher.randomPort}
       |cassandra-snapshot-store.port = ${CassandraLauncher.randomPort}
+      |cassandra-journal.keyspace=CassandraJournalSpec
+      |cassandra-snapshot-store.keyspace=CassandraJournalSpecSnapshot
       |cassandra-journal.circuit-breaker.call-timeout = 20s
     """.stripMargin
   )
@@ -25,6 +27,8 @@ object CassandraJournalConfiguration {
   lazy val perfConfig = ConfigFactory.parseString(
     """
     akka.actor.serialize-messages=off
+    cassandra-journal.keyspace=CassandraJournalPerfSpec
+    cassandra-snapshot-store.keyspace=CassandraJournalPerfSpecSnapshot
     """
   ).withFallback(config)
 }

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
@@ -25,6 +25,8 @@ object CassandraLoadSpec {
       |cassandra-journal.replication-strategy = NetworkTopologyStrategy
       |cassandra-journal.data-center-replication-factors = ["dc1:1"]
       |cassandra-journal.circuit-breaker.call-timeout = 20s
+      |cassandra-journal.keyspace=CassandraLoadSpec
+      |cassandra-snapshot-store.keyspace=CassandraLoadSpecSnapshot
       |akka.actor.serialize-messages=off
     """.stripMargin
   )

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraSslSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraSslSpec.scala
@@ -29,6 +29,8 @@ object CassandraSslSpec {
         |cassandra-journal.max-result-size = 3
         |cassandra-journal.port = ${CassandraLauncher.randomPort}
         |cassandra-snapshot-store.port = ${CassandraLauncher.randomPort}
+        |cassandra-journal.keyspace=CassandraSslSpec${if (keyStore) 1 else 2}
+        |cassandra-snapshot-store.keyspace=CassandraLoadSpec${if (keyStore) 1 else 2}Snapshot
         |cassandra-journal.circuit-breaker.call-timeout = 20s
         |cassandra-snapshot-store.ssl.truststore.path="src/test/resources/security/cts_truststore.jks"
         |cassandra-snapshot-store.ssl.truststore.password="hbbUtqn3Y1D4Tw"

--- a/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
@@ -28,6 +28,7 @@ object AllPersistenceIdsSpec {
     akka.test.single-expect-default = 10s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
+    cassandra-journal.keyspace=AllPersistenceIdsSpec
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 10

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -24,6 +24,7 @@ object EventsByPersistenceIdSpec {
     akka.test.single-expect-default = 10s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
+    cassandra-journal.keyspace=EventsByPersistenceIdSpec
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 2

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -49,6 +49,7 @@ object EventsByTagSpec {
     cassandra-journal {
       #target-partition-size = 5
       port = ${CassandraLauncher.randomPort}
+      keyspace=EventsByTagSpec
       event-adapters {
         color-tagger  = akka.persistence.cassandra.query.ColorFruitTagger
       }

--- a/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
@@ -25,6 +25,7 @@ object CassandraReadJournalSpec {
     akka.test.single-expect-default = 10s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
+    cassandra-journal.keyspace=JavadslCassandraReadJournalSpec
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.eventual-consistency-delay = 1s

--- a/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -25,6 +25,7 @@ object CassandraReadJournalSpec {
     akka.test.single-expect-default = 10s
     akka.persistence.journal.plugin = "cassandra-journal"
     cassandra-journal.port = ${CassandraLauncher.randomPort}
+    cassandra-journal.keyspace=ScaladslCassandraReadJournalSpec
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.eventual-consistency-delay = 1s

--- a/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -24,6 +24,8 @@ object CassandraSnapshotStoreConfiguration {
       |akka.test.single-expect-default = 10s
       |cassandra-journal.port = ${CassandraLauncher.randomPort}
       |cassandra-snapshot-store.port = ${CassandraLauncher.randomPort}
+      |cassandra-journal.keyspace=CassandraSnapshotStoreSpec
+      |cassandra-snapshot-store.keyspace=CassandraSnapshotStoreSpecSnapshot
       |cassandra-snapshot-store.max-metadata-result-size = 2
     """.stripMargin
   )


### PR DESCRIPTION
* this uses a new feature in Cassandra 3.x,
  the old implementation is kept when using config
  cassandra-journal.cassandra-2x-compat=on to make
  it possible to still use it with Cassandra 2.x
  server
* ran all tests with Cassandra 2.x server (requires
  some manual patching, see cassandra-2x-compat
  in reference.conf