### PR TITLE
skip strict seq nr checks for eventsByTag, #66

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -461,11 +461,17 @@ cassandra-query-journal {
   # delivered in different order (not strictly by their timestamp).  
   eventual-consistency-delay = 10s
   
-  # For each `persistenceId` the events are delivered strictly by sequence number. If
-  # a sequence number is missing the query is delayed up to the configured
-  # `delayed-event-timeout` and if the expected event is still not found
-  # the stream is completed with failure.
-  delayed-event-timeout = 30s
+  # If you use the same tag for all events for a `persistenceId` it is possible to get
+  # a more strict delivery order than otherwise. This can be useful when all events of
+  # a PersistentActor class (all events of all instances of that PersistentActor class)
+  # are tagged with the same tag. Then the events for each `persistenceId` can be delivered
+  # strictly by sequence number. If a sequence number is missing the query is delayed up 
+  # to the configured `delayed-event-timeout` and if the expected event is still not 
+  # found the stream is completed with failure. This means that there must not be any 
+  # holes in the sequence numbers for a given tag, i.e. all events must be tagged
+  # with the same tag. Set this property to for example 30s to enable this feature.
+  # It is disabled by default.
+  delayed-event-timeout = 0s
   
   # Dispatcher for the plugin actors.
   plugin-dispatcher = "cassandra-query-journal.default-dispatcher"

--- a/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -53,26 +53,33 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
   val poolingOptions = new PoolingOptions()
     .setNewConnectionThreshold(
       HostDistance.LOCAL,
-      connectionPoolConfig.getInt("new-connection-threshold-local"))
+      connectionPoolConfig.getInt("new-connection-threshold-local")
+    )
     .setNewConnectionThreshold(
       HostDistance.REMOTE,
-      connectionPoolConfig.getInt("new-connection-threshold-remote"))
+      connectionPoolConfig.getInt("new-connection-threshold-remote")
+    )
     .setMaxRequestsPerConnection(
       HostDistance.LOCAL,
-      connectionPoolConfig.getInt("max-requests-per-connection-local"))
+      connectionPoolConfig.getInt("max-requests-per-connection-local")
+    )
     .setMaxRequestsPerConnection(
       HostDistance.REMOTE,
-      connectionPoolConfig.getInt("max-requests-per-connection-remote"))
+      connectionPoolConfig.getInt("max-requests-per-connection-remote")
+    )
     .setConnectionsPerHost(
       HostDistance.LOCAL,
       connectionPoolConfig.getInt("connections-per-host-core-local"),
-      connectionPoolConfig.getInt("connections-per-host-max-local"))
+      connectionPoolConfig.getInt("connections-per-host-max-local")
+    )
     .setConnectionsPerHost(
       HostDistance.REMOTE,
       connectionPoolConfig.getInt("connections-per-host-core-remote"),
-      connectionPoolConfig.getInt("connections-per-host-max-remote"))
+      connectionPoolConfig.getInt("connections-per-host-max-remote")
+    )
     .setPoolTimeoutMillis(
-      connectionPoolConfig.getInt("pool-timeout-millis"))
+      connectionPoolConfig.getInt("pool-timeout-millis")
+    )
 
   def clusterBuilder(clusterId: String)(implicit ec: ExecutionContext): Future[Cluster.Builder] = {
     lookupContactPoints(clusterId).map { cp =>
@@ -89,28 +96,33 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
       if (username != "") {
         b.withCredentials(
           username,
-          config.getString("authentication.password"))
+          config.getString("authentication.password")
+        )
       }
 
       val localDatacenter = config.getString("local-datacenter")
       if (localDatacenter != "") {
         b.withLoadBalancingPolicy(
           new TokenAwarePolicy(
-            DCAwareRoundRobinPolicy.builder.withLocalDc(localDatacenter).build()))
+            DCAwareRoundRobinPolicy.builder.withLocalDc(localDatacenter).build()
+          )
+        )
       }
 
       val truststorePath = config.getString("ssl.truststore.path")
       if (truststorePath != "") {
         val trustStore = StorePathPasswordConfig(
           truststorePath,
-          config.getString("ssl.truststore.password"))
+          config.getString("ssl.truststore.password")
+        )
 
         val keystorePath = config.getString("ssl.keystore.path")
         val keyStore: Option[StorePathPasswordConfig] =
           if (keystorePath != "") {
             val keyStore = StorePathPasswordConfig(
               keystorePath,
-              config.getString("ssl.keystore.password"))
+              config.getString("ssl.keystore.password")
+            )
             Some(keyStore)
           } else None
 

--- a/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -102,6 +102,17 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    * `delayed-event-timeout` and if the expected event is still not found
    * the stream is completed with failure.
    *
+   * If you use the same tag for all events for a `persistenceId` it is possible to get
+   * a more strict delivery order than otherwise. This can be useful when all events of
+   * a PersistentActor class (all events of all instances of that PersistentActor class)
+   * are tagged with the same tag. Then the events for each `persistenceId` can be delivered
+   * strictly by sequence number. If a sequence number is missing the query is delayed up
+   * to the configured `delayed-event-timeout` and if the expected event is still not
+   * found the stream is completed with failure. This means that there must not be any
+   * holes in the sequence numbers for a given tag, i.e. all events must be tagged
+   * with the same tag. Set `delayed-event-timeout` to for example 30s to enable this
+   * feature. It is disabled by default.
+   *
    * Deleted events are also deleted from the tagged event stream.
    *
    * The stream is not completed when it reaches the end of the currently stored events,

--- a/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -45,7 +45,6 @@ object EventAdaptersReadSpec {
       max-buffer-size = 50
       first-time-bucket = ${TimeBucket(today.minusDays(5)).key}
       eventual-consistency-delay = 2s
-      delayed-event-timeout = 3s
     }
     """).withFallback(CassandraLifecycle.config)
 }


### PR DESCRIPTION
* by default we can't check sequence numbers,
  but user can enable it if all events of
  a persistenceId is always tagged with same
  tag