### PR TITLE
Fixed typo in createMetatdataTable

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -476,12 +476,12 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
               metaSerId,
               metaSerManifest
             ) match {
-              case Success(m) => m
-              case Failure(_) =>
-                // don't fail replay/query because of deserialization problem with meta data
-                // see motivation in UnknownMetaData
-                UnknownMetaData(metaSerId, metaSerManifest)
-            }
+                case Success(m) => m
+                case Failure(_) =>
+                  // don't fail replay/query because of deserialization problem with meta data
+                  // see motivation in UnknownMetaData
+                  UnknownMetaData(metaSerId, metaSerManifest)
+              }
             EventWithMetaData(event, meta)
         }
       } else {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -89,7 +89,7 @@ trait CassandraStatements {
         PRIMARY KEY (persistence_id, tag))
        """
 
-  private[akka] def createMetatdataTable =
+  private[akka] def createMetadataTable =
     s"""
       CREATE TABLE IF NOT EXISTS $metadataTableName(
         persistence_id text PRIMARY KEY,
@@ -252,7 +252,7 @@ trait CassandraStatements {
         for {
           _ <- keyspace
           _ <- session.executeAsync(createTable)
-          _ <- session.executeAsync(createMetatdataTable)
+          _ <- session.executeAsync(createMetadataTable)
           _ <- session.executeAsync(createTagsTable)
           _ <- session.executeAsync(createTagsProgressTable)
           done <- session.executeAsync(createConfigTable).map(_ => Done)

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -321,12 +321,12 @@ private[snapshot] object CassandraSnapshotStore {
               metaSerId,
               metaSerManifest
             ) match {
-              case Success(m) => m
-              case Failure(_) =>
-                // don't fail query because of deserialization problem with meta data
-                // see motivation in UnknownMetaData
-                SnapshotWithMetaData.UnknownMetaData(metaSerId, metaSerManifest)
-            }
+                case Success(m) => m
+                case Failure(_) =>
+                  // don't fail query because of deserialization problem with meta data
+                  // see motivation in UnknownMetaData
+                  SnapshotWithMetaData.UnknownMetaData(metaSerId, metaSerManifest)
+              }
             SnapshotWithMetaData(payload, meta)
         }
       } else {


### PR DESCRIPTION
Small spelling error in createMetatdataTable and some spacing changes after running the build.

Did not follow the contributing guidelines completely, so sorry for that. Will do better next time.
As this was a small typo I did not correct my omissions.