### PR TITLE
make it possible to lookup contact points

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -24,6 +24,23 @@ cassandra-journal {
   # Port of contact points in the cluster.
   # Will be ignored if the contact point list is defined by host:port pairs.
   port = 9042
+  
+  # The implementation of akka.persistence.cassandra.SessionProvider
+  # is used for creating the Cassandra Session. By default the 
+  # the ConfigSessionProvider is building the Cluster from configuration properties
+  # but it is possible to replace the implementation of the SessionProvider
+  # to reuse another session or override the Cluster builder with other
+  # settings.
+  # For example, it is possible to lookup the contact points of the Cassandra cluster
+  # asynchronously instead of giving them in the configuration in a subclass of
+  # ConfigSessionProvider and overriding the lookupContactPoints method.
+  # It may optionally have a constructor with an ActorSystem and Config parameter.
+  # The config parameter is this config section of the plugin.
+  session-provider = akka.persistence.cassandra.ConfigSessionProvider
+  
+  # The identifier that will be passed as parameter to the
+  # ConfigSessionProvider.lookupContactPoints method. 
+  cluster-id = ""
 
   # Name of the keyspace to be created/used by the journal
   keyspace = "akka"
@@ -242,6 +259,23 @@ cassandra-snapshot-store {
   # Port of contact points in the cluster.
   # Will be ignored if the contact point list is defined by host:port pairs.
   port = 9042
+  
+  # The implementation of akka.persistence.cassandra.SessionProvider
+  # is used for creating the Cassandra Session. By default the 
+  # the ConfigSessionProvider is building the Cluster from configuration properties
+  # but it is possible to replace the implementation of the SessionProvider
+  # to reuse another session or override the Cluster builder with other
+  # settings.
+  # For example, it is possible to lookup the contact points of the Cassandra cluster
+  # asynchronously instead of giving them in the configuration in a subclass of
+  # ConfigSessionProvider and overriding the lookupContactPoints method.
+  # It may optionally have a constructor with an ActorSystem and Config parameter.
+  # The config parameter is this config section of the plugin.
+  session-provider = akka.persistence.cassandra.ConfigSessionProvider
+  
+  # The identifier that will be passed as parameter to the
+  # ConfigSessionProvider.lookupContactPoints method. 
+  cluster-id = ""
 
   # Name of the keyspace to be created/used by the snapshot store
   keyspace = "akka_snapshot"

--- a/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -1,0 +1,155 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra
+
+import java.net.InetSocketAddress
+
+import scala.collection.JavaConverters._
+import scala.collection.immutable
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.actor.ActorSystem
+import com.datastax.driver.core.Cluster
+import com.datastax.driver.core.HostDistance
+import com.datastax.driver.core.JdkSSLOptions
+import com.datastax.driver.core.PoolingOptions
+import com.datastax.driver.core.ProtocolVersion
+import com.datastax.driver.core.QueryOptions
+import com.datastax.driver.core.Session
+import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
+import com.datastax.driver.core.policies.TokenAwarePolicy
+import com.typesafe.config.Config
+
+/**
+ * Default implementation of the `SessionProvider` that is used for creating the
+ * Cassandra Session. This class is building the Cluster from configuration
+ * properties.
+ *
+ * You may create a subclass of this that performs lookup the contact points
+ * of the Cassandra cluster asynchronously instead of reading them in the
+ * configuration. Such a subclass should override the [[#lookupContactPoints]]
+ * method.
+ *
+ * The implementation is defined in configuration `session-provider` property.
+ * The config parameter is the config section of the plugin.
+ */
+class ConfigSessionProvider(system: ActorSystem, config: Config) extends SessionProvider {
+
+  def connect()(implicit ec: ExecutionContext): Future[Session] = {
+    val clusterId = config.getString("cluster-id")
+    clusterBuilder(clusterId).flatMap(_.build().connectAsync())
+  }
+
+  val fetchSize = config.getInt("max-result-size")
+  val protocolVersion: Option[ProtocolVersion] = config.getString("protocol-version") match {
+    case "" => None
+    case _  => Some(ProtocolVersion.fromInt(config.getInt("protocol-version")))
+  }
+
+  private[this] val connectionPoolConfig = config.getConfig("connection-pool")
+
+  val poolingOptions = new PoolingOptions()
+    .setNewConnectionThreshold(
+      HostDistance.LOCAL,
+      connectionPoolConfig.getInt("new-connection-threshold-local"))
+    .setNewConnectionThreshold(
+      HostDistance.REMOTE,
+      connectionPoolConfig.getInt("new-connection-threshold-remote"))
+    .setMaxRequestsPerConnection(
+      HostDistance.LOCAL,
+      connectionPoolConfig.getInt("max-requests-per-connection-local"))
+    .setMaxRequestsPerConnection(
+      HostDistance.REMOTE,
+      connectionPoolConfig.getInt("max-requests-per-connection-remote"))
+    .setConnectionsPerHost(
+      HostDistance.LOCAL,
+      connectionPoolConfig.getInt("connections-per-host-core-local"),
+      connectionPoolConfig.getInt("connections-per-host-max-local"))
+    .setConnectionsPerHost(
+      HostDistance.REMOTE,
+      connectionPoolConfig.getInt("connections-per-host-core-remote"),
+      connectionPoolConfig.getInt("connections-per-host-max-remote"))
+    .setPoolTimeoutMillis(
+      connectionPoolConfig.getInt("pool-timeout-millis"))
+
+  def clusterBuilder(clusterId: String)(implicit ec: ExecutionContext): Future[Cluster.Builder] = {
+    lookupContactPoints(clusterId).map { cp =>
+      val b = Cluster.builder
+        .addContactPointsWithPorts(cp.asJava)
+        .withPoolingOptions(poolingOptions)
+        .withQueryOptions(new QueryOptions().setFetchSize(fetchSize))
+      protocolVersion match {
+        case None    => b
+        case Some(v) => b.withProtocolVersion(v)
+      }
+
+      val username = config.getString("authentication.username")
+      if (username != "") {
+        b.withCredentials(
+          username,
+          config.getString("authentication.password"))
+      }
+
+      val localDatacenter = config.getString("local-datacenter")
+      if (localDatacenter != "") {
+        b.withLoadBalancingPolicy(
+          new TokenAwarePolicy(
+            DCAwareRoundRobinPolicy.builder.withLocalDc(localDatacenter).build()))
+      }
+
+      val truststorePath = config.getString("ssl.truststore.path")
+      if (truststorePath != "") {
+        val trustStore = StorePathPasswordConfig(
+          truststorePath,
+          config.getString("ssl.truststore.password"))
+
+        val keystorePath = config.getString("ssl.keystore.path")
+        val keyStore: Option[StorePathPasswordConfig] =
+          if (keystorePath != "") {
+            val keyStore = StorePathPasswordConfig(
+              keystorePath,
+              config.getString("ssl.keystore.password"))
+            Some(keyStore)
+          } else None
+
+        val context = SSLSetup.constructContext(trustStore, keyStore)
+
+        b.withSSL(JdkSSLOptions.builder.withSSLContext(context).build())
+      }
+
+      b
+    }
+  }
+
+  /**
+   * Subclass may override this method to perform lookup the contact points
+   * of the Cassandra cluster asynchronously instead of reading them from the
+   * configuration.
+   *
+   * @param clusterId the configured `cluster-id` to lookup
+   */
+  def lookupContactPoints(clusterId: String)(implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] = {
+    val port: Int = config.getInt("port")
+    val contactPoints = config.getStringList("contact-points").asScala.toList
+    Future.successful(buildContactPoints(contactPoints, port))
+  }
+
+  /**
+   * Builds list of InetSocketAddress out of host:port pairs or host entries + given port parameter.
+   */
+  protected def buildContactPoints(contactPoints: immutable.Seq[String], port: Int): immutable.Seq[InetSocketAddress] = {
+    contactPoints match {
+      case null | Nil => throw new IllegalArgumentException("A contact point list cannot be empty.")
+      case hosts => hosts map {
+        ipWithPort =>
+          ipWithPort.split(":") match {
+            case Array(host, port) => new InetSocketAddress(host, port.toInt)
+            case Array(host)       => new InetSocketAddress(host, port)
+            case msg               => throw new IllegalArgumentException(s"A contact point should have the form [host:port] or [host] but was: $msg.")
+          }
+      }
+    }
+  }
+}

--- a/src/main/scala/akka/persistence/cassandra/SessionProvider.scala
+++ b/src/main/scala/akka/persistence/cassandra/SessionProvider.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra
+
+import scala.concurrent.Future
+import com.datastax.driver.core.Session
+import com.typesafe.config.Config
+import scala.concurrent.ExecutionContext
+
+/**
+ * The implementation of the `SessionProvider` is used for creating the
+ * Cassandra Session. By default the [[ConfigSessionProvider]] is building
+ * the Cluster from configuration properties but it is possible to
+ * replace the implementation of the SessionProvider to reuse another
+ * session or override the Cluster builder with other settings.
+ *
+ * The implementation is defined in configuration `session-provider` property.
+ * It may optionally have a constructor with an ActorSystem and Config parameter.
+ * The config parameter is the config section of the plugin.
+ */
+trait SessionProvider {
+
+  def connect()(implicit ec: ExecutionContext): Future[Session]
+
+}

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -4,16 +4,14 @@
 package akka.persistence.cassandra.journal
 
 import java.util.Locale
-
 import scala.collection.immutable.HashMap
 import scala.concurrent.duration.Duration
-
 import com.typesafe.config.{ Config, ConfigValueType }
-
 import akka.persistence.cassandra.CassandraPluginConfig
 import akka.util.Helpers.{ ConfigOps, Requiring }
+import akka.actor.ActorSystem
 
-class CassandraJournalConfig(config: Config) extends CassandraPluginConfig(config) {
+class CassandraJournalConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) {
   val targetPartitionSize: Int = config.getInt(CassandraJournalConfig.TargetPartitionProperty)
   val maxResultSize: Int = config.getInt("max-result-size")
   val replayMaxResultSize: Int = config.getInt("max-result-size-replay")

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -4,9 +4,9 @@
 package akka.persistence.cassandra.snapshot
 
 import com.typesafe.config.Config
-
 import akka.persistence.cassandra.CassandraPluginConfig
+import akka.actor.ActorSystem
 
-class CassandraSnapshotStoreConfig(config: Config) extends CassandraPluginConfig(config) {
+class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) {
   val maxMetadataResultSize = config.getInt("max-metadata-result-size")
 }

--- a/src/test/scala/akka/persistence/cassandra/query/TestEventAdapter.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/TestEventAdapter.scala
@@ -28,6 +28,7 @@ class TestEventAdapter(system: ExtendedActorSystem) extends EventAdapter {
       case "dropped" :: _ :: Nil            => EventSeq.empty
       case "duplicated" :: x :: Nil         => EventSeq(x, x)
       case "prefixed" :: prefix :: x :: Nil => EventSeq.single(s"$prefix-$x")
+      case _                                => throw new IllegalArgumentException(e)
     }
     case _ => EventSeq.single(event)
   }


### PR DESCRIPTION
* allow configuration of a ContactPointsProvider, which
  can lookup the contact points asynchronously (from a service registry or
  whatever)

Please ignore the horrible Awaits, that requires a bigger refactoring that is scheduled for https://github.com/akka/akka-persistence-cassandra/issues/6