### PR TITLE
updates cassandra to resolve bug with jdk 1.8.0_161

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -110,7 +110,7 @@ lazy val cassandraBundle = (project in file("cassandra-bundle"))
     name := "akka-persistence-cassandra-bundle",
     crossPaths := false,
     autoScalaLibrary := false,
-    libraryDependencies += "org.apache.cassandra" % "cassandra-all" % "3.10" exclude("commons-logging", "commons-logging"),
+    libraryDependencies += "org.apache.cassandra" % "cassandra-all" % "3.11.2" exclude("commons-logging", "commons-logging"),
     target in assembly := target.value / "bundle" / "akka" / "persistence" / "cassandra" / "launcher",
     assemblyJarName in assembly := "cassandra-bundle.jar"
   )


### PR DESCRIPTION
This will need to be incorporated once cassandra releases the new version, which [should be soon](https://lists.apache.org/thread.html/39db379ff77b890f04ffacd7be31ce227837382b3e79155061fffd69@%3Cdev.cassandra.apache.org%3E).