### PR TITLE
Journal should call mapEvent for eventsByPersistenceId

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -58,7 +58,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
             extractor = Extractors.taggedPersistentRepr
           ).map(sendMissingTagWrite(tp, tagWrites))
       })
-    ).map(_.pr)
+    ).map(te => queries.mapEvent(te.pr))
       .runForeach(replayCallback)
       .map(_ => ())
   }

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -429,7 +429,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       extractor = Extractors.taggedPersistentRepr
     )
       .mapMaterializedValue(_ => NotUsed)
-      .map(_.pr)
+      .map(te => mapEvent(te.pr))
       .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**
@@ -453,7 +453,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       extractor = Extractors.taggedPersistentRepr
     )
       .mapMaterializedValue(_ => NotUsed)
-      .map(_.pr)
+      .map(te => mapEvent(te.pr))
       .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**
@@ -474,7 +474,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       refreshInterval.orElse(Some(queryPluginConfig.refreshInterval)),
       s"eventsByPersistenceId-$persistenceId",
       extractor = Extractors.taggedPersistentRepr
-    ).map(_.pr)
+    ).map(te => mapEvent(te.pr))
       .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**

--- a/core/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalOverrideSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalOverrideSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.query
+
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.persistence.PersistentRepr
+import akka.persistence.cassandra.TestTaggingActor.Ack
+import akka.persistence.cassandra.{ CassandraLifecycle, TestTaggingActor }
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.query.{ PersistenceQuery, ReadJournalProvider }
+import akka.stream.ActorMaterializer
+import akka.stream.testkit.scaladsl.TestSink
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.WordSpecLike
+import scala.concurrent.duration._
+
+class JournalOverride(as: ExtendedActorSystem, config: Config) extends CassandraReadJournal(as, config) {
+  override private[akka] def mapEvent(pr: PersistentRepr) =
+    PersistentRepr("cat", pr.sequenceNr, pr.persistenceId, pr.manifest, pr.deleted, pr.sender, pr.writerUuid)
+}
+
+class JournalOverrideProvider(as: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
+  override def scaladslReadJournal() = new JournalOverride(as, config)
+  override def javadslReadJournal() = null
+}
+
+object CassandraReadJournalOverrideSpec {
+
+  val config = ConfigFactory.parseString(
+    """
+      cassandra-query-journal {
+        class = "akka.persistence.cassandra.query.JournalOverrideProvider"
+      }
+    """.stripMargin
+  ).withFallback(CassandraLifecycle.config)
+
+}
+
+class CassandraReadJournalOverrideSpec extends TestKit(ActorSystem(
+  "CassandraReadJournalOverride",
+  CassandraReadJournalOverrideSpec.config
+))
+  with WordSpecLike
+  with ImplicitSender
+  with CassandraLifecycle {
+
+  override def systemName = "CassandraReadJournalOverride"
+  implicit val materialiser = ActorMaterializer()
+
+  lazy val journal =
+    PersistenceQuery(system).readJournalFor[JournalOverride](
+      CassandraReadJournal.Identifier
+    )
+
+  "Cassandra read journal override" must {
+    "map events" in {
+      val pid = "p1"
+      val p1 = system.actorOf(TestTaggingActor.props(pid))
+      p1 ! "not a cat"
+      expectMsg(Ack)
+
+      val currentEvents = journal.currentEventsByPersistenceId(pid, 0, Long.MaxValue)
+      val currentProbe = currentEvents.map(_.event.toString).runWith(TestSink.probe[String])
+      currentProbe.request(2)
+      currentProbe.expectNext("cat")
+      currentProbe.expectComplete()
+
+      val liveEvents = journal.eventsByPersistenceId(pid, 0, Long.MaxValue)
+      val liveProbe = liveEvents.map(_.event.toString).runWith(TestSink.probe[String])
+      liveProbe.request(2)
+      liveProbe.expectNext("cat")
+      liveProbe.expectNoMessage(100.millis)
+      liveProbe.cancel()
+
+      val internalEvents = journal.eventsByPersistenceIdWithControl(pid, 0, Long.MaxValue, None)
+      val internalProbe = internalEvents.map(_.event.toString).runWith(TestSink.probe[String])
+      internalProbe.request(2)
+      internalProbe.expectNext("cat")
+      liveProbe.expectNoMessage(100.millis)
+      liveProbe.cancel()
+    }
+  }
+}


### PR DESCRIPTION
This was a regression in 0.80-RC1. Added a test with a journal
that overrides mapEvent