### PR TITLE
Maintain low watermark seqNr as starting point for tag scanning, #333

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -171,6 +171,11 @@ cassandra-journal {
     # with respect to the PersistentActor's persist call. However, this will be very bad for throughput.
     flush-interval = 250ms
 
+    # Update the tag_scanning table with this interval. Shouldn't be done too often to
+    # avoid unecessary load. The tag_scanning table keeps track of a starting point for tag
+    # scanning during recovery of persistent actor.
+    scanning-flush-interval = 30s
+
     table = "tag_views"
     gc-grace-seconds = 864000
     compaction-strategy {

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -30,22 +30,21 @@ import scala.concurrent.duration._
 object EventsByTagMigration {
   def apply(system: ActorSystem): EventsByTagMigration = new EventsByTagMigration(system)
   // Extracts a Cassandra Row, assuming the pre 0.80 schema into a [[RawEvent]]
-  val RawPayloadOldTagSchema = (bucketSize: BucketSize, transportInformation: Option[Serialization.Information]) => (row: Row, _: EventDeserializer, serialization: Serialization) => {
+  val RawPayloadOldTagSchema = (bucketSize: BucketSize, transportInformation: Option[Serialization.Information]) => (row: Row, ed: EventDeserializer, serialization: Serialization) => {
     // Get the tags from the old location i.e. tag1, tag2, tag3
-    val tags: Set[String] = (1 to 3).foldLeft(Set.empty[String]) {
-      case (acc, i) =>
-        if (row.getColumnDefinitions.contains(s"tag$i")) {
-          val tag = row.getString(s"tag$i")
-          if (tag != null) acc + tag
-          else acc
-        } else {
-          acc
+    val tags: Set[String] =
+      if (ed.hasOldTagsColumns(row)) {
+        (1 to 3).foldLeft(Set.empty[String]) {
+          case (acc, i) =>
+            val tag = row.getString(s"tag$i")
+            if (tag != null) acc + tag
+            else acc
         }
-    }
+      } else Set.empty
+
     val timeUuid = row.getUUID("timestamp")
     val sequenceNr = row.getLong("sequence_nr")
-    // TODO could cache this decision
-    val meta = if (row.getColumnDefinitions.contains("meta")) {
+    val meta = if (ed.hasMetaColumns(row)) {
       val m = row.getBytes("meta")
       Option(m).map(SerializedMeta(_, row.getString("meta_ser_manifest"), row.getInt("meta_ser_id")))
     } else {
@@ -91,7 +90,7 @@ class EventsByTagMigration(system: ActorSystem)
   private val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
   private implicit val materialiser = ActorMaterializer()(system)
 
-  implicit val ec = system.dispatcher
+  implicit val ec = system.dispatchers.lookup(system.settings.config.getString("cassandra-journal.plugin-dispatcher"))
   override def config: CassandraJournalConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
   val session: CassandraSession = new CassandraSession(
     system,
@@ -109,6 +108,7 @@ class EventsByTagMigration(system: ActorSystem)
       _ <- session.executeWrite(createKeyspace)
       _ <- session.executeWrite(createTagsTable)
       _ <- session.executeWrite(createTagsProgressTable)
+      _ <- session.executeWrite(createTagScanningTable)
     } yield Done
   }
 
@@ -161,11 +161,10 @@ class EventsByTagMigration(system: ActorSystem)
       preparedWriteToTagViewWithMeta,
       session.executeWrite,
       session.selectResultSet,
-      preparedWriteToTagProgress
+      preparedWriteToTagProgress,
+      preparedWriteTagScanning
     )
-    val tagWriters = system.actorOf(TagWriters.props(
-      (arf, tag) => arf.actorOf(TagWriter.props(tagWriterSession, tag, config.tagWriterSettings))
-    ))
+    val tagWriters = system.actorOf(TagWriters.props(config.tagWriterSettings, tagWriterSession))
 
     // A bit arbitrary, but we could be waiting on many Cassandra writes during the flush
     implicit val timeout = Timeout(30.seconds)
@@ -177,7 +176,7 @@ class EventsByTagMigration(system: ActorSystem)
         val prereqs: Future[(Map[Tag, TagProgress], SequenceNr)] = for {
           tp <- lookupTagProgress(pid)
           _ <- sendTagProgress(pid, tp, tagWriters)
-          startingSeq = calculateStartingSequenceNr(tp)
+          startingSeq <- tagScanningStartingSequenceNr(pid, tp)
         } yield (tp, startingSeq)
 
         // would be nice to group these up into a TagWrites message but also

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -63,6 +63,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config) extends Cassan
   val tagWriterSettings = TagWriterSettings(
     config.getInt("events-by-tag.max-message-batch-size"),
     config.getDuration("events-by-tag.flush-interval", TimeUnit.MILLISECONDS).millis,
+    config.getDuration("events-by-tag.scanning-flush-interval", TimeUnit.MILLISECONDS).millis,
     config.getBoolean("pubsub-notification")
   )
 }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
@@ -9,14 +9,15 @@ import akka.actor.ActorRef
 import akka.pattern.ask
 import akka.event.LoggingAdapter
 import akka.persistence.cassandra.journal.CassandraJournal.{ SequenceNr, Tag }
-import akka.persistence.cassandra.journal.TagWriter.{ TagProgress, TagWrite }
-import akka.persistence.cassandra.journal.TagWriters.{ PidRecovering, PidRecoveringAck }
+import akka.persistence.cassandra.journal.TagWriter.TagProgress
+import akka.persistence.cassandra.journal.TagWriters.{ PidRecovering, PidRecoveringAck, TagWrite }
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.RawEvent
 import akka.util.Timeout
-
 import scala.collection.JavaConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.concurrent.duration._
+
+import akka.persistence.cassandra.journal.TagWriters.BulkTagWrite
 
 trait CassandraTagRecovery {
   self: TaggedPreparedStatements =>
@@ -36,13 +37,15 @@ trait CassandraTagRecovery {
       })
 
   // Before starting the actual recovery first go from the oldest tag progress -> fromSequenceNr
-  // and fix any tags. This recovers any tag writes that happened before the latest snapshot
-  private[akka] def calculateStartingSequenceNr(tps: Map[Tag, TagProgress]): SequenceNr =
-    if (tps.isEmpty) 1L
-    else
-      tps.foldLeft(Long.MaxValue) {
-        case (currentMin, (_, TagProgress(_, sequenceNr, _))) => math.min(currentMin, sequenceNr)
+  // or min tag scanning sequence number, and fix any tags. This recovers any tag writes that
+  // happened before the latest snapshot
+  private[akka] def tagScanningStartingSequenceNr(persistenceId: String, tps: Map[Tag, TagProgress]): Future[SequenceNr] = {
+    preparedSelectTagScanningForPersistenceId.map(_.bind(persistenceId))
+      .flatMap(session.selectOne).map {
+        case Some(row) => row.getLong("sequence_nr")
+        case None      => 1L
       }
+  }
 
   private[akka] def sendMissingTagWriteRaw(tp: Map[Tag, TagProgress], to: ActorRef)(rawEvent: RawEvent): RawEvent = {
     // FIXME logging before releasing
@@ -51,11 +54,11 @@ trait CassandraTagRecovery {
       tp.get(tag) match {
         case None =>
           log.debug("Tag write not in progress. Sending to TagWriter. Tag {} Sequence Nr {}.", tag, rawEvent.sequenceNr)
-          to ! TagWrite(tag, Vector(rawEvent.serialized))
+          to ! TagWrite(tag, rawEvent.serialized :: Nil)
         case Some(progress) =>
           if (rawEvent.sequenceNr > progress.sequenceNr) {
             log.debug("Sequence nr > than write progress. Sending to TagWriter. Tag {} Sequence Nr {}. ", tag, rawEvent.sequenceNr)
-            to ! TagWrite(tag, Vector(rawEvent.serialized))
+            to ! TagWrite(tag, rawEvent.serialized :: Nil)
           }
       }
     })
@@ -63,7 +66,7 @@ trait CassandraTagRecovery {
   }
 
   private[akka] def sendTagProgress(pid: String, tp: Map[Tag, TagProgress], ref: ActorRef): Future[Done] = {
-    log.debug("Recovery sending tag progress: {}", tp)
+    log.debug("Recovery of pid [{}] sending tag progress: {}", pid, tp)
     (ref ? PidRecovering(pid, tp)).mapTo[PidRecoveringAck.type].map(_ => Done)
   }
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
@@ -39,7 +39,7 @@ trait CassandraTagRecovery {
   // Before starting the actual recovery first go from the oldest tag progress -> fromSequenceNr
   // or min tag scanning sequence number, and fix any tags. This recovers any tag writes that
   // happened before the latest snapshot
-  private[akka] def tagScanningStartingSequenceNr(persistenceId: String, tps: Map[Tag, TagProgress]): Future[SequenceNr] = {
+  private[akka] def tagScanningStartingSequenceNr(persistenceId: String): Future[SequenceNr] = {
     preparedSelectTagScanningForPersistenceId.map(_.bind(persistenceId))
       .flatMap(session.selectOne).map {
         case Some(row) => row.getLong("sequence_nr")

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
@@ -18,4 +18,6 @@ trait TaggedPreparedStatements extends CassandraStatements {
   def preparedWriteToTagProgress: Future[PreparedStatement] = session.prepare(writeTagProgress).map(_.setIdempotent(true))
   def preparedSelectTagProgress: Future[PreparedStatement] = session.prepare(selectTagProgress).map(_.setIdempotent(true))
   def preparedSelectTagProgressForPersistenceId: Future[PreparedStatement] = session.prepare(selectTagProgressForPersistenceId).map(_.setIdempotent(true))
+  def preparedWriteTagScanning: Future[PreparedStatement] = session.prepare(writeTagScanning).map(_.setIdempotent(true))
+  def preparedSelectTagScanningForPersistenceId: Future[PreparedStatement] = session.prepare(selectTagScanningForPersistenceId).map(_.setIdempotent(true))
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -149,6 +149,7 @@ import akka.util.OptionVal
       }
     }
 
+    // TODO performance improvement could be to use another query that is not "select *"
     val sequenceNumber: Extractor[SeqNrValue] = (row, ed, s) => {
       SeqNrValue(row.getLong("sequence_nr"))
     }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -22,12 +22,13 @@ import akka.stream.stage._
 import com.datastax.driver.core._
 import com.datastax.driver.core.policies.RetryPolicy
 import com.datastax.driver.core.utils.Bytes
-
 import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.util.{ Failure, Success, Try }
+
+import akka.util.OptionVal
 
 /**
  * INTERNAL API
@@ -40,6 +41,8 @@ import scala.util.{ Failure, Success, Try }
   private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) extends Extracted {
     def sequenceNr = pr.sequenceNr
   }
+
+  private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr]) extends Extracted
 
   private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized) extends Extracted
 
@@ -116,11 +119,44 @@ import scala.util.{ Failure, Success, Try }
 
     type Extractor[T <: Extracted] = (Row, EventDeserializer, Serialization) => T
 
+    final case class SeqNrValue(sequenceNr: Long) extends Extracted
+
+    final case class PersistentReprValue(persistentRepr: PersistentRepr) extends Extracted {
+      override def sequenceNr: Long = persistentRepr.sequenceNr
+    }
+
+    val persistentRepr: Extractor[PersistentReprValue] = (row, ed, s) => {
+      val persistentRepr = extractPersistentRepr(row, ed, s)
+      PersistentReprValue(persistentRepr)
+    }
+
     val taggedPersistentRepr: Extractor[TaggedPersistentRepr] = (row, ed, s) => {
-      val tags = extractTags(row)
+      val tags = extractTags(row, ed)
+      val persistentRepr = extractPersistentRepr(row, ed, s)
+      TaggedPersistentRepr(persistentRepr, tags, row.getUUID("timestamp"))
+    }
+
+    val optionalTaggedPersistentRepr: Extractor[OptionalTagged] = (row, ed, s) => {
+      val seqNr = row.getLong("sequence_nr")
+      val tags = extractTags(row, ed)
+      if (tags.isEmpty) {
+        // no tags, no need to extract more
+        OptionalTagged(seqNr, OptionVal.None)
+      } else {
+        val persistentRepr = extractPersistentRepr(row, ed, s)
+        val tagged = TaggedPersistentRepr(persistentRepr, tags, row.getUUID("timestamp"))
+        OptionalTagged(seqNr, OptionVal.Some(tagged))
+      }
+    }
+
+    val sequenceNumber: Extractor[SeqNrValue] = (row, ed, s) => {
+      SeqNrValue(row.getLong("sequence_nr"))
+    }
+
+    private def extractPersistentRepr(row: Row, ed: EventDeserializer, s: Serialization): PersistentRepr = {
       row.getBytes("message") match {
         case null =>
-          TaggedPersistentRepr(PersistentRepr(
+          PersistentRepr(
             payload = ed.deserializeEvent(row),
             sequenceNr = row.getLong("sequence_nr"),
             persistenceId = row.getString("persistence_id"),
@@ -128,30 +164,31 @@ import scala.util.{ Failure, Success, Try }
             deleted = false,
             sender = null,
             writerUuid = row.getString("writer_uuid")
-          ), tags, row.getUUID("timestamp"))
+          )
         case b =>
           // for backwards compatibility
-          TaggedPersistentRepr(persistentFromByteBuffer(s, b), tags, row.getUUID("timestamp"))
+          persistentFromByteBuffer(s, b)
       }
     }
 
-    private def extractTags(row: Row): Set[String] = {
-      // TODO can be removed in 0.81, this is only used during migration from the old version on initial recovery
-      // we could make this a config flag to disable looking for the old or the new
-      val oldTags = (1 to 3).foldLeft(Set.empty[String]) {
-        case (acc, i) =>
-          if (row.getColumnDefinitions.contains(s"tag$i")) {
-            val tag = row.getString(s"tag$i")
-            if (tag != null) acc + tag
-            else acc
-          } else {
-            acc
+    private def extractTags(row: Row, ed: EventDeserializer): Set[String] = {
+      // TODO can be removed in 1.0, this is only used during migration from the old version on initial recovery
+      val oldTags: Set[String] =
+        if (ed.hasOldTagsColumns(row)) {
+          (1 to 3).foldLeft(Set.empty[String]) {
+            case (acc, i) =>
+              val tag = row.getString(s"tag$i")
+              if (tag != null) acc + tag
+              else acc
           }
-      }
-      val newTags = if (row.getColumnDefinitions.contains("tags")) {
-        row.getSet("tags", classOf[String]).asScala.toSet
-      } else Set.empty[String]
-      oldTags ++ newTags
+        } else Set.empty
+
+      val newTags: Set[String] =
+        if (ed.hasTagsColumn(row))
+          row.getSet("tags", classOf[String]).asScala.toSet
+        else Set.empty
+
+      oldTags.union(newTags)
     }
 
     def persistentFromByteBuffer(serialization: Serialization, b: ByteBuffer): PersistentRepr = {

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -319,7 +319,7 @@ import com.datastax.driver.core.utils.UUIDs
           val bucket = TimeBucket(startingOffset, bucketSize)
           val lookInPrevious = !bucket.within(startingOffset)
           missingLookup = Some(LookingForMissing(
-            List(repr),
+            repr :: Nil,
             startingOffset,
             bucket,
             lookInPrevious,
@@ -349,7 +349,7 @@ import com.datastax.driver.core.utils.UUIDs
           val bucket = TimeBucket(repr.offset, bucketSize)
           val lookInPrevious = !bucket.within(lastUUID)
           missingLookup = Some(LookingForMissing(
-            List(repr),
+            repr :: Nil,
             lastUUID,
             bucket,
             lookInPrevious,

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -434,10 +434,10 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       queryPluginConfig.fetchSize,
       Some(queryPluginConfig.refreshInterval),
       s"eventsByPersistenceId-$persistenceId",
-      extractor = Extractors.taggedPersistentRepr
+      extractor = Extractors.persistentRepr
     )
       .mapMaterializedValue(_ => NotUsed)
-      .map(te => mapEvent(te.pr))
+      .map(p => mapEvent(p.persistentRepr))
       .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**
@@ -458,10 +458,10 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       queryPluginConfig.fetchSize,
       None,
       s"currentEventsByPersistenceId-$persistenceId",
-      extractor = Extractors.taggedPersistentRepr
+      extractor = Extractors.persistentRepr
     )
       .mapMaterializedValue(_ => NotUsed)
-      .map(te => mapEvent(te.pr))
+      .map(p => mapEvent(p.persistentRepr))
       .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**
@@ -481,8 +481,8 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       queryPluginConfig.fetchSize,
       refreshInterval.orElse(Some(queryPluginConfig.refreshInterval)),
       s"eventsByPersistenceId-$persistenceId",
-      extractor = Extractors.taggedPersistentRepr
-    ).map(te => mapEvent(te.pr))
+      extractor = Extractors.persistentRepr
+    ).map(p => mapEvent(p.persistentRepr))
       .mapConcat(r => toEventEnvelopes(r, r.sequenceNr))
 
   /**

--- a/core/src/main/scala/akka/persistence/cassandra/session/scaladsl/CassandraSession.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/session/scaladsl/CassandraSession.scala
@@ -366,8 +366,10 @@ final class CassandraSession(
   def selectOne(stmt: Statement): Future[Option[Row]] = {
     if (stmt.getConsistencyLevel == null)
       stmt.setConsistencyLevel(readConsistency)
-    Source.fromGraph(new SelectSource(Future.successful(stmt)))
-      .runWith(Sink.headOption)
+
+    selectResultSet(stmt).map { rs =>
+      Option(rs.one()) // rs.one returns null if exhausted
+    }
   }
 
   /**

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -9,6 +9,10 @@
     </appender>
 
     <logger name="org.apache.cassandra" level="ERROR" />
+    <!-- Change to DEBUG to see query logging, and set config:
+         cassandra-journal.log-queries = on
+         cassandra-snapshot-store.log-queries = on
+     -->
     <logger name="com.datastax.driver.core.QueryLogger.NORMAL" level="INFO" />
     <logger name="com.datastax.driver.core" level="WARN" />
     <logger name="com.codahale.metrics.JmxReporter" level="INFO" />

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -25,7 +25,7 @@ object CassandraLifecycle {
   // Set to external to use your own cassandra instance running on localhost:9042
   // beware that most tests rely on the data directory being removed for clean up
   // which won't happen for an external cassandra
-  val mode: CassandraMode = Embedded
+  val mode: CassandraMode = Embedded //External
 
   val config = {
     val always = ConfigFactory.parseString(

--- a/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import scala.concurrent.duration._
+
+import akka.actor._
+import akka.persistence.PersistentActor
+import akka.persistence.RecoveryCompleted
+import akka.persistence.SnapshotOffer
+import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.journal.Tagged
+import akka.testkit._
+import com.typesafe.config.ConfigFactory
+import org.scalatest._
+
+object RecoveryLoadSpec {
+  val config = ConfigFactory.parseString(
+    s"""
+      akka.loglevel = INFO
+      cassandra-journal.keyspace=RecoveryLoadSpec
+      cassandra-journal.events-by-tag.enabled = on
+      cassandra-journal.events-by-tag.scanning-flush-interval = 2s
+      cassandra-journal.replay-filter.mode = off
+      cassandra-journal.log-queries = on
+      cassandra-snapshot-store.keyspace=RecoveryLoadSpecSnapshot
+      cassandra-snapshot-store.log-queries = on
+    """
+  ).withFallback(CassandraLifecycle.config)
+
+  final case class Init(numberOfEvents: Int)
+  case object InitDone
+  private final case class Next(remaining: Int)
+  final case class Delete(seqNr: Long)
+  case object GetMetrics
+  final case class Metrics(snapshotDuration: FiniteDuration, replayDuration1: FiniteDuration,
+                           replayDuration2: FiniteDuration, replayedEvents: Int,
+                           totalDuration: FiniteDuration)
+
+  def props(persistenceId: String, snapshotEvery: Int, tagging: Long => Set[String]): Props =
+    Props(new ProcessorA(persistenceId, snapshotEvery, tagging))
+
+  class ProcessorA(val persistenceId: String, snapshotEvery: Int, tagging: Long => Set[String]) extends PersistentActor {
+    val startTime = System.nanoTime()
+    var snapshotEndTime = startTime
+    var replayStartTime = startTime
+    var replayEndTime = startTime
+    var replayedEvents = 0
+
+    def receiveRecover: Receive = {
+      case s: SnapshotOffer =>
+        snapshotEndTime = System.nanoTime()
+        replayStartTime = snapshotEndTime
+      case _: String =>
+        replayedEvents += 1
+
+        if (replayStartTime == snapshotEndTime)
+          replayStartTime = System.nanoTime() // first event
+      case RecoveryCompleted =>
+        replayEndTime = System.nanoTime()
+    }
+
+    def receiveCommand: Receive = {
+      case Init(numberOfEvents) =>
+        self ! Next(numberOfEvents)
+        context.become(init(sender()))
+      case Delete(seqNr) =>
+        deleteMessages(seqNr)
+      case GetMetrics =>
+        sender() ! Metrics(
+          snapshotDuration = (snapshotEndTime - startTime).nanos,
+          replayDuration1 = (replayStartTime - snapshotEndTime).nanos,
+          replayDuration2 = (replayEndTime - replayStartTime).nanos,
+          replayedEvents,
+          totalDuration = (replayEndTime - startTime).nanos
+        )
+    }
+
+    def init(replyTo: ActorRef): Receive = {
+      case Next(remaining) =>
+        if (remaining == 0)
+          replyTo ! InitDone
+        else {
+          val tags = tagging(lastSequenceNr)
+          val event =
+            if (tags.isEmpty) s"event-$lastSequenceNr"
+            else Tagged(s"event-$lastSequenceNr", tags)
+
+          persist(event) { _ =>
+            if (lastSequenceNr % snapshotEvery == 0) {
+              saveSnapshot(s"snap-$lastSequenceNr")
+            }
+            self ! Next(remaining - 1)
+          }
+        }
+    }
+
+  }
+
+}
+
+class RecoveryLoadSpec extends TestKit(ActorSystem("RecoveryLoadSpec", RecoveryLoadSpec.config))
+  with ImplicitSender with WordSpecLike with Matchers with CassandraLifecycle {
+
+  import RecoveryLoadSpec._
+
+  override def systemName: String = "RecoveryLoadSpec"
+
+  private def printMetrics(metrics: Metrics): Unit = {
+    println(s"  snapshot recovery took ${metrics.snapshotDuration.toMillis} ms")
+    println(s"  replay init took ${metrics.replayDuration1.toMillis} ms")
+    println(s"  replay of ${metrics.replayedEvents} events took ${metrics.replayDuration2.toMillis} ms")
+    println(s"  total recovery took ${metrics.totalDuration.toMillis} ms")
+  }
+
+  "Recovery" should {
+
+    "have some reasonable performance" in {
+      val pid = "a1"
+      val snapshotEvery = 1000
+      val tagging: Long => Set[String] = { _ => Set.empty }
+      //      val tagging: Long => Set[String] = { seqNr =>
+      //        if (seqNr % 10 == 0) Set("blue")
+      //        else if (seqNr % 17 == 0) Set("blue", "green")
+      //        else Set.empty
+      //      }
+      val prps = props(persistenceId = pid, snapshotEvery, tagging)
+
+      val p1 = system.actorOf(prps)
+      p1 ! Init(numberOfEvents = 9999)
+      expectMsg(20.seconds, InitDone)
+      //            p1 ! Delete(seqNr = 2000000)
+      //            Thread.sleep(3000)
+      system.stop(p1)
+
+      // wait > 2 * scanning-flush-interval
+      Thread.sleep(4500)
+
+      (1 to 3).foreach { n =>
+        val p2 = system.actorOf(prps)
+        p2 ! GetMetrics
+        val metrics = expectMsgType[Metrics](3.seconds)
+        println(s"iteration #$n")
+        printMetrics(metrics)
+        system.stop(p2)
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
@@ -21,7 +21,6 @@ import com.datastax.driver.core.utils.UUIDs
 import com.datastax.driver.core.{ PreparedStatement, Statement }
 import com.typesafe.config.ConfigFactory
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach, WordSpecLike }
-
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future, Promise }
 import scala.util.control.NoStackTrace
@@ -500,7 +499,7 @@ class TagWriterSpec extends TestKit(ActorSystem("TagWriterSpec", TagWriterSpec.c
 
       ref ! TagWrite(tagName, Vector(e2))
       logProbe.expectMsgPF(waitDuration) {
-        case Error(`t`, _, _, "Writing tags has failed. This means that any eventsByTag query will be out of date. The write will be retried.") =>
+        case Warning(_, _, msg) if msg.toString.contains("Writing tags has failed") =>
       }
       ref ! TagWrite(tagName, Vector(e3, e4))
 
@@ -531,7 +530,7 @@ class TagWriterSpec extends TestKit(ActorSystem("TagWriterSpec", TagWriterSpec.c
       probe.expectMsg(Vector(toEw(e1, 1), toEw(e2, 2)))
       probe.expectMsg(ProgressWrite("p1", 2, 2, e2.timeUuid))
       logProbe.expectMsgPF(waitDuration) {
-        case Error(`t`, _, _, msg) if msg.toString.contains("Tag progress write has failed") =>
+        case Warning(_, _, msg) if msg.toString.contains("Tag progress write has failed") =>
       }
 
       ref ! TagWrite(tagName, Vector(e3, e4))


### PR DESCRIPTION
* Recovery was slow for persistent actors with many events without tags
  because then there was no tag progress to start from and it always
  started the tag scanning from 1
* The performance of the actual tag scanning was also improved by two things:
  * optimized event extractor
  * avoid repeated getColumnDefinition checks
* Some other performance related boy scouting

Refs #333