### PR TITLE
EventsByTagMigration: Flush/backpressure every 1k rows

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -94,8 +94,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
   def preparedDeleteMessages = session.prepare(deleteMessages).map(_.setIdempotent(true))
   def preparedSelectMessages = session.prepare(selectMessages)
     .map(_.setConsistencyLevel(readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
-  def preparedCheckInUse = session.prepare(selectInUse)
-    .map(_.setConsistencyLevel(readConsistency).setIdempotent(true))
   def preparedWriteInUse = session.prepare(writeInUse).map(_.setIdempotent(true))
   def preparedSelectHighestSequenceNr = session.prepare(selectHighestSequenceNr)
     .map(_.setConsistencyLevel(readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
@@ -124,7 +122,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
       preparedWriteMessageWithMeta
       preparedDeleteMessages
       preparedSelectMessages
-      preparedCheckInUse
       preparedWriteInUse
       preparedSelectHighestSequenceNr
       preparedSelectDeletedTo

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -183,13 +183,6 @@ trait CassandraStatements {
         sequence_nr <= ?
     """
 
-  private[akka] def selectInUse =
-    s"""
-     SELECT used from ${tableName} WHERE
-      persistence_id = ? AND
-      partition_nr = ?
-   """
-
   private[akka] def selectConfig =
     s"""
       SELECT * FROM ${configTableName}

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -116,7 +116,7 @@ class EventsByTagMigrationProvidePersistenceIds extends AbstractEventsByTagMigra
       migrator.createTables()
       migrator.addTagsColumn()
 
-      migrator.migrateToTagViews(List(pidOne)).futureValue shouldEqual Done
+      migrator.migratePidsToTagViews(List(pidOne)).futureValue shouldEqual Done
 
       val blueSrc = queries.eventsByTag("blue", NoOffset)
       val blueProbe = blueSrc.runWith(TestSink.probe[Any])(materialiser)
@@ -126,7 +126,7 @@ class EventsByTagMigrationProvidePersistenceIds extends AbstractEventsByTagMigra
       blueProbe.expectNoMessage(waitTime)
       blueProbe.cancel()
 
-      migrator.migrateToTagViews(List(pidTwo)).futureValue shouldEqual Done
+      migrator.migratePidsToTagViews(List(pidTwo)).futureValue shouldEqual Done
 
       val blueSrcTakeTwo = queries.eventsByTag("blue", NoOffset)
       val blueProbeTakeTwo = blueSrcTakeTwo.runWith(TestSink.probe[Any])(materialiser)


### PR DESCRIPTION
It mistakingly only flushed at the end

Also remove unused query