### PR TITLE
Allow use of shaded Cassandra

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,12 +69,8 @@ libraryDependencies ++= Seq(
   "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion     % "test",
   "com.typesafe.akka"      %% "akka-stream-testkit"                 % AkkaVersion     % "test",
   "org.scalatest"          %% "scalatest"                           % "3.0.0"         % "test",
-  // cassandra-all for testkit.CassandraLauncher, app should define it as test dependency if needed
-  "org.apache.cassandra"    % "cassandra-all"                       % "3.10"          % "optional" exclude("io.netty", "netty-all"),
-  // cassandra-all 3.10 depends on netty-all 4.0.39, while cassandra-driver-core 3.1.0 depends on netty-handler 4.0.37,
-  // we exclude netty-all, and upgrade individual deps
-  "io.netty"                % "netty-handler"                       % "4.0.39.Final"  % "optional",
-  "io.netty"                % "netty-transport-native-epoll"        % "4.0.39.Final"  % "optional",
+  // cassandra-unit-shaded for testkit.CassandraLauncher, app should define it as test dependency if needed
+  "org.cassandraunit"       % "cassandra-unit-shaded"               % "3.1.3.2"       % "optional",
   "org.osgi"                % "org.osgi.core"                       % "5.0.0"         % "provided"
 )
 

--- a/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -27,7 +27,7 @@ object CassandraLifecycle {
     akka.actor.serialize-messages=on
     """)
 
-  def awaitPersistenceInit(system: ActorSystem, journalPluginId: String="", snapshotPluginId: String=""): Unit = {
+  def awaitPersistenceInit(system: ActorSystem, journalPluginId: String = "", snapshotPluginId: String = ""): Unit = {
     val probe = TestProbe()(system)
     val t0 = System.nanoTime()
     var n = 0


### PR DESCRIPTION
This removes the binary dependency on Cassandra, and instead detects Cassandra from the classpath, either Cassandra proper, or the shaded version published by cassandra-unit (LGPL).

Projects can use the shaded version to avoid classpath conflicts with Cassandra itself, such as with the version of Netty or Guice that it depends on.