### PR TITLE
Increase gap timeout to 3s due to waitForNoMessages adding up

### DIFF
--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -53,7 +53,7 @@ object EventsByTagStageSpec {
        |   log-queries = on
        |   refresh-interval = 200ms
        |   events-by-tag {
-       |     gap-timeout = 2s
+       |     gap-timeout = 3s
        |   }
        | }
     """.stripMargin


### PR DESCRIPTION
This was recently reduced from the default of 10s but 2s was a little
ambitious

Refs https://github.com/akka/akka-persistence-cassandra/issues/282