### PR TITLE
update cassandra-driver to 3.1.4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ parallelExecution in Test := false
 val AkkaVersion = "2.5.0"
 
 libraryDependencies ++= Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.1.0",
+  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.1.4",
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
   "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query"              % AkkaVersion,


### PR DESCRIPTION
There is also a 3.2.0, but since I want to release today I picked the conservative patch update only.