### PR TITLE
update Cassandra driver version

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import sbtassembly.AssemblyPlugin.autoImport._
 val AkkaVersion = "2.5.1"
 
 val akkaPersistenceCassandraDependencies = Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.1.4",
+  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.2.0",
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
   "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query"              % AkkaVersion,


### PR DESCRIPTION
Version 3.2.0 of the driver uses a much more up-to-date version of Guava (19, but can be used with versions through at least 21).  Since Guava classes are used in the public interface of the Datastax Cassandra driver, users of the akka-persistence-cassandra library are forced to use an older version (17, max).