### PR TITLE
Tombstone creation fix for cassandra versions < 2.1.x (release-2.4)

### DIFF
--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -245,13 +245,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
         bs.setString("event_manifest", m.eventManifest)
         bs.setBytes("event", m.serialized)
 
-        if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
-          bs.setToNull("message")
-          (1 to maxTagsPerEvent).foreach(tagId => bs.setToNull("tag" + tagId))
-        } else {
-          bs.unset("message")
-        }
-
         if (m.tags.nonEmpty) {
           var tagCounts = Array.ofDim[Int](maxTagsPerEvent)
           m.tags.foreach { tag =>

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -64,22 +64,12 @@ trait CassandraStatements {
          WITH CLUSTERING ORDER BY (timestamp ASC)
       """
 
-  def writeMessage_threeTags = s"""
+  def writeMessage = s"""
       INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, tag3, used)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """
 
-  def writeMessage_twoTags = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, used)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, true)
-    """
-
-  def writeMessage_oneTag = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, used)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
-    """
-
-  def writeMessage_noTag = s"""
+  def writeMessage_noTags = s"""
       INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, used)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -64,7 +64,22 @@ trait CassandraStatements {
          WITH CLUSTERING ORDER BY (timestamp ASC)
       """
 
-  def writeMessage = s"""
+  def writeMessage_threeTags = s"""
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, tag3, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
+    """
+
+  def writeMessage_twoTags = s"""
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, true)
+    """
+
+  def writeMessage_oneTag = s"""
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
+    """
+
+  def writeMessage_noTag = s"""
       INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, used)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """

--- a/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -65,8 +65,8 @@ trait CassandraStatements {
       """
 
   def writeMessage = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, tag3, message, used)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """
 
   def deleteMessage = s"""

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -169,12 +169,6 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
         bs.setInt("ser_id", ser.serId)
         bs.setString("ser_manifest", ser.serManifest)
         bs.setBytes("snapshot_data", ser.serialized)
-        // for backwards compatibility
-        if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
-          bs.setToNull("snapshot")
-        } else {
-          bs.unset("snapshot")
-        }
 
         session.executeWrite(bs).map(_ => ())
       }

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -32,8 +32,8 @@ trait CassandraStatements {
     """
 
   def writeSnapshot = s"""
-      INSERT INTO ${tableName} (persistence_id, sequence_nr, timestamp, ser_manifest, ser_id, snapshot_data, snapshot)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO ${tableName} (persistence_id, sequence_nr, timestamp, ser_manifest, ser_id, snapshot_data)
+      VALUES (?, ?, ?, ?, ?, ?)
     """
 
   def deleteSnapshot = s"""

--- a/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -29,6 +29,7 @@ object CassandraJournalConfiguration {
   lazy val protocolV3Config = ConfigFactory.parseString(
     s"""
       cassandra-journal.protocol-version = 3
+      cassandra-journal.enable-events-by-tag-query = off
       cassandra-journal.keyspace=CassandraJournalProtocolV3Spec
       cassandra-snapshot-store.keyspace=CassandraJournalProtocolV3Spec
     """

--- a/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -124,7 +124,7 @@ abstract class AbstractEventsByTagSpec(override val systemName: String, config: 
     val writeStatements: CassandraStatements = new CassandraStatements {
       def config: CassandraJournalConfig = writePluginConfig
     }
-    session.prepare(writeStatements.writeMessage_threeTags)
+    session.prepare(writeStatements.writeMessage)
   }
 
   def writeTestEvent(time: LocalDateTime, persistent: PersistentRepr, tags: Set[String]): Unit = {

--- a/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -29,6 +29,7 @@ object CassandraSnapshotStoreConfiguration {
   lazy val protocolV3Config = ConfigFactory.parseString(
     s"""
       cassandra-journal.protocol-version = 3
+      cassandra-journal.enable-events-by-tag-query = off
       cassandra-journal.keyspace=CassandraSnapshotStoreProtocolV3Spec
       cassandra-snapshot-store.keyspace=CassandraSnapshotStoreProtocolV3Spec
     """

--- a/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -78,8 +78,8 @@ class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(CassandraSnapshotStor
       val expected = probe.expectMsgPF() { case LoadSnapshotResult(Some(snapshot), _) => snapshot }
 
       // write two more snapshots that cannot be de-serialized.
-      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")), null)
-      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")), null)
+      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")))
+      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")))
 
       // load most recent snapshot, first two attempts will fail ...
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), probe.ref)
@@ -97,9 +97,9 @@ class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(CassandraSnapshotStor
       probe.expectMsgPF() { case LoadSnapshotResult(Some(snapshot), _) => snapshot }
 
       // write three more snapshots that cannot be de-serialized.
-      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")), null)
-      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")), null)
-      session.execute(writeSnapshot, pid, 19L: JLong, 125L: JLong, serId, "", ByteBuffer.wrap("fail-3".getBytes("UTF-8")), null)
+      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")))
+      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")))
+      session.execute(writeSnapshot, pid, 19L: JLong, 125L: JLong, serId, "", ByteBuffer.wrap("fail-3".getBytes("UTF-8")))
 
       // load most recent snapshot, first three attempts will fail ...
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), probe.ref)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.26-SNAPSHOT"
+version in ThisBuild := "0.26"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.26"
+version in ThisBuild := "0.26-SNAPSHOT"


### PR DESCRIPTION
According to the [docs](http://docs.datastax.com/en/developer/java-driver/3.2/manual/native_protocol/#compatibility-matrix), cassandra 2.1.x and early don't support protocol v4. This means that collumns `message`, `tag1..3` and `snapshot` will be explicitly set to null, thus creating tombstones. 

A workaround is to use different prepared statements, each of them excluding the column that would otherwise be set to null. This adds some complexity to the code, but it does not create the extra tombstones. 

This change is intended to help projects that generate a lot of events and that can't (easily) upgrade cassandra to >= 2.2.x.

I have raised this against the 2.4 release. If accepted, I will make the change for 2.5 as well.