### PR TITLE
Handle tag write recovery when there is a current snapshot

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
@@ -59,7 +59,8 @@ trait CassandraTagRecovery {
   }
 
   private[akka] def sendTagProgress(tp: Map[Tag, TagProgress], ref: ActorRef): Future[Done] = {
-    implicit val timeout = Timeout(1.second)
+    implicit val timeout = Timeout(10.second)
+    log.debug("Recovery sending tag progress: {}", tp)
     val progressSets = tp.map {
       case (tag, progress) => (ref ? SetTagProgress(tag, progress)).mapTo[TagWriter.SetTagProgressAck.type]
     }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -109,6 +109,7 @@ import scala.concurrent.duration._
         tagActor(tw.tag) forward tw
       })
     case p: SetTagProgress =>
+      log.debug("Forwarding tag progress {}", p)
       tagActor(p.tag) forward p
     case akka.actor.Status.Failure(_) =>
       log.debug("Failed to write to Cassandra so will not do TagWrites")

--- a/core/src/test/scala/akka/persistence/cassandra/TestTaggingActor.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/TestTaggingActor.scala
@@ -19,6 +19,7 @@ object TestTaggingActor {
 }
 
 class TestTaggingActor(val persistenceId: String, tags: Set[String], probe: Option[ActorRef]) extends PersistentActor with ActorLogging {
+
   def receiveRecover: Receive = {
     case RecoveryCompleted =>
       probe.foreach(_ ! RecoveryCompleted)


### PR DESCRIPTION
If the very last event was in the latest snapshot i.e. a snapshot on
shutdown then the replayMessages is never called as no replay
is required. This meant that tag writes progress was not sent to
the tag writers so they reset the tag pid sequence nr.