### PR TITLE
allow tables-autocreate=on without adding meta columns, #269

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Persistence Query usage example to obtain a stream with all events tagged with "
 Migrations
 ----------
 
-### Migrations from 0.54 to 0.55
+### Migrations from 0.54 to 0.59
 
 In version 0.55 additional columns were added to be able to store meta data about an event without altering
 the actual domain event.
@@ -101,12 +101,14 @@ These columns are used when the event is wrapped in `akka.persistence.cassandra.
 
 It is also not required to add the materialized views, not even if the meta data is stored in the journal table. If the materialized view is not changed the plain events are retrieved with the `eventsByTag` query and they are not wrapped in `EventWithMetaData`. Note that Cassandra [does not support](http://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlAlterMaterializedView.html) adding columns to an existing materialized view.
 
-
-If you see exception "Undefined column name meta_ser_id" it is because Cassandra validates the ["CREATE MATERIALIZED VIEW IF NOT EXISTS"](https://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlCreateMaterializedView.html#cqlCreateMaterializedView__if-not-exists) even though the view already exists and will not be created. To work around that issue you can disable the `tables-autocreate`:
+If you don't alter existing messages table and still use `tables-autocreate=on` you have to set config:
 
 ```
-cassandra-journal.tables-autocreate = off
+cassandra-journal.meta-in-events-by-tag-view = off
 ``` 
+
+When trying to create the materialized view (tables-autocreate=on) with the meta columns before corresponding columns have been added the messages table an exception "Undefined column name meta_ser_id" is raised, because Cassandra validates the ["CREATE MATERIALIZED VIEW IF NOT EXISTS"](https://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlCreateMaterializedView.html#cqlCreateMaterializedView__if-not-exists) even though the view already exists and will not be created. To work around that issue you can disable the meta columns in the materialized view by setting `meta-in-events-by-tag-view=off`.
+
 
 ### Migrations from 0.51 to 0.52
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -162,6 +162,15 @@ cassandra-journal {
   # Name of the materialized view for eventsByTag query
   events-by-tag-view = "eventsbytag"
 
+  # meta columns were added in version 0.55. If you don't alter existing messages table and still
+  # use `tables-autocreate=on` you have to set this property to off.
+  # When trying to create the materialized view with the meta columns before corresponding columns
+  # have been added the messages table an exception "Undefined column name meta_ser_id" is raised,
+  # because Cassandra validates the "CREATE MATERIALIZED VIEW IF NOT EXISTS"
+  # even though the view already exists and will not be created. To work around that issue you can disable the
+  # meta data columns in the materialized view by setting this property to off.
+  meta-in-events-by-tag-view = on
+
   # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
   replication-strategy = "SimpleStrategy"
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -20,6 +20,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config) extends Cassan
   val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
   val enableEventsByTagQuery: Boolean = !cassandra2xCompat && config.getBoolean("enable-events-by-tag-query")
   val eventsByTagView: String = config.getString("events-by-tag-view")
+  val metaInEventsByTagView: Boolean = config.getBoolean("meta-in-events-by-tag-view")
   val queryPlugin = config.getString("query-plugin")
   val pubsubMinimumInterval: Duration = {
     val key = "pubsub-minimum-interval"

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -64,7 +64,7 @@ trait CassandraStatements {
   def createEventsByTagMaterializedView(tagId: Int) = s"""
       CREATE MATERIALIZED VIEW IF NOT EXISTS $eventsByTagViewName$tagId AS
          SELECT tag$tagId, timebucket, timestamp, persistence_id, partition_nr, sequence_nr, writer_uuid, ser_id, ser_manifest, event_manifest, event,
-           meta_ser_id, meta_ser_manifest, meta, message
+           ${if (config.metaInEventsByTagView) "meta_ser_id, meta_ser_manifest, meta, " else ""} message
          FROM $tableName
          WHERE persistence_id IS NOT NULL AND partition_nr IS NOT NULL AND sequence_nr IS NOT NULL
            AND tag$tagId IS NOT NULL AND timestamp IS NOT NULL AND timebucket IS NOT NULL


### PR DESCRIPTION
Refs #269

@ignasi35 This means that you can set `cassandra-journal.meta-in-events-by-tag-view = off` in lagom reference overrides.

cc @TimMoore