### PR TITLE
112 serialize Props ignore

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/PreparedStatementEnvelope.scala
+++ b/src/main/scala/akka/persistence/cassandra/PreparedStatementEnvelope.scala
@@ -1,0 +1,12 @@
+package akka.persistence.cassandra
+
+import akka.actor.NoSerializationVerificationNeeded
+import com.datastax.driver.core.{PreparedStatement, Session}
+
+/**
+  * Created with IntelliJ IDEA.
+  * User: kasper
+  * Date: 14-07-16
+  * Time: 22:29
+  */
+case class PreparedStatementEnvelope(session:Session, ps:PreparedStatement) extends NoSerializationVerificationNeeded

--- a/src/main/scala/akka/persistence/cassandra/PreparedStatementEnvelope.scala
+++ b/src/main/scala/akka/persistence/cassandra/PreparedStatementEnvelope.scala
@@ -1,12 +1,9 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
 package akka.persistence.cassandra
 
 import akka.actor.NoSerializationVerificationNeeded
 import com.datastax.driver.core.{PreparedStatement, Session}
 
-/**
-  * Created with IntelliJ IDEA.
-  * User: kasper
-  * Date: 14-07-16
-  * Time: 22:29
-  */
 case class PreparedStatementEnvelope(session:Session, ps:PreparedStatement) extends NoSerializationVerificationNeeded

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -4,7 +4,6 @@
 package akka.persistence.cassandra.query
 
 import akka.actor.NoSerializationVerificationNeeded
-
 import scala.concurrent.duration._
 import com.typesafe.config.Config
 import com.datastax.driver.core.ConsistencyLevel

--- a/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -3,13 +3,16 @@
  */
 package akka.persistence.cassandra.query
 
+import akka.actor.NoSerializationVerificationNeeded
+
 import scala.concurrent.duration._
 import com.typesafe.config.Config
 import com.datastax.driver.core.ConsistencyLevel
 import akka.persistence.cassandra.journal.CassandraJournalConfig
 import akka.persistence.cassandra.journal.TimeBucket
 
-private[query] class CassandraReadJournalConfig(config: Config, writePluginConfig: CassandraJournalConfig) {
+private[query] class CassandraReadJournalConfig(config: Config, writePluginConfig: CassandraJournalConfig)
+  extends NoSerializationVerificationNeeded {
   val refreshInterval: FiniteDuration = config.getDuration("refresh-interval", MILLISECONDS).millis
   val maxBufferSize: Int = config.getInt("max-buffer-size")
   val fetchSize: Int = config.getInt("max-result-size-query")

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdPublisher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdPublisher.scala
@@ -3,21 +3,21 @@
  */
 package akka.persistence.cassandra.query
 
-import java.lang.{ Long => JLong }
+import java.lang.{Long => JLong}
 import java.nio.ByteBuffer
 
-import akka.actor.Props
+import akka.actor.{NoSerializationVerificationNeeded, Props}
 import akka.persistence.PersistentRepr
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.CassandraJournal
 import akka.persistence.cassandra.query.EventsByPersistenceIdPublisher._
 import akka.persistence.cassandra.query.QueryActorPublisher._
-import akka.serialization.{ Serialization, SerializationExtension }
+import akka.serialization.{Serialization, SerializationExtension}
 import com.datastax.driver.core._
 import com.datastax.driver.core.utils.Bytes
 
 import scala.concurrent.duration.FiniteDuration
-import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.{ExecutionContext, Future}
 
 private[query] object EventsByPersistenceIdPublisher {
   private[query] final case class EventsByPersistenceIdSession(
@@ -26,7 +26,7 @@ private[query] object EventsByPersistenceIdPublisher {
     selectDeletedToQuery:             PreparedStatement,
     session:                          Session,
     customConsistencyLevel:           Option[ConsistencyLevel]
-  ) {
+  ) extends NoSerializationVerificationNeeded{
 
     def selectEventsByPersistenceId(
       persistenceId: String,
@@ -69,8 +69,8 @@ private[query] object EventsByPersistenceIdPublisher {
     config: CassandraReadJournalConfig
   ): Props =
     Props(
-      new EventsByPersistenceIdPublisher(persistenceId, fromSeqNr, toSeqNr, max, fetchSize,
-        refreshInterval, session, config)
+      classOf[EventsByPersistenceIdPublisher],persistenceId, fromSeqNr, toSeqNr, max, fetchSize,
+        refreshInterval, session, config
     )
 }
 

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
@@ -6,8 +6,6 @@ package akka.persistence.cassandra.query
 import java.nio.ByteBuffer
 import java.util.UUID
 
-import akka.persistence.journal.EventAdapters
-
 import scala.concurrent.Future
 import akka.actor.Actor
 import akka.actor.ActorRef
@@ -16,9 +14,7 @@ import akka.actor.Status
 import akka.pattern.pipe
 import akka.persistence.PersistentRepr
 import akka.serialization.SerializationExtension
-import com.datastax.driver.core.PreparedStatement
 import com.datastax.driver.core.ResultSet
-import com.datastax.driver.core.Session
 import com.datastax.driver.core.utils.Bytes
 import akka.actor.ActorLogging
 
@@ -26,7 +22,7 @@ import scala.annotation.tailrec
 import akka.actor.DeadLetterSuppression
 import akka.persistence.cassandra.journal.TimeBucket
 import akka.actor.NoSerializationVerificationNeeded
-import akka.persistence.cassandra.{PreparedStatementEnvelope, SessionEnvelope}
+import akka.persistence.cassandra.PreparedStatementEnvelope
 import com.datastax.driver.core.Row
 import akka.persistence.cassandra.journal.CassandraJournal
 

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
@@ -17,7 +17,6 @@ import akka.serialization.SerializationExtension
 import com.datastax.driver.core.ResultSet
 import com.datastax.driver.core.utils.Bytes
 import akka.actor.ActorLogging
-
 import scala.annotation.tailrec
 import akka.actor.DeadLetterSuppression
 import akka.persistence.cassandra.journal.TimeBucket

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByTagPublisher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByTagPublisher.scala
@@ -8,6 +8,7 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
+
 import akka.persistence.journal.EventAdapters
 
 import scala.concurrent.duration._
@@ -27,13 +28,14 @@ import com.datastax.driver.core.utils.UUIDs
 import akka.persistence.cassandra.journal.TimeBucket
 import akka.cluster.pubsub.DistributedPubSub
 import akka.cluster.pubsub.DistributedPubSubMediator
+import akka.persistence.cassandra.PreparedStatementEnvelope
 
 private[query] object EventsByTagPublisher {
 
   def props(tag: String, fromOffset: UUID, toOffset: Option[UUID], settings: CassandraReadJournalConfig,
             session: Session, preparedSelect: PreparedStatement): Props = {
-    Props(new EventsByTagPublisher(tag, fromOffset, toOffset,
-      settings, session, preparedSelect))
+    Props(classOf[EventsByTagPublisher],tag, fromOffset, toOffset,
+      settings, PreparedStatementEnvelope(session,preparedSelect))
   }
 
   private[query] case object Continue extends DeadLetterSuppression
@@ -51,7 +53,7 @@ private[query] object EventsByTagPublisher {
 
 private[query] class EventsByTagPublisher(
   tag: String, fromOffset: UUID, toOffset: Option[UUID],
-  settings: CassandraReadJournalConfig, session: Session, preparedSelect: PreparedStatement
+  settings: CassandraReadJournalConfig, preparedSelect: PreparedStatementEnvelope
 )
   extends ActorPublisher[UUIDPersistentRepr] with DeliveryBuffer[UUIDPersistentRepr] with ActorLogging {
   import akka.persistence.cassandra.query.UUIDComparator.comparator.compare
@@ -201,7 +203,7 @@ private[query] class EventsByTagPublisher(
         tag, currTimeBucket, currOffset, limit
       )
     context.actorOf(EventsByTagFetcher.props(tag, currTimeBucket, currOffset, toOffs, limit, backtracking,
-      self, session, preparedSelect, seqNumbers, settings))
+      self, preparedSelect, seqNumbers, settings))
     context.become(replaying(limit))
   }
 

--- a/src/main/scala/akka/persistence/cassandra/query/EventsByTagPublisher.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/EventsByTagPublisher.scala
@@ -8,7 +8,6 @@ import java.time.LocalDateTime
 import java.time.ZoneOffset
 import java.time.temporal.ChronoUnit
 import java.util.UUID
-
 import akka.persistence.journal.EventAdapters
 
 import scala.concurrent.duration._

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -21,6 +21,8 @@ import akka.stream.testkit.scaladsl.TestSink
 object EventsByPersistenceIdSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
+    akka.actor.serialize-messages = on
+    akka.actor.serialize-creators = on
     cassandra-journal.port = ${CassandraLauncher.randomPort}
     cassandra-journal.keyspace=EventsByPersistenceIdSpec
     cassandra-query-journal.max-buffer-size = 10

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
@@ -44,6 +44,8 @@ object EventsByTagPubsubSpec {
 
   val config = ConfigFactory.parseString(s"""
     akka.actor.provider = "akka.cluster.ClusterActorRefProvider"
+    akka.actor.serialize-messages = on
+    akka.actor.serialize-creators = on
     cassandra-journal {
       pubsub-minimum-interval = 1 millisecond
     }

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -44,6 +44,8 @@ object EventsByTagSpec {
 
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
+    akka.actor.serialize-messages = on
+    akka.actor.serialize-creators = on
     cassandra-journal {
       #target-partition-size = 5
       port = ${CassandraLauncher.randomPort}


### PR DESCRIPTION
Prevent failures when serialization debugging is turned on. 
```
akka.actor.serialize-messages = on
akka.actor.serialize-creators = on
```
Ensure all parameters on props are serializable or extends NoSerializationVerificationNeeded