### PR TITLE
Flush all tag writers after migration has finished

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -4,37 +4,104 @@
 
 package akka.persistence.cassandra.journal
 
-import akka.Done
-import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
-import akka.annotation.InternalApi
-import akka.persistence.cassandra.journal.TagWriter.{ SetTagProgress, TagWrite, TagWriterSession, TagWriterSettings }
-import akka.persistence.cassandra.journal.TagWriters.{ BulkTagWrite, TagWritersSession }
-import com.datastax.driver.core.{ PreparedStatement, ResultSet, Statement }
+import java.lang.{ Integer => JInt, Long => JLong }
+import java.util.UUID
 
-import scala.concurrent.Future
+import akka.Done
+import akka.pattern.ask
+import akka.pattern.pipe
+import akka.actor.{ Actor, ActorLogging, ActorRef, ActorRefFactory, Props }
+import akka.annotation.InternalApi
+import akka.persistence.cassandra.journal.CassandraJournal.{ Serialized, Tag }
+import akka.persistence.cassandra.journal.TagWriter._
+import akka.persistence.cassandra.journal.TagWriters._
+import akka.util.Timeout
+import com.datastax.driver.core.{ BatchStatement, PreparedStatement, ResultSet, Statement }
+
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.concurrent.duration._
 
 @InternalApi private[akka] object TagWriters {
 
-  case class TagWritersSession(
+  private[akka] case class TagWritersSession(
     tagWritePs:         Future[PreparedStatement],
     tagWriteWithMetaPs: Future[PreparedStatement],
     executeStatement:   Statement => Future[Done],
     selectStatement:    Statement => Future[ResultSet],
     tagProgressPs:      Future[PreparedStatement]
-  )
+  ) {
+
+    def writeBatch(tag: Tag, events: Seq[(Serialized, Long)])(implicit ec: ExecutionContext): Future[Done] = {
+      val batch = new BatchStatement(BatchStatement.Type.UNLOGGED)
+      val tagWritePSs = for {
+        withMeta <- tagWriteWithMetaPs
+        withoutMeta <- tagWritePs
+      } yield (withMeta, withoutMeta)
+
+      tagWritePSs.map {
+        case (withMeta, withoutMeta) =>
+          events.foreach {
+            case (event, pidTagSequenceNr) => {
+              val ps = if (event.meta.isDefined) withMeta else withoutMeta
+              val bound = ps.bind(
+                tag,
+                event.timeBucket.key: JLong,
+                event.timeUuid,
+                pidTagSequenceNr: JLong,
+                event.serialized,
+                event.eventAdapterManifest,
+                event.persistenceId,
+                event.sequenceNr: JLong,
+                event.serId: JInt,
+                event.serManifest,
+                event.writerUuid
+              )
+              event.meta.foreach { m =>
+                bound.setBytes("meta", m.serialized)
+                bound.setString("meta_ser_manifest", m.serManifest)
+                bound.setInt("meta_ser_id", m.serId)
+              }
+              batch.add(bound)
+            }
+          }
+          batch
+      }.flatMap(executeStatement)
+    }
+
+    def writeProgress(tag: Tag, persistenceId: String, seqNr: Long, tagPidSequenceNr: Long, offset: UUID)(implicit ec: ExecutionContext): Future[Done] = {
+      tagProgressPs.map(ps =>
+        ps.bind(persistenceId, tag, seqNr: JLong, tagPidSequenceNr: JLong, offset)).flatMap(executeStatement)
+    }
+
+  }
 
   private[akka] case class BulkTagWrite(tagWrites: Vector[TagWrite])
 
-  def props(session: TagWritersSession, tagWriterSettings: TagWriterSettings): Props =
-    Props(new TagWriters(session, tagWriterSettings))
+  def props(tagWriterCreator: (ActorRefFactory, Tag) => ActorRef): Props =
+    Props(new TagWriters(tagWriterCreator))
+
+  case class TagFlush(tag: String)
+  case object FlushAllTagWriters
+  case object AllFlushed
 }
 
-@InternalApi private[akka] class TagWriters(session: TagWritersSession, tagWriterSettings: TagWriterSettings) extends Actor
-  with ActorLogging {
+@InternalApi private[akka] class TagWriters(tagWriterCreator: (ActorRefFactory, Tag) => ActorRef)
+  extends Actor with ActorLogging {
+
+  import context._
 
   private var tagActors = Map.empty[String, ActorRef]
 
   def receive: Receive = {
+    case FlushAllTagWriters =>
+      log.debug("Flushing all tag writers")
+      // will include a C* write so be patient
+      implicit val timeout = Timeout(10.seconds)
+      val replyTo = sender()
+      val flushes = tagActors.map { case (_, ref) => (ref ? Flush).mapTo[Flushed.type] }
+      Future.sequence(flushes).map(_ => AllFlushed) pipeTo replyTo
+    case twf: TagFlush =>
+      tagActor(twf.tag).tell(Flush, sender())
     case tw: TagWrite =>
       tagActor(tw.tag) forward tw
     case BulkTagWrite(tws) =>
@@ -44,23 +111,13 @@ import scala.concurrent.Future
     case p: SetTagProgress =>
       tagActor(p.tag) forward p
     case akka.actor.Status.Failure(_) =>
-      log.debug("Failed tow write to Cassandra so will not do TagWrites")
+      log.debug("Failed to write to Cassandra so will not do TagWrites")
   }
 
   protected def tagActor(tag: String): ActorRef =
     tagActors.get(tag) match {
       case None =>
-        val tagSession = new TagWriterSession(
-          tag,
-          session.tagWritePs,
-          session.tagWriteWithMetaPs,
-          session.executeStatement,
-          session.selectStatement,
-          session.tagProgressPs
-        )
-        val ref = context.actorOf(
-          TagWriter.props(tagSession, tag, tagWriterSettings), s"tag-writer-$tag"
-        )
+        val ref = tagWriterCreator(context, tag)
         tagActors += (tag -> ref)
         ref
       case Some(ar) => ar

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -399,8 +399,10 @@ import scala.util.{ Failure, Success, Try }
             else if (rs.isExhausted) {
               (lookingForMissingSeqNr, pendingFastForward) match {
                 case (Some(MissingSeqNr(_, sawSeqNr)), Some(fastForwardTo)) if fastForwardTo >= sawSeqNr =>
-                  log.debug("Aborting missing sequence search: {} nr due to fast forward to next sequence nr: {}",
-                    lookingForMissingSeqNr, fastForwardTo)
+                  log.debug(
+                    "Aborting missing sequence search: {} nr due to fast forward to next sequence nr: {}",
+                    lookingForMissingSeqNr, fastForwardTo
+                  )
                   internalFastForward(fastForwardTo)
                   pendingFastForward = None
                   lookingForMissingSeqNr = None

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -101,7 +101,7 @@ object EventsByTagMigrationSpec {
 
 class EventsByTagMigrationProvidePersistenceIds extends AbstractEventsByTagMigrationSpec {
 
-  implicit val patience = PatienceConfig(timeout = Span(10, Seconds), interval = Span(500, Milliseconds))
+  implicit val patience = PatienceConfig(timeout = Span(45, Seconds), interval = Span(500, Milliseconds))
 
   "Partial events by tag migration" must {
     val pidOne = "pOne"

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import akka.actor.ActorSystem
+import akka.persistence.cassandra.journal.TagWriter._
+import akka.persistence.cassandra.journal.TagWriters.{ AllFlushed, FlushAllTagWriters, TagFlush }
+import akka.testkit.{ ImplicitSender, TestKit, TestProbe }
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
+
+import scala.concurrent.duration._
+
+class TagWritersSpec extends TestKit(ActorSystem("TagWriterSpec"))
+  with WordSpecLike
+  with BeforeAndAfterAll
+  with ImplicitSender
+  with Matchers {
+
+  "Tag writers" must {
+    "forward flush requests" in {
+      val probe = TestProbe()
+      val tagWriters = system.actorOf(TagWriters.props((_, tag) => {
+        tag shouldEqual "blue"
+        probe.ref
+      }))
+
+      tagWriters ! TagFlush("blue")
+      probe.expectMsg(Flush)
+      probe.reply(Flushed)
+      expectMsg(Flushed) // should be forwarded
+    }
+
+    "flush all tag writers" in {
+      val probe = TestProbe()
+      val tagWriters = system.actorOf(TagWriters.props((_, tag) => probe.ref))
+
+      // do something to make it create a couple
+      val tp = TagProgress("p", 1, 1)
+      tagWriters ! SetTagProgress("blue", tp)
+      probe.expectMsg(SetTagProgress("blue", tp))
+      tagWriters ! SetTagProgress("red", tp)
+      probe.expectMsg(SetTagProgress("red", tp))
+
+      tagWriters ! FlushAllTagWriters
+      probe.expectMsg(Flush)
+      probe.reply(Flushed)
+      expectNoMessage(100.millis)
+      probe.expectMsg(Flush)
+      probe.reply(Flushed)
+      expectMsg(AllFlushed)
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    shutdown()
+  }
+}


### PR DESCRIPTION
Also removes the TagWriterSession as it was mainly duplicated
in the TagWritersSession.