### PR TITLE
Add exception type to the warning log on snapshot load failure

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -75,7 +75,7 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
       case Snapshot(s) => Some(SelectedSnapshot(md, s))
     } recoverWith {
       case e =>
-        log.warning("Failed to load snapshot, trying older one. Caused by: {}", e.getMessage)
+        log.warning("Failed to load snapshot, trying older one. Caused by: [{}: {}]", e.getClass.getName, e.getMessage)
         loadNAsync(mds) // try older snapshot
     }
   }


### PR DESCRIPTION
Log message like `Failed to load snapshot, trying older one. Caused by: null` is not very useful. Shall we add at least exception class name?