### PR TITLE
fix mightBeMore condition in EventsByTagFetcher, #237

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagFetcher.scala
@@ -105,7 +105,10 @@ import akka.annotation.InternalApi
   }
 
   private def replayDone(): Unit = {
-    replyTo ! ReplayDone(retrievedCount, deliveredCount, seqNumbers, highestOffset, retrievedCount >= selectLimit)
+    // Note that we use different selectLimit depending on if it's a backtracking query or not,
+    // but replayDone may be triggered earlier than selectLimit if deliveredCount == limit.
+    val mightBeMore = retrievedCount >= math.min(selectLimit, limit)
+    replyTo ! ReplayDone(retrievedCount, deliveredCount, seqNumbers, highestOffset, mightBeMore)
     context.stop(self)
   }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -1392,6 +1392,33 @@ class EventsByTagStrictBySeqMemoryIssueSpec
 
       probe.cancel()
     }
+
+    "find all events" in {
+      val t1 = LocalDateTime.now(ZoneOffset.UTC).minusMinutes(5).minusDays(5)
+      val w1 = UUID.randomUUID().toString
+
+      // max-buffer-size = 50
+      // start at seqNr 1 here to trigger the backtracking mode
+      (101L to 430L).foreach { n =>
+        val eventA = PersistentRepr(s"B$n", n, "b", "", writerUuid = w1)
+        val t = t1.plus(n, ChronoUnit.MILLIS)
+        writeTestEvent(t, eventA, Set("T15"))
+      }
+
+      val src = queries.currentEventsByTag(tag = "T15", offset = NoOffset)
+      val probe = src.runWith(TestSink.probe[Any])
+
+      (1 to 10).foreach { _ =>
+        probe.request(30)
+        probe.expectNextN(30)
+        // reduce downstream demand, which will result in limit < maxBufferSize
+        probe.expectNoMsg(100.millis)
+      }
+
+      probe.request(100)
+      probe.expectNextN(30)
+      probe.expectComplete
+    }
   }
 }
 


### PR DESCRIPTION
* it's using different select limit depending on if it's a backtracking query or not,
  but the ReplayDone might still be triggered earlier because events are delivered
  (not many duplicates) and reaching the limit even though the select limit is higher
* this caused wrong mightBeMore flag and moving to next bucket too early