### PR TITLE
minor reference.conf doc improvement

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -546,7 +546,7 @@ cassandra-query-journal {
   speculative-executions-delay = 1s
 
   # Configure this to the day (yyyyMMdd) when the system was first started.
-  # When offset 0L is used it will look for events from this day and forward.
+  # When NoOffset is used it will look for events from this day and forward.
   first-time-bucket = "20151120"
 
   # The returned event stream is ordered by the offset (timestamp), which corresponds


### PR DESCRIPTION
I believe that this property is used when the user doesn't provide an Offset. 
Because offsets in cassandra is time based we need a point in time to start the query.