### PR TITLE
Fixing recovery mechanism to support multiple journals.

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -191,7 +191,7 @@ cassandra-journal {
   plugin-dispatcher = "cassandra-journal.default-dispatcher"
 
   # The query journal to use when recoverying
-  recovery-cassandra-query-journal = "cassandra-query-journal"
+  query-plugin = "cassandra-query-journal"
 
   # Default dispatcher for plugin actor and task.
   default-dispatcher {

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -190,6 +190,9 @@ cassandra-journal {
   # Dispatcher for the plugin actor.
   plugin-dispatcher = "cassandra-journal.default-dispatcher"
 
+  # The query journal to use when recoverying
+  recovery-cassandra-query-journal = "cassandra-query-journal"
+
   # Default dispatcher for plugin actor and task.
   default-dispatcher {
     type = Dispatcher

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -22,6 +22,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config) extends Cassan
   val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
   val enableEventsByTagQuery: Boolean = !cassandra2xCompat && config.getBoolean("enable-events-by-tag-query")
   val eventsByTagView: String = config.getString("events-by-tag-view")
+  val recoveryCassandraQueryJournal = config.getString("recovery-cassandra-query-journal")
   val pubsubMinimumInterval: Duration = {
     val key = "pubsub-minimum-interval"
     config.getString(key).toLowerCase(Locale.ROOT) match {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -22,7 +22,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config) extends Cassan
   val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
   val enableEventsByTagQuery: Boolean = !cassandra2xCompat && config.getBoolean("enable-events-by-tag-query")
   val eventsByTagView: String = config.getString("events-by-tag-view")
-  val recoveryCassandraQueryJournal = config.getString("recovery-cassandra-query-journal")
+  val queryPlugin = config.getString("query-plugin")
   val pubsubMinimumInterval: Duration = {
     val key = "pubsub-minimum-interval"
     config.getString(key).toLowerCase(Locale.ROOT) match {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -25,7 +25,7 @@ trait CassandraRecovery extends ActorLogging {
   private[this] lazy val queries: CassandraReadJournal =
     new CassandraReadJournal(
       extendedActorSystem,
-      context.system.settings.config.getConfig(config.recoveryCassandraQueryJournal)
+      context.system.settings.config.getConfig(config.queryPlugin)
     )
 
   override def asyncReplayMessages(

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -22,10 +22,10 @@ trait CassandraRecovery extends ActorLogging {
   private[this] val extendedActorSystem = context.system.asInstanceOf[ExtendedActorSystem]
   private implicit val materializer = ActorMaterializer()
 
-  private[this] val queries: CassandraReadJournal =
+  private[this] lazy val queries: CassandraReadJournal =
     new CassandraReadJournal(
       extendedActorSystem,
-      context.system.settings.config.getConfig("cassandra-query-journal")
+      context.system.settings.config.getConfig(config.recoveryCassandraQueryJournal)
     )
 
   override def asyncReplayMessages(


### PR DESCRIPTION
The recovery mechanism for the journal does not work for multiple defined journals. 

The current implementation assumes there is only one journal when recovering. As a result when you define an additional journal the persistent actor fails to recover as it uses the default cassandra-query-journal configuration which points (cassandra-query-journal.write-plugin) to the default journal (cassandra-journal). 

This pull request fixes the problem by making the cassandra-query-journal configurable.  

