### PR TITLE
reduce threads of cassandra-plugin-default-dispatcher

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -549,9 +549,9 @@ cassandra-plugin-default-dispatcher {
   type = Dispatcher
   executor = "fork-join-executor"
   fork-join-executor {
-    parallelism-min = 8
-    parallelism-factor = 1.0
-    parallelism-max = 16
+    parallelism-min = 2
+    parallelism-factor = 0.5
+    parallelism-max = 8
   }
 }
 


### PR DESCRIPTION
* to reduce risk over overloading the system
* e.g. serialization can be cpu intensive