### PR TITLE
eventual consistency for events by persistence id

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -544,6 +544,12 @@ cassandra-query-journal {
   # this can be relaxed by setting this property to off.
   gap-free-sequence-numbers = on
 
+
+  # When using LQ writing in one DC and querying in another, the events for an entity may
+  # appear in the querying DC out of order, when that happens, try for this amount of
+  # time to find the in-order sequence number before failing the stream
+  events-by-persistence-id-gap-timeout = 10s
+
   # How many events to fetch in one query (replay) and keep buffered until they
   # are delivered downstreams.
   max-buffer-size = 500

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -40,4 +40,6 @@ import akka.annotation.InternalApi
   val table: String = writePluginConfig.table
   val pubsubMinimumInterval: Duration = writePluginConfig.pubsubMinimumInterval
 
+  val eventsByPersistenceIdEventTimeout: FiniteDuration =
+    config.getDuration("events-by-persistence-id-gap-timeout", MILLISECONDS).millis
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -252,16 +252,18 @@ import com.datastax.driver.core.utils.Bytes
       }
 
       override protected def onTimer(timerKey: Any): Unit = timerKey match {
-        case Continue if lookingForMissingSeqNr.isDefined => // regular ticks disabled when looking for missing seqNr
-        case Continue                                     => continue()
-        case LookForMissingSeqNr                          => lookForMissingSeqNr()
+        case Continue            => continue()
+        case LookForMissingSeqNr => lookForMissingSeqNr()
       }
 
       def continue(): Unit = {
-        queryState match {
-          case QueryIdle          => query(switchPartition = false)
-          case _: QueryResult     => tryPushOne()
-          case _: QueryInProgress => // result will come
+        // regular continue-by-tick disabled when looking for missing seqNr
+        if (lookingForMissingSeqNr.isEmpty) {
+          queryState match {
+            case QueryIdle          => query(switchPartition = false)
+            case _: QueryResult     => tryPushOne()
+            case _: QueryInProgress => // result will come
+          }
         }
       }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -6,7 +6,6 @@ package akka.persistence.cassandra.query
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.persistence.cassandra.CassandraLifecycle
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
-import akka.persistence.cassandra.testkit.CassandraLauncher
 import akka.persistence.query.PersistenceQuery
 import akka.stream.{ ActorMaterializer, KillSwitches }
 import akka.testkit.{ ImplicitSender, TestKit }
@@ -18,7 +17,7 @@ import scala.concurrent.duration._
 import akka.stream.testkit.scaladsl.TestSink
 import akka.persistence.query.Offset
 import akka.persistence.DeleteMessagesSuccess
-import akka.persistence.cassandra.journal.{ CassandraJournalConfig, CassandraStatements }
+import akka.persistence.cassandra.journal.CassandraJournalConfig
 
 import scala.concurrent.Await
 import akka.persistence.cassandra.journal.CassandraStatements
@@ -330,7 +329,7 @@ class EventsByPersistenceIdSpec
         .request(10)
 
       // timeout dictated by events-by-persistence-id-gap-timeout above
-      within(5.seconds) {
+      probe.within(7.seconds) {
         probe.expectNextOrError() match {
           case Right("e1") =>
             probe.expectNextOrError() match {


### PR DESCRIPTION
Refs #260 

Depends on the mat-view rework to build green etc. Tests pass locally with embedded Cassandra.