### PR TITLE
Abort missing sequence nr search if fast forward is for after it

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/TimeBucket.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TimeBucket.scala
@@ -55,7 +55,6 @@ import com.datastax.driver.core.utils.UUIDs
     key < other.key
   }
 
-
   override def equals(other: Any): Boolean = other match {
     case that: TimeBucket =>
       key == that.key &&

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -304,8 +304,10 @@ import com.datastax.driver.core.utils.UUIDs
           push(out, repr)
           false
         } else {
-          log.info("{}: Missing event for new persistence id: {}. Expected sequence nr: {}, actual: {}.",
-            session.tag, repr.persistentRepr.persistenceId, expectedSequenceNr, repr.tagPidSequenceNr)
+          log.info(
+            "{}: Missing event for new persistence id: {}. Expected sequence nr: {}, actual: {}.",
+            session.tag, repr.persistentRepr.persistenceId, expectedSequenceNr, repr.tagPidSequenceNr
+          )
           val previousBucketStart = UUIDs.startOf(currTimeBucket.previous(1).key)
           val startingOffset: UUID = if (UUIDComparator.comparator.compare(previousBucketStart, fromOffset) < 0) {
             log.debug("Starting at fromOffset")

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -84,7 +84,7 @@ class EventsByPersistenceIdSpec
     }
 
     "not see any events if the stream starts after current latest event" in {
-      val ref = setup("c", 3)
+      setup("c", 3)
       val src = queries.currentEventsByPersistenceId("c", 5L, Long.MaxValue)
       src.map(_.event).runWith(TestSink.probe[Any])
         .request(5)
@@ -92,7 +92,7 @@ class EventsByPersistenceIdSpec
     }
 
     "find existing events up to a sequence number" in {
-      val ref = setup("d", 3)
+      setup("d", 3)
       val src = queries.currentEventsByPersistenceId("d", 0L, 2L)
       src.map(_.sequenceNr).runWith(TestSink.probe[Any])
         .request(5)
@@ -120,7 +120,7 @@ class EventsByPersistenceIdSpec
     }
 
     "only deliver what requested if there is more in the buffer" in {
-      val ref = setup("f", 1000)
+      setup("f", 1000)
 
       val src = queries.currentEventsByPersistenceId("f", 0L, Long.MaxValue)
       val probe = src.map(_.event).runWith(TestSink.probe[Any])
@@ -149,7 +149,7 @@ class EventsByPersistenceIdSpec
     }
 
     "produce correct sequence of sequence numbers and offsets" in {
-      val ref = setup("h", 3)
+      setup("h", 3)
 
       val src = queries.currentEventsByPersistenceId("h", 0L, Long.MaxValue)
       src.map(x => (x.persistenceId, x.sequenceNr, x.offset)).runWith(TestSink.probe[Any])
@@ -163,7 +163,7 @@ class EventsByPersistenceIdSpec
     }
 
     "produce correct sequence of events across multiple partitions" in {
-      val ref = setup("i", 20)
+      setup("i", 20)
 
       val src = queries.currentEventsByPersistenceId("i", 0L, Long.MaxValue)
       src.map(_.event).runWith(TestSink.probe[Any])
@@ -216,7 +216,7 @@ class EventsByPersistenceIdSpec
     }
 
     "stop at last event in partition" in {
-      val ref = setup("i2", 15) // partition size is 15
+      setup("i2", 15) // partition size is 15
 
       val src = queries.currentEventsByPersistenceId("i2", 0L, Long.MaxValue)
       src.map(_.event).runWith(TestSink.probe[Any])
@@ -365,7 +365,7 @@ class EventsByPersistenceIdSpec
     }
 
     "only deliver what requested if there is more in the buffer" in {
-      val ref = setup("n", 1000)
+      setup("n", 1000)
 
       val src = queries.eventsByPersistenceId("n", 0L, Long.MaxValue)
       val probe = src.map(_.event).runWith(TestSink.probe[Any])
@@ -388,7 +388,7 @@ class EventsByPersistenceIdSpec
     }
 
     "not produce anything if there aren't any events" in {
-      val ref = setup("o2", 1) // Database init.
+      setup("o2", 1) // Database init.
       val src = queries.eventsByPersistenceId("o", 0L, Long.MaxValue)
 
       val probe = src.map(_.event).runWith(TestSink.probe[Any])
@@ -399,7 +399,7 @@ class EventsByPersistenceIdSpec
     }
 
     "not produce anything until there are existing events" in {
-      val ref = setup("p2", 1) // Database init.
+      setup("p2", 1) // Database init.
       val src = queries.eventsByPersistenceId("p", 0L, Long.MaxValue)
 
       val probe = src.map(_.event).runWith(TestSink.probe[Any])


### PR DESCRIPTION
If a fast forward happens while a query is in progress and it means
the missing sequence nr isn't required don't keep looking for it

Refs #272