### PR TITLE
[#46] make metric registry of cassandra available for each connection…

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/CassandraMetricsRegistry.scala
+++ b/src/main/scala/akka/persistence/cassandra/CassandraMetricsRegistry.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra
+
+import java.util.concurrent.atomic.AtomicLong
+
+import akka.actor._
+
+import com.codahale.metrics.MetricRegistry
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.collection.convert.wrapAsScala._
+import ExecutionContext.Implicits.global
+
+/**
+ * Retrieves Cassandra metrics registry for an actor system
+ */
+class CassandraMetricsRegistry extends Extension {
+  private val metricRegistry = new MetricRegistry()
+
+  def getRegistry: MetricRegistry = metricRegistry
+
+  private[cassandra] def addMetrics(category: String, registry: MetricRegistry): Unit =
+    metricRegistry.register(category, registry)
+
+  private[cassandra] def removeMetrics(category: String): Unit =
+    Future {
+      metricRegistry.getNames.toList.filter(_.startsWith(category)).foreach(metricRegistry.remove)
+    }
+}
+
+object CassandraMetricsRegistry
+  extends ExtensionId[CassandraMetricsRegistry]
+  with ExtensionIdProvider {
+  override def lookup = CassandraMetricsRegistry
+  override def createExtension(system: ExtendedActorSystem) = new CassandraMetricsRegistry
+  override def get(system: ActorSystem): CassandraMetricsRegistry = super.get(system)
+}

--- a/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -12,7 +12,6 @@ import akka.persistence.cassandra.testkit.CassandraLauncher
 import akka.testkit.TestKitBase
 import akka.testkit.TestProbe
 import org.scalatest._
-import java.util.Locale
 import com.typesafe.config.ConfigFactory
 
 object CassandraLifecycle {
@@ -64,7 +63,6 @@ trait CassandraLifecycle extends BeforeAndAfterAll { this: TestKitBase with Suit
     )
 
     awaitPersistenceInit()
-
     super.beforeAll()
   }
 

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -6,7 +6,7 @@ package akka.persistence.cassandra.journal
 import scala.concurrent.duration._
 import akka.persistence.cassandra.testkit.CassandraLauncher
 import akka.persistence.journal._
-import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.{ CassandraMetricsRegistry, CassandraLifecycle }
 
 import com.typesafe.config.ConfigFactory
 
@@ -41,6 +41,14 @@ class CassandraJournalSpec extends JournalSpec(CassandraJournalConfiguration.con
   override def systemName: String = "CassandraJournalSpec"
 
   override def supportsRejectingNonSerializableObjects = false
+  "A Cassandra Journal" must {
+    "insert Cassandra metrics to Cassandra Metrics Registry" in {
+      val registry = CassandraMetricsRegistry(system).getRegistry
+      val snapshots = registry.getNames.toArray()
+      snapshots.length should be > 0
+
+    }
+  }
 }
 
 /**

--- a/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -12,7 +12,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{ Seconds, Second, Span }
 import org.scalatest.{ Matchers, WordSpecLike }
-import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.{ CassandraMetricsRegistry, CassandraLifecycle }
 import akka.persistence.cassandra.query.TestActor
 import akka.persistence.cassandra.testkit.CassandraLauncher
 import akka.persistence.journal.{ Tagged, WriteEventAdapter }
@@ -101,6 +101,12 @@ class CassandraReadJournalSpec
         .request(10)
         .expectNext("a")
         .expectComplete()
+    }
+
+    "insert Cassandra metrics to Cassandra Metrics Registry" in {
+      val registry = CassandraMetricsRegistry(system).getRegistry
+      val snapshots = registry.getNames.toArray().filter(value => value.toString.startsWith(s"${CassandraReadJournal.Identifier}"))
+      snapshots.length should be > 0
     }
   }
 }

--- a/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -10,7 +10,7 @@ import java.nio.ByteBuffer
 
 import akka.persistence._
 import akka.persistence.SnapshotProtocol._
-import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.{ CassandraMetricsRegistry, CassandraLifecycle }
 import akka.persistence.snapshot.SnapshotStoreSpec
 import akka.testkit.TestProbe
 
@@ -66,6 +66,11 @@ class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(CassandraSnapshotStor
   val serId: JInteger = 4
 
   "A Cassandra snapshot store" must {
+    "insert Cassandra metrics to Cassandra Metrics Registry" in {
+      val registry = CassandraMetricsRegistry(system).getRegistry
+      val snapshots = registry.getNames.toArray()
+      snapshots.length should be > 0
+    }
     "make up to 3 snapshot loading attempts" in {
       val probe = TestProbe()
 


### PR DESCRIPTION
… of actorsystem

CassandraMetricsRegistry Contains complete list of CassandraMetrics. Metrics Can be accessed by:
`CassandraMetricsRegistry(system).getRegistry`
A separate list of metrics for each session connection is created there is following format:
Journal:
cassandra.journal.{systemName}.{actorName}.{cassandraMetricName}
SnapshotStore
cassandra.snapshotstore.{systemName}.{actorName}.{cassandraMetricName}
ReadJournal:
cassandra.readjournal.{systemName}.path.{instanceHash}.{cassandraMetricName}