### PR TITLE
Support Cassandra 3.8

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,12 +66,16 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
   "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query"              % AkkaVersion,
-  "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion   % "test",
-  "com.typesafe.akka"      %% "akka-stream-testkit"                 % AkkaVersion   % "test",
-  "org.scalatest"          %% "scalatest"                           % "3.0.0"       % "test",
+  "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion     % "test",
+  "com.typesafe.akka"      %% "akka-stream-testkit"                 % AkkaVersion     % "test",
+  "org.scalatest"          %% "scalatest"                           % "3.0.0"         % "test",
   // cassandra-all for testkit.CassandraLauncher, app should define it as test dependency if needed
-  "org.apache.cassandra"    % "cassandra-all"                       % "3.7"         % "optional",
-  "org.osgi"                % "org.osgi.core"                       % "5.0.0"       % "provided"
+  "org.apache.cassandra"    % "cassandra-all"                       % "3.10"          % "optional" exclude("io.netty", "netty-all"),
+  // cassandra-all 3.10 depends on netty-all 4.0.39, while cassandra-driver-core 3.1.0 depends on netty-handler 4.0.37,
+  // we exclude netty-all, and upgrade individual deps
+  "io.netty"                % "netty-handler"                       % "4.0.39.Final"  % "optional",
+  "io.netty"                % "netty-transport-native-epoll"        % "4.0.39.Final"  % "optional",
+  "org.osgi"                % "org.osgi.core"                       % "5.0.0"         % "provided"
 )
 
 headers := headers.value ++ Map(

--- a/src/main/resources/test-embedded-cassandra.yaml
+++ b/src/main/resources/test-embedded-cassandra.yaml
@@ -22,6 +22,8 @@ saved_caches_directory: $DIR/saved_caches
 
 hints_directory: $DIR/hints
 
+cdc_raw_directory: $DIR/cdc_raw
+
 commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
 

--- a/src/test/resources/test-embedded-cassandra-net.yaml
+++ b/src/test/resources/test-embedded-cassandra-net.yaml
@@ -21,6 +21,8 @@ saved_caches_directory: $DIR/saved_caches
 
 hints_directory: $DIR/hints
 
+cdc_raw_directory: $DIR/cdc_raw
+
 commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
 

--- a/src/test/resources/test-embedded-cassandra-ssl-server-client.yaml
+++ b/src/test/resources/test-embedded-cassandra-ssl-server-client.yaml
@@ -22,6 +22,8 @@ saved_caches_directory: $DIR/saved_caches
 
 hints_directory: $DIR/hints
 
+cdc_raw_directory: $DIR/cdc_raw
+
 commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
 

--- a/src/test/resources/test-embedded-cassandra-ssl-server.yaml
+++ b/src/test/resources/test-embedded-cassandra-ssl-server.yaml
@@ -22,6 +22,8 @@ saved_caches_directory: $DIR/saved_caches
 
 hints_directory: $DIR/hints
 
+cdc_raw_directory: $DIR/cdc_raw
+
 commitlog_sync: periodic
 commitlog_sync_period_in_ms: 10000
 


### PR DESCRIPTION
Cassandra 3.8 and onwards require that the cdc_raw_directory configuration parameter is set.

This actually upgrades akka-persistence-cassandra to use Cassandra 3.10 in its tests.