### PR TITLE
Added fork option to CassandraLauncher

### DIFF
--- a/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -76,7 +76,8 @@ trait CassandraLifecycle extends BeforeAndAfterAll { this: TestKitBase with Suit
       cassandraDirectory,
       configResource = cassandraConfigResource,
       clean = true,
-      port = 0
+      port = 0,
+      fork = true
     )
   }
 

--- a/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -76,8 +76,7 @@ trait CassandraLifecycle extends BeforeAndAfterAll { this: TestKitBase with Suit
       cassandraDirectory,
       configResource = cassandraConfigResource,
       clean = true,
-      port = 0,
-      fork = true
+      port = 0
     )
   }
 

--- a/src/test/scala/akka/persistence/cassandra/testkit/CassandraLauncherSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/testkit/CassandraLauncherSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2016 Typesafe Inc. <http://www.typesafe.com>
+ */
+package akka.persistence.cassandra.testkit
+
+import java.io.File
+
+import akka.actor.ActorSystem
+import akka.testkit.TestKit
+import com.datastax.driver.core.Cluster
+import org.scalatest.{ Matchers, WordSpecLike }
+import scala.concurrent.duration._
+
+class CassandraLauncherSpec extends TestKit(ActorSystem("CassandraLauncherSpec")) with Matchers with WordSpecLike {
+
+  private def testCassandra() = {
+    Cluster.builder()
+      .addContactPoints("localhost").withPort(CassandraLauncher.randomPort)
+      .build().connect().execute("SELECT now() from system.local;").one()
+  }
+
+  "The CassandraLauncher" should {
+    "support forking" in {
+      val cassandraDirectory = new File("target/" + system.name)
+      CassandraLauncher.start(
+        cassandraDirectory,
+        configResource = CassandraLauncher.DefaultTestConfigResource,
+        clean = true,
+        port = 0,
+        fork = true
+      )
+
+      awaitAssert({
+        testCassandra()
+      }, 45.seconds)
+
+      CassandraLauncher.stop()
+
+      an[Exception] shouldBe thrownBy(testCassandra())
+    }
+  }
+
+}

--- a/src/test/scala/akka/persistence/cassandra/testkit/CassandraLauncherSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/testkit/CassandraLauncherSpec.scala
@@ -26,8 +26,7 @@ class CassandraLauncherSpec extends TestKit(ActorSystem("CassandraLauncherSpec")
         cassandraDirectory,
         configResource = CassandraLauncher.DefaultTestConfigResource,
         clean = true,
-        port = 0,
-        fork = true
+        port = 0
       )
 
       awaitAssert({


### PR DESCRIPTION
Fixes #153.

Restarting an embedded Cassandra in memory is not supported, see:

https://issues.apache.org/jira/browse/CASSANDRA-11154

In there a Cassandra core developer says "Oh, and C* is definitely not designed to be in-memory restartable". Hence, when using the CassandraLauncher for tests, it should be forked into its own process.

This commit introduces that forking. It maintains backwards compatibility, and keeps the default behaviour to not fork, but adds a flag that can be set to fork.

The approach taken is to discover the classpath of CassandraLauncher, by assuming its classloader is a URLClassLoader. If this assumption is not true, the launcher fails with an appropriate error message.

There is one potential issue with this implementation, that is that it specifies the classpath on the command line, which will fail on Windows if the Classpath exceeds 8192 characters. There are a few potential solutions to that, none of them are very clean, but I thought I'd start with this as a first pass.