### PR TITLE
don't serialize in journal actor's thread

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -159,10 +159,7 @@ cassandra-journal {
   # Dispatcher for the plugin actor.
   plugin-dispatcher = "cassandra-journal.default-dispatcher"
 
-  # Dispatcher for fetching and replaying messages
-  replay-dispatcher = "akka.persistence.dispatchers.default-replay-dispatcher"
-  
-  # Default dispatcher for plugin actor.
+  # Default dispatcher for plugin actor and task.
   default-dispatcher {
     type = Dispatcher
     executor = "fork-join-executor"
@@ -334,7 +331,7 @@ cassandra-snapshot-store {
   # Maximum size of result set
   max-result-size = 50001
 
-  # Dispatcher for the plugin actor.
+  # Dispatcher for the plugin actor and task.
   plugin-dispatcher = "cassandra-snapshot-store.default-dispatcher"
 
   # Default dispatcher for plugin actor.
@@ -400,5 +397,15 @@ cassandra-query-journal {
   delayed-event-timeout = 30s
   
   # Dispatcher for the plugin actors.
-  plugin-dispatcher = "akka.actor.default-dispatcher"
+  plugin-dispatcher = "cassandra-query-journal.default-dispatcher"
+  
+  # Default dispatcher for plugin actor and tasks.
+  default-dispatcher {
+    type = Dispatcher
+    executor = "fork-join-executor"
+    fork-join-executor {
+      parallelism-min = 2
+      parallelism-max = 8
+    }
+  }
 }

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -14,7 +14,6 @@ import akka.persistence.cassandra.CassandraPluginConfig
 import akka.util.Helpers.{ ConfigOps, Requiring }
 
 class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(config) {
-  val replayDispatcherId: String = config.getString("replay-dispatcher")
   val targetPartitionSize: Int = config.getInt(CassandraJournalConfig.TargetPartitionProperty)
   val maxResultSize: Int = config.getInt("max-result-size")
   val replayMaxResultSize: Int = config.getInt("max-result-size-replay")

--- a/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
@@ -4,8 +4,8 @@
 package akka.persistence.cassandra.journal
 
 import scala.concurrent.duration.FiniteDuration
-
 import akka.actor.{ Actor, ActorRef }
+import akka.actor.Props
 
 /**
  * Proxies messages to another actor, only allowing identical messages through once every [interval].
@@ -50,6 +50,10 @@ private[journal] class PubSubThrottler(delegate: ActorRef, interval: FiniteDurat
 }
 
 private[journal] object PubSubThrottler {
+
+  def props(delegate: ActorRef, interval: FiniteDuration): Props =
+    Props(new PubSubThrottler(delegate, interval))
+
   private case object Tick
 
 }


### PR DESCRIPTION
* serialization can be bottleneck when using many
  persistent actors
* also cleanup other dispather usages

Fixes #51 