### PR TITLE
Use unset instead of null to avoid tumbstones

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -226,11 +226,12 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
         bs.setString("ser_manifest", m.serManifest)
         bs.setString("event_manifest", m.eventManifest)
         bs.setBytes("event", m.serialized)
-        // for backwards compatibility
-        bs.unset("message")
 
         if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
-          (1 to maxTagsPerEvent).foreach(tagId => bs.unset("tag" + tagId))
+          bs.setToNull("message")
+          (1 to maxTagsPerEvent).foreach(tagId => bs.setToNull("tag" + tagId))
+        } else {
+          bs.unset("message")
         }
 
         if (m.tags.nonEmpty) {

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -227,9 +227,10 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
         bs.setString("event_manifest", m.eventManifest)
         bs.setBytes("event", m.serialized)
         // for backwards compatibility
-        bs.setToNull("message")
+        bs.unset("message")
+
         if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
-          (1 to maxTagsPerEvent).foreach(tagId => bs.setToNull("tag" + tagId))
+          (1 to maxTagsPerEvent).foreach(tagId => bs.unset("tag" + tagId))
         }
 
         if (m.tags.nonEmpty) {

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -109,7 +109,12 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
         bs.setString("ser_manifest", ser.serManifest)
         bs.setBytes("snapshot_data", ser.serialized)
         // for backwards compatibility
-        bs.unset("snapshot")
+        if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
+          bs.setToNull("snapshot")
+        } else {
+          bs.unset("snapshot")
+        }
+
         session.executeWrite(bs)
       }
     }

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -109,7 +109,7 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
         bs.setString("ser_manifest", ser.serManifest)
         bs.setBytes("snapshot_data", ser.serialized)
         // for backwards compatibility
-        bs.setToNull("snapshot")
+        bs.unset("snapshot")
         session.executeWrite(bs)
       }
     }


### PR DESCRIPTION
Every null value creates thumb-stone in cassandra. For every event added to cassandra depending on cassandra version will be created 1-2 thumb-stones. Setting value to unset mitigates this issue.