### PR TITLE
Tombstone creation fix for cassandra versions < 2.1.x (master)

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -245,13 +245,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
         bs.setString("event_manifest", m.eventManifest)
         bs.setBytes("event", m.serialized)
 
-        if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
-          bs.setToNull("message")
-          (1 to maxTagsPerEvent).foreach(tagId => bs.setToNull("tag" + tagId))
-        } else {
-          bs.unset("message")
-        }
-
         if (m.tags.nonEmpty) {
           var tagCounts = Array.ofDim[Int](maxTagsPerEvent)
           m.tags.foreach { tag =>

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -64,22 +64,12 @@ trait CassandraStatements {
          WITH CLUSTERING ORDER BY (timestamp ASC)
       """
 
-  def writeMessage_threeTags = s"""
+  def writeMessage = s"""
       INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, tag3, used)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """
 
-  def writeMessage_twoTags = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, used)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, true)
-    """
-
-  def writeMessage_oneTag = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, used)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
-    """
-
-  def writeMessage_noTag = s"""
+  def writeMessage_noTags = s"""
       INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, used)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -64,7 +64,22 @@ trait CassandraStatements {
          WITH CLUSTERING ORDER BY (timestamp ASC)
       """
 
-  def writeMessage = s"""
+  def writeMessage_threeTags = s"""
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, tag3, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
+    """
+
+  def writeMessage_twoTags = s"""
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, true)
+    """
+
+  def writeMessage_oneTag = s"""
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
+    """
+
+  def writeMessage_noTag = s"""
       INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, used)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -65,8 +65,8 @@ trait CassandraStatements {
       """
 
   def writeMessage = s"""
-      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, tag1, tag2, tag3, message, used)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
+      INSERT INTO ${tableName} (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event, used)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ? , true)
     """
 
   def deleteMessage = s"""

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -169,12 +169,6 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
         bs.setInt("ser_id", ser.serId)
         bs.setString("ser_manifest", ser.serManifest)
         bs.setBytes("snapshot_data", ser.serialized)
-        // for backwards compatibility
-        if (session.protocolVersion.compareTo(ProtocolVersion.V4) < 0) {
-          bs.setToNull("snapshot")
-        } else {
-          bs.unset("snapshot")
-        }
 
         session.executeWrite(bs).map(_ => ())
       }

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -32,8 +32,8 @@ trait CassandraStatements {
     """
 
   def writeSnapshot = s"""
-      INSERT INTO ${tableName} (persistence_id, sequence_nr, timestamp, ser_manifest, ser_id, snapshot_data, snapshot)
-      VALUES (?, ?, ?, ?, ?, ?, ?)
+      INSERT INTO ${tableName} (persistence_id, sequence_nr, timestamp, ser_manifest, ser_id, snapshot_data)
+      VALUES (?, ?, ?, ?, ?, ?)
     """
 
   def deleteSnapshot = s"""

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -29,6 +29,7 @@ object CassandraJournalConfiguration {
   lazy val protocolV3Config = ConfigFactory.parseString(
     s"""
       cassandra-journal.protocol-version = 3
+      cassandra-journal.enable-events-by-tag-query = off
       cassandra-journal.keyspace=CassandraJournalProtocolV3Spec
       cassandra-snapshot-store.keyspace=CassandraJournalProtocolV3Spec
     """

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -25,7 +25,7 @@ import akka.persistence.journal.Tagged
 import akka.persistence.journal.WriteEventAdapter
 import akka.persistence.query.{ EventEnvelope, NoOffset, PersistenceQuery }
 import akka.persistence.query.scaladsl.{ CurrentEventsByTagQuery, EventsByTagQuery }
-import akka.serialization.SerializationExtension
+import akka.serialization.{ SerializationExtension, SerializerWithStringManifest }
 import akka.stream.ActorMaterializer
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
@@ -127,7 +127,7 @@ abstract class AbstractEventsByTagSpec(override val systemName: String, config: 
     val writeStatements: CassandraStatements = new CassandraStatements {
       def config: CassandraJournalConfig = writePluginConfig
     }
-    session.prepare(writeStatements.writeMessage)
+    session.prepare(writeStatements.writeMessage_threeTags)
   }
 
   def writeTestEvent(time: LocalDateTime, persistent: PersistentRepr, tags: Set[String]): Unit = {
@@ -144,7 +144,18 @@ abstract class AbstractEventsByTagSpec(override val systemName: String, config: 
       val tagId = writePluginConfig.tags.getOrElse(tag, 1)
       bs.setString("tag" + tagId, tag)
     }
-    bs.setBytes("message", serialized)
+    val serializer = serialization.findSerializerFor(persistent)
+    val serManifest = serializer match {
+      case ser2: SerializerWithStringManifest ⇒
+        ser2.manifest(persistent)
+      case _ ⇒
+        if (serializer.includeManifest) persistent.getClass.getName
+        else PersistentRepr.Undefined
+    }
+    bs.setInt("ser_id", serializer.identifier)
+    bs.setString("ser_manifest", serManifest)
+    bs.setString("event_manifest", persistent.manifest)
+    bs.setBytes("event", serialized)
     session.execute(bs)
   }
 
@@ -307,12 +318,12 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val src = queries.currentEventsByTag(tag = "T1", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(2)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
       probe.expectNoMsg(500.millis)
       probe.request(5)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "e3") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "e4") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, `pr3`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, `pr4`) => e }
       probe.expectComplete()
     }
   }
@@ -400,8 +411,8 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val src = queries.eventsByTag(tag = "T1", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
 
       val t3 = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(5)
       val pr3 = PersistentRepr("e3", 3L, "p1", "", writerUuid = w1)
@@ -410,8 +421,16 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val pr4 = PersistentRepr("e4", 4L, "p1", "", writerUuid = w1)
       writeTestEvent(t4, pr4, Set("T1"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "e3") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "e4") => e }
+      probe.expectNextPF {
+        case e @ EventEnvelope(_, "p1", 3L, _pr3) =>
+          _pr3 shouldBe a[PersistentRepr]
+          _pr3.asInstanceOf[PersistentRepr].payload shouldBe "e3"
+      }
+      probe.expectNextPF {
+        case e @ EventEnvelope(_, "p1", 4L, _pr4) =>
+          _pr4 shouldBe a[PersistentRepr]
+          _pr4.asInstanceOf[PersistentRepr].payload shouldBe "e4"
+      }
       probe.cancel()
     }
 
@@ -436,9 +455,9 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val pr2 = PersistentRepr("p2-e1", 1L, "p2", "", writerUuid = w2)
       writeTestEvent(t2, pr2, Set("T2"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "p1-e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, "p2-e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "p1-e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr3`) => e }
       probe.cancel()
     }
 
@@ -539,16 +558,16 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T3", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
       probe.expectNoMsg(500.millis)
 
       val t3 = t1.plusSeconds(2)
       val pr3 = PersistentRepr("e3", 3L, "p1", "", writerUuid = w1)
       writeTestEvent(t3, pr3, Set("T3"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "e3") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "e4") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, `pr3`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, `pr4`) => e }
       probe.cancel()
     }
 
@@ -569,8 +588,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T4", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
       probe.expectNoMsg(1.seconds)
       probe.expectError().getClass should be(classOf[IllegalStateException])
     }
@@ -597,10 +616,10 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T5", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "p1-e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "p1-e2") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, "p2-e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 2L, "p2-e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, `pr3`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 2L, `pr4`) => e }
 
       // too early p1-e4
       val t5 = t1.plusSeconds(5)
@@ -613,13 +632,13 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val pr6 = PersistentRepr("p1-e3", 3L, "p1", "", writerUuid = w1)
       writeTestEvent(t6, pr6, Set("T5"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "p1-e3") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "p1-e4") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, `pr6`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, `pr5`) => e }
 
       val t7 = t1.plusSeconds(7)
       val pr7 = PersistentRepr("p2-e3", 3L, "p2", "", writerUuid = w2)
       writeTestEvent(t7, pr7, Set("T5"))
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 3L, "p2-e3") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 3L, `pr7`) => e }
 
       probe.cancel()
     }
@@ -638,15 +657,15 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T6", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "p1-e1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, "p2-e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, `pr2`) => e }
 
       // delayed, and timestamp is before p2-e1
       val t3 = t1.plusSeconds(1)
       val pr3 = PersistentRepr("p1-e2", 2L, "p1", "", writerUuid = w1)
       writeTestEvent(t3, pr3, Set("T6"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "p1-e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr3`) => e }
 
       probe.cancel()
     }
@@ -663,7 +682,7 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T7", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, "A1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, `eventA1`) => e }
 
       // delayed, timestamp is before A1
       val eventB1 = PersistentRepr("B1", 1L, "b", "", writerUuid = w2)
@@ -672,8 +691,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB2 = PersistentRepr("B2", 2L, "b", "", writerUuid = w2)
       writeTestEvent(t3, eventB2, Set("T7"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, "B1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, `eventB1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB2`) => e }
 
       probe.cancel()
     }
@@ -693,8 +712,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T8", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, "B0") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, "A1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, `eventB0`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, `eventA1`) => e }
 
       // delayed, timestamp is before A1
       val eventB1 = PersistentRepr("B1", 2L, "b", "", writerUuid = w2)
@@ -703,8 +722,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB2 = PersistentRepr("B2", 3L, "b", "", writerUuid = w2)
       writeTestEvent(t3, eventB2, Set("T8"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B1") => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 3L, "B2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 3L, `eventB2`) => e }
 
       probe.cancel()
     }
@@ -720,7 +739,7 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src1 = queries.eventsByTag(tag = "T9", offset = NoOffset)
       val probe1 = src1.runWith(TestSink.probe[Any])
       probe1.request(10)
-      val offs = probe1.expectNextPF { case e @ EventEnvelope(_, "a", 1L, "A1") => e }.offset.asInstanceOf[TimeBasedUUID]
+      val offs = probe1.expectNextPF { case e @ EventEnvelope(_, "a", 1L, `eventA1`) => e }.offset.asInstanceOf[TimeBasedUUID]
       probe1.cancel()
 
       // start a new query from the offset
@@ -734,7 +753,7 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB2 = PersistentRepr("B2", 2L, "b", "", writerUuid = w2)
       writeTestEvent(t1.plusSeconds(3), eventB2, Set("T9"))
 
-      probe2.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B2") => e }
+      probe2.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB2`) => e }
 
       probe2.cancel()
     }
@@ -765,12 +784,12 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB1 = PersistentRepr("B1", 1L, "b", "", writerUuid = w2)
       writeTestEvent(t2.minus(100, ChronoUnit.MILLIS), eventB1, Set("T10"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, "B1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, `eventB1`) => e }
       probe.expectNoMsg(2.second)
 
       val eventB2 = PersistentRepr("B2", 2L, "b", "", writerUuid = w2)
       writeTestEvent(t2.plusSeconds(1), eventB2, Set("T10"))
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB2`) => e }
 
       probe.cancel()
     }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -131,7 +131,18 @@ abstract class AbstractEventsByTagSpec(override val systemName: String, config: 
   }
 
   def writeTestEvent(time: LocalDateTime, persistent: PersistentRepr, tags: Set[String]): Unit = {
-    val serialized = ByteBuffer.wrap(serialization.serialize(persistent).get)
+    val event = persistent.payload.asInstanceOf[AnyRef]
+    val serializer = serialization.findSerializerFor(event)
+    val serialized = ByteBuffer.wrap(serialization.serialize(event).get)
+
+    val serManifest = serializer match {
+      case ser2: SerializerWithStringManifest ⇒
+        ser2.manifest(persistent)
+      case _ ⇒
+        if (serializer.includeManifest) persistent.getClass.getName
+        else PersistentRepr.Undefined
+    }
+
     val timestamp = time.toInstant(ZoneOffset.UTC).toEpochMilli
 
     val bs = preparedWriteMessage.bind()
@@ -143,14 +154,6 @@ abstract class AbstractEventsByTagSpec(override val systemName: String, config: 
     tags.foreach { tag =>
       val tagId = writePluginConfig.tags.getOrElse(tag, 1)
       bs.setString("tag" + tagId, tag)
-    }
-    val serializer = serialization.findSerializerFor(persistent)
-    val serManifest = serializer match {
-      case ser2: SerializerWithStringManifest ⇒
-        ser2.manifest(persistent)
-      case _ ⇒
-        if (serializer.includeManifest) persistent.getClass.getName
-        else PersistentRepr.Undefined
     }
     bs.setInt("ser_id", serializer.identifier)
     bs.setString("ser_manifest", serManifest)
@@ -318,12 +321,12 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val src = queries.currentEventsByTag(tag = "T1", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(2)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
       probe.expectNoMsg(500.millis)
       probe.request(5)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, `pr3`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, `pr4`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "e3") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "e4") => e }
       probe.expectComplete()
     }
   }
@@ -411,8 +414,8 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val src = queries.eventsByTag(tag = "T1", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
 
       val t3 = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(5)
       val pr3 = PersistentRepr("e3", 3L, "p1", "", writerUuid = w1)
@@ -421,16 +424,8 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val pr4 = PersistentRepr("e4", 4L, "p1", "", writerUuid = w1)
       writeTestEvent(t4, pr4, Set("T1"))
 
-      probe.expectNextPF {
-        case e @ EventEnvelope(_, "p1", 3L, _pr3) =>
-          _pr3 shouldBe a[PersistentRepr]
-          _pr3.asInstanceOf[PersistentRepr].payload shouldBe "e3"
-      }
-      probe.expectNextPF {
-        case e @ EventEnvelope(_, "p1", 4L, _pr4) =>
-          _pr4 shouldBe a[PersistentRepr]
-          _pr4.asInstanceOf[PersistentRepr].payload shouldBe "e4"
-      }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "e3") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "e4") => e }
       probe.cancel()
     }
 
@@ -455,9 +450,9 @@ class EventsByTagSpec extends AbstractEventsByTagSpec("EventsByTagSpec", EventsB
       val pr2 = PersistentRepr("p2-e1", 1L, "p2", "", writerUuid = w2)
       writeTestEvent(t2, pr2, Set("T2"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, `pr2`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr3`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "p1-e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, "p2-e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "p1-e2") => e }
       probe.cancel()
     }
 
@@ -558,16 +553,16 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T3", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
       probe.expectNoMsg(500.millis)
 
       val t3 = t1.plusSeconds(2)
       val pr3 = PersistentRepr("e3", 3L, "p1", "", writerUuid = w1)
       writeTestEvent(t3, pr3, Set("T3"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, `pr3`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, `pr4`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "e3") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "e4") => e }
       probe.cancel()
     }
 
@@ -588,8 +583,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T4", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "e2") => e }
       probe.expectNoMsg(1.seconds)
       probe.expectError().getClass should be(classOf[IllegalStateException])
     }
@@ -616,10 +611,10 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T5", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr2`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, `pr3`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 2L, `pr4`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "p1-e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "p1-e2") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, "p2-e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 2L, "p2-e2") => e }
 
       // too early p1-e4
       val t5 = t1.plusSeconds(5)
@@ -632,13 +627,13 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val pr6 = PersistentRepr("p1-e3", 3L, "p1", "", writerUuid = w1)
       writeTestEvent(t6, pr6, Set("T5"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, `pr6`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, `pr5`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 3L, "p1-e3") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 4L, "p1-e4") => e }
 
       val t7 = t1.plusSeconds(7)
       val pr7 = PersistentRepr("p2-e3", 3L, "p2", "", writerUuid = w2)
       writeTestEvent(t7, pr7, Set("T5"))
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 3L, `pr7`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 3L, "p2-e3") => e }
 
       probe.cancel()
     }
@@ -657,15 +652,15 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T6", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, `pr1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, `pr2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 1L, "p1-e1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p2", 1L, "p2-e1") => e }
 
       // delayed, and timestamp is before p2-e1
       val t3 = t1.plusSeconds(1)
       val pr3 = PersistentRepr("p1-e2", 2L, "p1", "", writerUuid = w1)
       writeTestEvent(t3, pr3, Set("T6"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, `pr3`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "p1", 2L, "p1-e2") => e }
 
       probe.cancel()
     }
@@ -682,7 +677,7 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T7", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, `eventA1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, "A1") => e }
 
       // delayed, timestamp is before A1
       val eventB1 = PersistentRepr("B1", 1L, "b", "", writerUuid = w2)
@@ -691,8 +686,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB2 = PersistentRepr("B2", 2L, "b", "", writerUuid = w2)
       writeTestEvent(t3, eventB2, Set("T7"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, `eventB1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, "B1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B2") => e }
 
       probe.cancel()
     }
@@ -712,8 +707,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src = queries.eventsByTag(tag = "T8", offset = NoOffset)
       val probe = src.runWith(TestSink.probe[Any])
       probe.request(10)
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, `eventB0`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, `eventA1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, "B0") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "a", 1L, "A1") => e }
 
       // delayed, timestamp is before A1
       val eventB1 = PersistentRepr("B1", 2L, "b", "", writerUuid = w2)
@@ -722,8 +717,8 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB2 = PersistentRepr("B2", 3L, "b", "", writerUuid = w2)
       writeTestEvent(t3, eventB2, Set("T8"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB1`) => e }
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 3L, `eventB2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B1") => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 3L, "B2") => e }
 
       probe.cancel()
     }
@@ -739,7 +734,7 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val src1 = queries.eventsByTag(tag = "T9", offset = NoOffset)
       val probe1 = src1.runWith(TestSink.probe[Any])
       probe1.request(10)
-      val offs = probe1.expectNextPF { case e @ EventEnvelope(_, "a", 1L, `eventA1`) => e }.offset.asInstanceOf[TimeBasedUUID]
+      val offs = probe1.expectNextPF { case e @ EventEnvelope(_, "a", 1L, "A1") => e }.offset.asInstanceOf[TimeBasedUUID]
       probe1.cancel()
 
       // start a new query from the offset
@@ -753,7 +748,7 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB2 = PersistentRepr("B2", 2L, "b", "", writerUuid = w2)
       writeTestEvent(t1.plusSeconds(3), eventB2, Set("T9"))
 
-      probe2.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB2`) => e }
+      probe2.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B2") => e }
 
       probe2.cancel()
     }
@@ -784,12 +779,12 @@ class EventsByTagStrictBySeqNoSpec extends AbstractEventsByTagSpec("EventsByTagS
       val eventB1 = PersistentRepr("B1", 1L, "b", "", writerUuid = w2)
       writeTestEvent(t2.minus(100, ChronoUnit.MILLIS), eventB1, Set("T10"))
 
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, `eventB1`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 1L, "B1") => e }
       probe.expectNoMsg(2.second)
 
       val eventB2 = PersistentRepr("B2", 2L, "b", "", writerUuid = w2)
       writeTestEvent(t2.plusSeconds(1), eventB2, Set("T10"))
-      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, `eventB2`) => e }
+      probe.expectNextPF { case e @ EventEnvelope(_, "b", 2L, "B2") => e }
 
       probe.cancel()
     }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -127,7 +127,7 @@ abstract class AbstractEventsByTagSpec(override val systemName: String, config: 
     val writeStatements: CassandraStatements = new CassandraStatements {
       def config: CassandraJournalConfig = writePluginConfig
     }
-    session.prepare(writeStatements.writeMessage_threeTags)
+    session.prepare(writeStatements.writeMessage)
   }
 
   def writeTestEvent(time: LocalDateTime, persistent: PersistentRepr, tags: Set[String]): Unit = {

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -29,6 +29,7 @@ object CassandraSnapshotStoreConfiguration {
   lazy val protocolV3Config = ConfigFactory.parseString(
     s"""
       cassandra-journal.protocol-version = 3
+      cassandra-journal.enable-events-by-tag-query = off
       cassandra-journal.keyspace=CassandraSnapshotStoreProtocolV3Spec
       cassandra-snapshot-store.keyspace=CassandraSnapshotStoreProtocolV3Spec
     """

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -78,8 +78,8 @@ class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(CassandraSnapshotStor
       val expected = probe.expectMsgPF() { case LoadSnapshotResult(Some(snapshot), _) => snapshot }
 
       // write two more snapshots that cannot be de-serialized.
-      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")), null)
-      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")), null)
+      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")))
+      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")))
 
       // load most recent snapshot, first two attempts will fail ...
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), probe.ref)
@@ -97,9 +97,9 @@ class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(CassandraSnapshotStor
       probe.expectMsgPF() { case LoadSnapshotResult(Some(snapshot), _) => snapshot }
 
       // write three more snapshots that cannot be de-serialized.
-      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")), null)
-      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")), null)
-      session.execute(writeSnapshot, pid, 19L: JLong, 125L: JLong, serId, "", ByteBuffer.wrap("fail-3".getBytes("UTF-8")), null)
+      session.execute(writeSnapshot, pid, 17L: JLong, 123L: JLong, serId, "", ByteBuffer.wrap("fail-1".getBytes("UTF-8")))
+      session.execute(writeSnapshot, pid, 18L: JLong, 124L: JLong, serId, "", ByteBuffer.wrap("fail-2".getBytes("UTF-8")))
+      session.execute(writeSnapshot, pid, 19L: JLong, 125L: JLong, serId, "", ByteBuffer.wrap("fail-3".getBytes("UTF-8")))
 
       // load most recent snapshot, first three attempts will fail ...
       snapshotStore.tell(LoadSnapshot(pid, SnapshotSelectionCriteria.Latest, Long.MaxValue), probe.ref)


### PR DESCRIPTION
According to the [docs](http://docs.datastax.com/en/developer/java-driver/3.2/manual/native_protocol/#compatibility-matrix), cassandra 2.1.x and early don't support protocol v4. This means that collumns `message`, `tag1..3` and `snapshot` will be explicitly set to null, thus creating tombstones. 

A workaround is to use different prepared statements, each of them excluding the column that would otherwise be set to null. This adds some complexity to the code, but it does not create the extra tombstones. 

This change is intended to help projects that generate a lot of events and that can't (easily) upgrade cassandra to >= 2.2.x.

Note: see [original PR](https://github.com/akka/akka-persistence-cassandra/pull/205)