### PR TITLE
split large message batches, #48

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -143,7 +143,7 @@ cassandra-journal {
 
   # Maximum number of messages that will be batched when using `persistAsync`. 
   # Also used as the max batch size for deletes.
-  max-message-batch-size = 200
+  max-message-batch-size = 100
 
   # Target number of entries per partition (= columns per row).
   # Must not be changed after table creation (currently not checked).


### PR DESCRIPTION
* In Akka 2.4.2 the max-message-batch-size is not used
  any more (see akka/akka#19694) and therefore we must split large batches
  ourselves
* It's important that they are written sequentially so that we don't get
  holes due to failing writes