### PR TITLE
fix end condition for currentEventsByTag, #117

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -194,6 +194,13 @@ class CassandraReadJournal(system: ExtendedActorSystem, config: Config)
   }
 
   /**
+   * Convert a `TimeBasedUUID` to a unix timestamp (as returned by
+   * `System#currentTimeMillis`.
+   */
+  def timestampFrom(offset: TimeBasedUUID): Long =
+    UUIDs.unixTimestamp(offset.value)
+
+  /**
    * `eventsByTag` is used for retrieving events that were marked with
    * a given tag, e.g. all events of an Aggregate Root type.
    *


### PR DESCRIPTION
* it was only waiting out the eventual-consistency-delay without
  checking that a query had returned empty results

Also, add missing test for the timestamp based query
* add convenience method to convert TimeBasedUUI to unix timestamp

Refs #117