### PR TITLE
Use the new offset type and implement new queries of Akka 2.4.12 

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -57,7 +57,7 @@ testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
 // disable parallel tests
 parallelExecution in Test := false
 
-val AkkaVersion = "2.4.10"
+val AkkaVersion = "2.4.12"
 
 libraryDependencies ++= Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.1.0",


### PR DESCRIPTION
Refs #138

I'm not quite sure about removing the deprecated implementations and calling the new ones wrt extra allocations for every event etc vs avoiding duplication. 

Please let me know if you think I should add it back @patriknw 