### PR TITLE
Fix #55 add event-adapters support for CassandraReadJournal

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/query/UUIDPersistentRepr.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/UUIDPersistentRepr.scala
@@ -1,0 +1,17 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.query
+
+import java.util.UUID
+
+import akka.persistence.PersistentRepr
+
+/**
+ * Wrap the [[PersistentRepr]] to add the UUID for
+ * `eventsByTag` query, or similar queries.
+ */
+private[query] final case class UUIDPersistentRepr(
+  offset:         UUID,
+  persistentRepr: PersistentRepr
+)

--- a/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -3,13 +3,16 @@
  */
 package akka.persistence.cassandra.query.scaladsl
 
+import akka.persistence.journal.EventSeq
+
 import scala.concurrent.duration.FiniteDuration
+import scala.collection.immutable
 import scala.util.control.NonFatal
 import java.net.URLEncoder
 import java.util.UUID
 import akka.actor.ExtendedActorSystem
 import akka.event.Logging
-import akka.persistence.PersistentRepr
+import akka.persistence.{ Persistence, PersistentRepr }
 import akka.persistence.query._
 import akka.persistence.query.scaladsl._
 import akka.stream.ActorAttributes
@@ -62,8 +65,10 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
   with CurrentEventsByTagQuery {
 
   private val log = Logging.getLogger(system, getClass)
-  private val writePluginConfig = new CassandraJournalConfig(system.settings.config.getConfig(config.getString("write-plugin")))
+  private val writePluginId = config.getString("write-plugin")
+  private val writePluginConfig = new CassandraJournalConfig(system.settings.config.getConfig(writePluginId))
   private val queryPluginConfig = new CassandraReadJournalConfig(config, writePluginConfig)
+  private val eventAdapters = Persistence(system).adaptersFor(writePluginId)
 
   private class CassandraSession(val underlying: Session) {
 
@@ -238,8 +243,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
     try {
       if (writePluginConfig.enableEventsByTagQuery) {
         import queryPluginConfig._
-        Source.actorPublisher[UUIDEventEnvelope](EventsByTagPublisher.props(tag, offset,
+        Source.actorPublisher[UUIDPersistentRepr](EventsByTagPublisher.props(tag, offset,
           None, queryPluginConfig, cassandraSession.underlying, selectStatement(tag)))
+          .mapConcat(r => toUUIDEventEnvelopes(r.persistentRepr, r.offset))
           .mapMaterializedValue(_ => NotUsed)
           .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
           .withAttributes(ActorAttributes.dispatcher(pluginDispatcher))
@@ -286,8 +292,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
       if (writePluginConfig.enableEventsByTagQuery) {
         import queryPluginConfig._
         val toOffset = Some(offsetUuid(System.currentTimeMillis()))
-        Source.actorPublisher[UUIDEventEnvelope](EventsByTagPublisher.props(tag, offset,
+        Source.actorPublisher[UUIDPersistentRepr](EventsByTagPublisher.props(tag, offset,
           toOffset, queryPluginConfig, cassandraSession.underlying, selectStatement(tag)))
+          .mapConcat(r => toUUIDEventEnvelopes(r.persistentRepr, r.offset))
           .mapMaterializedValue(_ => NotUsed)
           .named("currentEventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
           .withAttributes(ActorAttributes.dispatcher(pluginDispatcher))
@@ -337,7 +344,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
       Some(queryPluginConfig.refreshInterval),
       s"eventsByPersistenceId-$persistenceId"
     )
-      .map(r => toEventEnvelope(r, r.sequenceNr))
+      .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**
    * Same type of query as `eventsByPersistenceId` but the event stream
@@ -358,8 +365,15 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
       None,
       s"currentEventsByPersistenceId-$persistenceId"
     )
-      .map(r => toEventEnvelope(r, r.sequenceNr))
+      .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
+  /**
+   * This is a low-level method that return journal events as they are persisted.
+   *
+   * The fromJournal adaptation happens at higher level:
+   *  - In the AsyncWriteJournal for the PersistentActor and PersistentView recovery.
+   *  - In the public eventsByPersistenceId and currentEventsByPersistenceId queries.
+   */
   private[cassandra] def eventsByPersistenceId(
     persistenceId:   String,
     fromSequenceNr:  Long,
@@ -392,8 +406,21 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
       .named(name)
   }
 
-  private[this] def toEventEnvelope(persistentRepr: PersistentRepr, offset: Long): EventEnvelope =
-    EventEnvelope(offset, persistentRepr.persistenceId, persistentRepr.sequenceNr, persistentRepr.payload)
+  private[this] def toUUIDEventEnvelopes(persistentRepr: PersistentRepr, offset: UUID): immutable.Iterable[UUIDEventEnvelope] =
+    adaptFromJournal(persistentRepr).map { payload =>
+      UUIDEventEnvelope(offset, persistentRepr.persistenceId, persistentRepr.sequenceNr, payload)
+    }
+
+  private[this] def toEventEnvelopes(persistentRepr: PersistentRepr, offset: Long): immutable.Iterable[EventEnvelope] =
+    adaptFromJournal(persistentRepr).map { payload =>
+      EventEnvelope(offset, persistentRepr.persistenceId, persistentRepr.sequenceNr, payload)
+    }
+
+  private def adaptFromJournal(persistentRepr: PersistentRepr): immutable.Iterable[Any] = {
+    val eventAdapter = eventAdapters.get(persistentRepr.payload.getClass)
+    val eventSeq = eventAdapter.fromJournal(persistentRepr.payload, persistentRepr.manifest)
+    eventSeq.events
+  }
 
   /**
    * `allPersistenceIds` is used to retrieve a stream of `persistenceId`s.

--- a/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -1,0 +1,176 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.query
+
+import java.time.{ ZoneOffset, LocalDate }
+
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.journal.TimeBucket
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.cassandra.testkit.CassandraLauncher
+import akka.persistence.query.PersistenceQuery
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.typesafe.config.ConfigFactory
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.concurrent.duration._
+
+object EventAdaptersReadSpec {
+  val today = LocalDate.now(ZoneOffset.UTC)
+
+  val config = ConfigFactory.parseString(s"""
+    akka.loglevel = INFO
+    cassandra-journal.port = ${CassandraLauncher.randomPort}
+    cassandra-journal.keyspace=EventAdaptersReadSpec
+    cassandra-query-journal.max-buffer-size = 10
+    cassandra-query-journal.refresh-interval = 0.5s
+    cassandra-query-journal.max-result-size-query = 2
+    cassandra-journal.target-partition-size = 15
+    cassandra-journal.event-adapters.test = "akka.persistence.cassandra.query.TestEventAdapter"
+    cassandra-journal.event-adapter-bindings {
+      "java.lang.String" = test
+    }
+    cassandra-journal.tags {
+      red = 1
+      yellow = 1
+      green = 1
+    }
+    cassandra-query-journal {
+      refresh-interval = 500ms
+      max-buffer-size = 50
+      first-time-bucket = ${TimeBucket(today.minusDays(5)).key}
+      eventual-consistency-delay = 2s
+      delayed-event-timeout = 3s
+    }
+    """).withFallback(CassandraLifecycle.config)
+}
+
+class EventAdaptersReadSpec
+  extends TestKit(ActorSystem("EventAdaptersReadSpec", EventAdaptersReadSpec.config))
+  with ScalaFutures
+  with ImplicitSender
+  with WordSpecLike
+  with CassandraLifecycle
+  with Matchers {
+
+  override def systemName: String = "EventAdaptersReadSpec"
+
+  implicit val mat = ActorMaterializer()(system)
+
+  lazy val queries: CassandraReadJournal =
+    PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+
+  def setup(persistenceId: String, n: Int, prefix: (Int) => String = _ => ""): ActorRef = {
+    val ref = system.actorOf(TestActor.props(persistenceId))
+    for (i <- 1 to n) {
+      val message = s"${prefix(i)}$persistenceId-$i"
+      ref ! message
+      expectMsg(s"$message-done")
+    }
+
+    ref
+  }
+
+  def tagged(tags: String*)(f: (Int) => String = _ => ""): Int => String = { i =>
+    s"tagged:${tags.mkString(",")}:${f(i)}"
+  }
+
+  "Cassandra query EventsByPersistenceId" must {
+
+    "not replay dropped events by the event-adapter" in {
+
+      val ref = setup("a", 6, {
+        case x if x % 2 == 0 => "dropped:"
+        case _               => ""
+      })
+
+      val src = queries.currentEventsByPersistenceId("a", 0L, Long.MaxValue)
+      src.map(_.event).runWith(TestSink.probe[Any])
+        .request(2)
+        .expectNext("a-1", "a-3")
+        .expectNoMsg(500.millis)
+        .request(2)
+        .expectNext("a-5")
+        .expectComplete()
+    }
+
+    "replay duplicate events by the event-adapter" in {
+
+      setup("b", 3, {
+        case x if x % 2 == 0 => "duplicated:"
+        case _               => ""
+      })
+
+      val src = queries.currentEventsByPersistenceId("b", 0L, Long.MaxValue)
+      src.map(_.event).runWith(TestSink.probe[Any])
+        .request(10)
+        .expectNext("b-1", "b-2", "b-2", "b-3")
+        .expectComplete()
+    }
+
+    "duplicate events with prefix added by the event-adapter" in {
+
+      setup("c", 1, {
+        case _ => "prefixed:foo:"
+      })
+
+      val src = queries.currentEventsByPersistenceId("c", 0L, Long.MaxValue)
+      src.map(_.event).runWith(TestSink.probe[Any])
+        .request(10)
+        .expectNext("foo-c-1")
+        .expectComplete()
+    }
+
+  }
+
+  "Cassandra query EventsByTag" must {
+
+    "not replay events dropped by the event-adapter" in {
+
+      setup("d", 6, tagged("red") {
+        case x if x % 2 == 0 => "dropped:"
+        case _               => ""
+      })
+
+      val src = queries.currentEventsByTag("red", 0L)
+      src.map(_.event).runWith(TestSink.probe[Any])
+        .request(10)
+        .expectNext("d-1", "d-3", "d-5")
+        .expectComplete()
+    }
+
+    "replay events duplicated by the event-adapter" in {
+
+      setup("e", 3, tagged("yellow") {
+        case x if x % 2 == 0 => "duplicated:"
+        case _               => ""
+      })
+
+      val src = queries.currentEventsByTag("yellow", 0L)
+      src.map(_.event).runWith(TestSink.probe[Any])
+        .request(10)
+        .expectNext("e-1", "e-2", "e-2", "e-3")
+        .expectComplete()
+    }
+
+    "replay events transformed by the event-adapter" in {
+
+      setup("e", 3, tagged("green") {
+        case x if x % 2 == 0 => "prefixed:foo:"
+        case _               => ""
+      })
+
+      val src = queries.currentEventsByTag("green", 0L)
+      src.map(_.event).runWith(TestSink.probe[Any])
+        .request(10)
+        .expectNext("e-1", "foo-e-2", "e-3")
+        .expectComplete()
+    }
+  }
+
+}

--- a/src/test/scala/akka/persistence/cassandra/query/TestEventAdapter.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/TestEventAdapter.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.query
+
+import akka.actor.ExtendedActorSystem
+import akka.persistence.journal.{ Tagged, EventSeq, EventAdapter }
+
+sealed trait TestEvent[T] {
+  def value: T
+}
+
+class TestEventAdapter(system: ExtendedActorSystem) extends EventAdapter {
+
+  override def manifest(event: Any): String = ""
+
+  override def toJournal(event: Any): Any = event match {
+    case e: String if e.startsWith("tagged:") =>
+      val taggedEvent = e.stripPrefix("tagged:")
+      val tags = taggedEvent.takeWhile(_ != ':').split(",").toSet
+      val payload = taggedEvent.dropWhile(_ != ':').drop(1)
+      Tagged(payload, tags)
+    case e => e
+  }
+
+  override def fromJournal(event: Any, manifest: String): EventSeq = event match {
+    case e: String if e.contains(":") => e.split(":").toList match {
+      case "dropped" :: _ :: Nil            => EventSeq.empty
+      case "duplicated" :: x :: Nil         => EventSeq(x, x)
+      case "prefixed" :: prefix :: x :: Nil => EventSeq.single(s"$prefix-$x")
+    }
+    case _ => EventSeq.single(event)
+  }
+}


### PR DESCRIPTION
This PR add the support for event-adapters in Cassandra persistence-queries.

The eventsByPersistenceId and currentEventsByPersistenceId are trivial as it is just matter of transform the replayed PersistentRepr to a sequence of EventEnvelope.

The eventsByTag and currentsEventByTag need instead a small refactor: The EventsByTagPublisher and Fetcher were returning directly a UUIDEventEnvelope. In this way the adaptation logic had to be spawned in two places. I have instead add a new private class to bind the UUID to the PersistentRepr to return to the CassandraReadJournal. In this way the adaptation logic is the last bit of the process.