### PR TITLE
Make it possible to enable query logging

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -68,8 +68,12 @@ cassandra-journal {
   # to the Cassandra cluster
   reconnect-max-delay = 30s
 
+  # Enable debug logging of queries as described in 
+  # https://docs.datastax.com/en/developer/java-driver/3.1/manual/logging/#logging-query-latencies 
+  log-queries = off
+
   # Cassandra driver connection pool settings
-  # Documented at https://datastax.github.io/java-driver/manual/pooling/
+  # Documented at http://docs.datastax.com/en/developer/java-driver/latest/manual/pooling/
   connection-pool {
 
     # Create new connection threshold local
@@ -323,9 +327,13 @@ cassandra-snapshot-store {
   # Max delay of the ExponentialReconnectionPolicy that is used when reconnecting
   # to the Cassandra cluster
   reconnect-max-delay = 30s
+  
+  # Enable debug logging of queries as described in 
+  # https://docs.datastax.com/en/developer/java-driver/3.1/manual/logging/#logging-query-latencies 
+  log-queries = off
 
   # Cassandra driver connection pool settings
-  # Documented at https://datastax.github.io/java-driver/manual/pooling/
+  # Documented at http://docs.datastax.com/en/developer/java-driver/latest/manual/pooling/
   # and http://docs.datastax.com/en/drivers/java/3.0/com/datastax/driver/core/PoolingOptions.html
   connection-pool {
 
@@ -442,7 +450,7 @@ cassandra-snapshot-store {
   protocol-version = ""
 
   # Options to configure low-level socket options for the connections to Cassandra hosts
-  # See: https://datastax.github.io/java-driver/manual/socket_options
+  # See: http://docs.datastax.com/en/developer/java-driver/latest/manual/socket_options
   socket {
 
     # how long the driver waits to establish a new connection to a Cassandra node before giving up


### PR DESCRIPTION
I was debugging https://github.com/akka/akka-persistence-cassandra/issues/149 and thought I had found something, but it was not a problem. Anyway, being able to enable query logging is very useful. https://docs.datastax.com/en/developer/java-driver/3.1/manual/logging/#logging-query-latencies