### PR TITLE
Expose settings for used-hosts-per-remote-dc value for DCAwareRoundRo…

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -148,7 +148,11 @@ cassandra-journal {
   # The id for the local datacenter of the Cassandra hosts it should connect to. 
   # By default, this property is not set resulting in Datastax's standard round robin policy being used.
   local-datacenter = ""
-  
+
+  # Number of hosts from non-local datacenter to use as a fall-back policy.
+  # Works only when local-datacenter is set
+  used-hosts-per-remote-dc = 0
+
   # To connect to the Cassandra hosts with credentials.
   # Authentication is disabled if username is not configured.
   authentication.username = ""
@@ -358,7 +362,11 @@ cassandra-snapshot-store {
   # The id for the local datacenter of the Cassandra hosts it should connect to. 
   # By default, this property is not set resulting in Datastax's standard round robin policy being used.
   local-datacenter = ""
-  
+
+  # Number of hosts from non-local datacenter to use as a fall-back policy.
+  # Works only when local-datacenter is set
+  used-hosts-per-remote-dc = 0
+
   # To connect to the Cassandra hosts with credentials.
   # Authentication is disabled if username is not configured.
   authentication.username = ""

--- a/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -102,9 +102,13 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
 
       val localDatacenter = config.getString("local-datacenter")
       if (localDatacenter != "") {
+        val usedHostsPerRemoteDc = config.getInt("used-hosts-per-remote-dc")
         b.withLoadBalancingPolicy(
           new TokenAwarePolicy(
-            DCAwareRoundRobinPolicy.builder.withLocalDc(localDatacenter).build()
+            DCAwareRoundRobinPolicy.builder
+              .withLocalDc(localDatacenter)
+              .withUsedHostsPerRemoteDc(usedHostsPerRemoteDc)
+              .build()
           )
         )
       }


### PR DESCRIPTION
Expose `used-hosts-per-remote-dc` of  `DCAwareRoundRobinPolicy` as a plugin settings.