### PR TITLE
update to Akka 2.4.2-RC1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -59,16 +59,16 @@ testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 // disable parallel tests
 parallelExecution in Test := false
 
-val AkkaVersion = "2.4.1"
+val AkkaVersion = "2.4.2-RC1"
 
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.0.0-rc1",
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
   "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query-experimental" % AkkaVersion,
-  "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion      % "test",
-  "org.scalatest"          %% "scalatest"                           % "2.1.4"      % "test",
-  "com.typesafe.akka"      %% "akka-stream-testkit-experimental"    % "1.0"        % "test",
+  "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion   % "test",
+  "com.typesafe.akka"      %% "akka-stream-testkit"                 % AkkaVersion   % "test",
+  "org.scalatest"          %% "scalatest"                           % "2.1.4"       % "test",
   // cassandra-all for testkit.CassandraLauncher, app should define it as test dependency if needed
   "org.apache.cassandra"    % "cassandra-all"                       % "3.0.2"      % "optional"
 )

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -3,24 +3,24 @@
  */
 package akka.persistence.cassandra.journal
 
-import akka.stream.scaladsl.ImplicitMaterializer
-
 import scala.concurrent._
 
 import java.lang.{ Long => JLong }
 
 import akka.actor.{ ExtendedActorSystem, ActorLogging }
 import akka.persistence.PersistentRepr
+import akka.stream.ActorMaterializer
 
 import akka.persistence.cassandra.listenableFutureToFuture
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 
-trait CassandraRecovery extends ActorLogging with ImplicitMaterializer {
+trait CassandraRecovery extends ActorLogging {
   this: CassandraJournal =>
   import config._
 
   implicit lazy val replayDispatcher = context.system.dispatchers.lookup(replayDispatcherId)
   private[this] val extendedActorSystem = context.system.asInstanceOf[ExtendedActorSystem]
+  private implicit val materializer = ActorMaterializer()
 
   private[this] val queries: CassandraReadJournal =
     new CassandraReadJournal(
@@ -45,6 +45,7 @@ trait CassandraRecovery extends ActorLogging with ImplicitMaterializer {
         "asyncReplayMessages"
       )
       .runForeach(replayCallback)
+      .map(_ => ())
 
   override def asyncReadHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] =
     asyncHighestDeletedSequenceNumber(persistenceId)

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByTagPublisher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByTagPublisher.scala
@@ -156,9 +156,9 @@ private[query] class EventsByTagPublisher(
       context.stop(self)
 
     case tagWritten: String if tagWritten == tag =>
-      if (eventualConsistencyDelayMillis == 0) 
+      if (eventualConsistencyDelayMillis == 0)
         self ! Continue
-      else 
+      else
         context.system.scheduler.scheduleOnce(settings.eventualConsistencyDelay, self, Continue)
   }
 

--- a/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -5,11 +5,11 @@ package akka.persistence.cassandra.query.javadsl
 
 import java.util.UUID
 
+import akka.NotUsed
+import akka.persistence.cassandra.query.UUIDEventEnvelope
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.javadsl._
 import akka.stream.javadsl.Source
-
-import akka.persistence.cassandra.query.UUIDEventEnvelope
 
 object CassandraReadJournal {
   /**
@@ -112,7 +112,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    * The stream is completed with failure if there is a failure in executing the query in the
    * backend journal.
    */
-  override def eventsByTag(tag: String, offset: Long): Source[EventEnvelope, Unit] =
+  override def eventsByTag(tag: String, offset: Long): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByTag(tag, offset).asJava
 
   /**
@@ -126,7 +126,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    * The `offset` is exclusive, i.e. the event with the exact same UUID will not be included
    * in the returned stream.
    */
-  def eventsByTag(tag: String, offset: UUID): Source[UUIDEventEnvelope, Unit] =
+  def eventsByTag(tag: String, offset: UUID): Source[UUIDEventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByTag(tag, offset).asJava
 
   /**
@@ -137,7 +137,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    * The `offset` is inclusive, i.e. the events with the exact same timestamp will be included
    * in the returned stream.
    */
-  override def currentEventsByTag(tag: String, offset: Long): Source[EventEnvelope, Unit] =
+  override def currentEventsByTag(tag: String, offset: Long): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.currentEventsByTag(tag, offset).asJava
 
   /**
@@ -151,7 +151,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    * The `offset` is exclusive, i.e. the event with the exact same UUID will not be included
    * in the returned stream.
    */
-  def currentEventsByTag(tag: String, offset: UUID): Source[UUIDEventEnvelope, Unit] =
+  def currentEventsByTag(tag: String, offset: UUID): Source[UUIDEventEnvelope, NotUsed] =
     scaladslReadJournal.currentEventsByTag(tag, offset).asJava
 
   /**
@@ -181,7 +181,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
     persistenceId:  String,
     fromSequenceNr: Long,
     toSequenceNr:   Long
-  ): Source[EventEnvelope, Unit] =
+  ): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal.eventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr).asJava
 
   /**
@@ -193,7 +193,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
     persistenceId:  String,
     fromSequenceNr: Long,
     toSequenceNr:   Long
-  ): Source[EventEnvelope, Unit] =
+  ): Source[EventEnvelope, NotUsed] =
     scaladslReadJournal
       .currentEventsByPersistenceId(persistenceId, fromSequenceNr, toSequenceNr)
       .asJava
@@ -218,13 +218,13 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    * More importantly the live query has to repeatedly execute the query each `refresh-interval`,
    * because order is not defined and new `persistenceId`s may appear anywhere in the query results.
    */
-  def allPersistenceIds(): Source[String, Unit] = scaladslReadJournal.allPersistenceIds().asJava
+  def allPersistenceIds(): Source[String, NotUsed] = scaladslReadJournal.allPersistenceIds().asJava
 
   /**
    * Same type of query as `allPersistenceIds` but the event stream
    * is completed immediately when it reaches the end of the "result set". Events that are
    * stored after the query is completed are not included in the event stream.
    */
-  def currentPersistenceIds(): Source[String, Unit] =
+  def currentPersistenceIds(): Source[String, NotUsed] =
     scaladslReadJournal.currentPersistenceIds().asJava
 }


### PR DESCRIPTION
note that 2.4.2-RC1 includes akka-stream, and the persistence query api is using that version of akka-stream (i.e. not akka-stream-experimental 1.0 any more)