### PR TITLE
Update sbt-header plugin to 1.6.0 #150

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.5.1")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "1.6.0")
 
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.5.1")
 


### PR DESCRIPTION
* sbt-header 1.6.0 fixes problems with newlines on Windows