### PR TITLE
Deletion and update functionality

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import com.typesafe.sbt.SbtScalariform.ScalariformKeys
 import sbt.Keys._
 import sbtassembly.AssemblyPlugin.autoImport._
 
-val AkkaVersion = "2.5.9"
+val AkkaVersion = "2.5.11"
 
 val akkaPersistenceCassandraDependencies = Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.3.1",
@@ -33,11 +33,9 @@ def common: Seq[Setting[_]] = SbtScalariform.scalariformSettings ++ Seq(
     "-feature",
     "-unchecked",
     "-deprecation",
-    //"-Xfatal-warnings",
     "-Xlint",
     "-Yno-adapted-args",
     "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
     "-Xfuture"
   ),
 

--- a/build.sbt
+++ b/build.sbt
@@ -24,8 +24,8 @@ def common: Seq[Setting[_]] = SbtScalariform.scalariformSettings ++ Seq(
   organizationName := "Lightbend Inc.",
   startYear := Some(2016),
   licenses := Seq(("Apache-2.0", url("http://www.apache.org/licenses/LICENSE-2.0"))),
-  crossScalaVersions := Seq("2.11.11", "2.12.4"),
-  scalaVersion := crossScalaVersions.value.head,
+  crossScalaVersions := Seq("2.11.11", "2.12.5"),
+  scalaVersion := crossScalaVersions.value.last,
   crossVersion := CrossVersion.binary,
 
   scalacOptions ++= Seq(

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -86,7 +86,7 @@ class EventsByTagMigration(system: ActorSystem)
   with TaggedPreparedStatements
   with CassandraTagRecovery {
 
-  protected val log = Logging.getLogger(system, getClass)
+  private[akka] val log = Logging.getLogger(system, getClass)
   private val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
   private implicit val materialiser = ActorMaterializer()(system)
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraDeletion.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraDeletion.scala
@@ -22,12 +22,12 @@ import akka.persistence.cassandra.journal.CassandraDeletion.{ MessageId, Partiti
 import scala.collection.immutable
 import scala.concurrent.{ ExecutionContext, Future }
 
-object CassandraDeletion {
+private[akka] object CassandraDeletion {
   private case class PartitionInfo(partitionNr: Long, minSequenceNr: Long, maxSequenceNr: Long)
   private case class MessageId(persistenceId: String, sequenceNr: Long)
 }
 
-trait CassandraDeletion extends CassandraStatements {
+private[akka] trait CassandraDeletion extends CassandraStatements {
   private[akka] val session: CassandraSession
 
   private[akka] val log: LoggingAdapter

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraDeletion.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraDeletion.scala
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.Sink
+import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
+import com.datastax.driver.core._
+import java.lang.{ Long => JLong }
+
+import scala.language.implicitConversions
+import akka.persistence.cassandra._
+import akka.Done
+import akka.event.LoggingAdapter
+import akka.persistence.cassandra.journal.CassandraDeletion.{ MessageId, PartitionInfo }
+
+import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future }
+
+object CassandraDeletion {
+  private case class PartitionInfo(partitionNr: Long, minSequenceNr: Long, maxSequenceNr: Long)
+  private case class MessageId(persistenceId: String, sequenceNr: Long)
+}
+
+trait CassandraDeletion extends CassandraStatements {
+  private[akka] val session: CassandraSession
+
+  private[akka] val log: LoggingAdapter
+  private[akka] def config: CassandraJournalConfig
+  private[akka] def queries: CassandraReadJournal
+  private[akka] implicit val ec: ExecutionContext
+  private[akka] implicit val materializer: ActorMaterializer
+
+  private[akka] val readRetryPolicy: RetryPolicy
+  private lazy val deleteRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(config.deleteRetries))
+
+  def preparedSelectDeletedTo = session.prepare(selectDeletedTo)
+    .map(_.setConsistencyLevel(config.readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
+  def preparedSelectHighestSequenceNr = session.prepare(selectHighestSequenceNr)
+    .map(_.setConsistencyLevel(config.readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
+  def preparedInsertDeletedTo = session.prepare(insertDeletedTo)
+    .map(_.setConsistencyLevel(config.writeConsistency).setIdempotent(true))
+  def preparedDeleteMessages = session.prepare(deleteMessages).map(_.setIdempotent(true))
+
+  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = {
+    asyncHighestDeletedSequenceNumber(persistenceId).flatMap {
+      highestDeletedSequenceNumber =>
+        asyncReadLowestSequenceNr(persistenceId, 1L, highestDeletedSequenceNumber, Some(config.readConsistency), Some(readRetryPolicy)).flatMap {
+          lowestSequenceNr =>
+            asyncFindHighestSequenceNr(persistenceId, lowestSequenceNr, config.targetPartitionSize).flatMap {
+              highestSequenceNr =>
+                val lowestPartition = partitionNr(lowestSequenceNr, config.targetPartitionSize)
+                val toSeqNr = math.min(toSequenceNr, highestSequenceNr)
+                val highestPartition = partitionNr(toSeqNr, config.targetPartitionSize) + 1 // may have been moved to the next partition
+
+                val boundInsertDeletedTo = preparedInsertDeletedTo.map(_.bind(persistenceId, toSeqNr: JLong))
+                val logicalDelete = boundInsertDeletedTo.flatMap(session.executeWrite)
+
+                def partitionInfos: immutable.Seq[Future[PartitionInfo]] = (lowestPartition to highestPartition).map(partitionInfo(persistenceId, _, toSeqNr))
+
+                def physicalDelete(): Unit = {
+                  if (config.cassandra2xCompat) {
+                    def asyncDeleteMessages(partitionNr: Long, messageIds: Seq[MessageId]): Future[Unit] = {
+                      val boundStatements = messageIds.map(mid =>
+                        preparedDeleteMessages.map(_.bind(mid.persistenceId, partitionNr: JLong, mid.sequenceNr: JLong)))
+                      Future.sequence(boundStatements).flatMap {
+                        stmts =>
+                          executeBatch(batch => stmts.foreach(batch.add), deleteRetryPolicy)
+                      }
+                    }
+
+                    partitionInfos.map(future => future.flatMap(pi => {
+                      Future.sequence((pi.minSequenceNr to pi.maxSequenceNr).grouped(config.maxMessageBatchSize).map {
+                        group =>
+                          {
+                            val delete = asyncDeleteMessages(pi.partitionNr, group map (MessageId(persistenceId, _)))
+                            delete.onFailure {
+                              case e => log.warning(s"Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
+                                "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
+                                "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
+                            }
+                            delete
+                          }
+                      })
+                    }))
+
+                  } else {
+                    Future.sequence(partitionInfos.map(future => future.flatMap {
+                      pi =>
+                        val boundDeleteMessages = preparedDeleteMessages.map(_.bind(persistenceId, pi.partitionNr: JLong, toSeqNr: JLong))
+                        boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
+                    }))
+                      .onFailure {
+                        case e => log.warning("Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
+                          "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
+                          "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
+                      }
+                  }
+                }
+
+                logicalDelete.foreach(_ => physicalDelete())
+
+                logicalDelete.map(_ => Done)
+            }
+        }
+    }
+  }
+
+  private def execute(stmt: Statement, retryPolicy: RetryPolicy): Future[Unit] = {
+    stmt.setConsistencyLevel(config.writeConsistency).setRetryPolicy(retryPolicy)
+    session.executeWrite(stmt).map(_ => ())
+  }
+
+  private def partitionInfo(persistenceId: String, partitionNr: Long, maxSequenceNr: Long): Future[PartitionInfo] = {
+    val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNr.map(_.bind(persistenceId, partitionNr: JLong))
+    boundSelectHighestSequenceNr.flatMap(session.selectOne)
+      .map(row => row.map(s => PartitionInfo(partitionNr, minSequenceNr(partitionNr), math.min(s.getLong("sequence_nr"), maxSequenceNr)))
+        .getOrElse(PartitionInfo(partitionNr, minSequenceNr(partitionNr), -1)))
+  }
+
+  private[akka] def asyncHighestDeletedSequenceNumber(persistenceId: String): Future[Long] = {
+    val boundSelectDeletedTo = preparedSelectDeletedTo.map(_.bind(persistenceId))
+    boundSelectDeletedTo.flatMap(session.selectOne)
+      .map(rowOption => rowOption.map(_.getLong("deleted_to")).getOrElse(0))
+  }
+
+  // TODO create a custom extractor that doesn't deserialise the event
+  private[akka] def asyncReadLowestSequenceNr(
+    persistenceId:                String,
+    fromSequenceNr:               Long,
+    highestDeletedSequenceNumber: Long,
+    readConsistency:              Option[ConsistencyLevel],
+    retryPolicy:                  Option[RetryPolicy]
+  ): Future[Long] = {
+    queries
+      .eventsByPersistenceId(
+        persistenceId,
+        fromSequenceNr,
+        highestDeletedSequenceNumber,
+        1,
+        1,
+        None,
+        "asyncReadLowestSequenceNr",
+        readConsistency,
+        retryPolicy,
+        extractor = Extractors.sequenceNumber
+      )
+      .map(_.sequenceNr)
+      .runWith(Sink.headOption)
+      .map {
+        case Some(sequenceNr) => sequenceNr
+        case None             => fromSequenceNr
+      }
+  }
+
+  private[akka] def asyncFindHighestSequenceNr(persistenceId: String, fromSequenceNr: Long, partitionSize: Long): Future[Long] = {
+    def find(currentPnr: Long, currentSnr: Long): Future[Long] = {
+      // if every message has been deleted and thus no sequence_nr the driver gives us back 0 for "null" :(
+      val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNr.map(_.bind(persistenceId, currentPnr: JLong))
+      boundSelectHighestSequenceNr.flatMap(session.selectOne)
+        .map { rowOption =>
+          rowOption.map { row =>
+            (row.getBool("used"), row.getLong("sequence_nr"))
+          }
+        }
+        .flatMap {
+          // never been to this partition
+          case None                   => Future.successful(currentSnr)
+          // don't currently explicitly set false
+          case Some((false, _))       => Future.successful(currentSnr)
+          // everything deleted in this partition, move to the next
+          case Some((true, 0))        => find(currentPnr + 1, currentSnr)
+          case Some((_, nextHighest)) => find(currentPnr + 1, nextHighest)
+        }
+    }
+
+    find(partitionNr(fromSequenceNr, partitionSize), fromSequenceNr)
+  }
+
+  private def executeBatch(body: BatchStatement ⇒ Unit, retryPolicy: RetryPolicy): Future[Unit] = {
+    val batch = new BatchStatement().setConsistencyLevel(config.writeConsistency).setRetryPolicy(retryPolicy).asInstanceOf[BatchStatement]
+    body(batch)
+    session.underlying().flatMap(_.executeAsync(batch)).map(_ => ())
+  }
+
+  private def minSequenceNr(partitionNr: Long): Long =
+    partitionNr * config.targetPartitionSize + 1
+
+}

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import akka.Done
+import akka.persistence.cassandra.journal.CassandraJournal.Serialized
+import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import com.datastax.driver.core.{ PreparedStatement, Statement }
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait CassandraEventUpdate extends CassandraStatements {
+
+  private[akka] val session: CassandraSession
+  private[akka] def config: CassandraJournalConfig
+  private[akka] implicit val ec: ExecutionContext
+
+  def preparedUpdateMessage: Future[PreparedStatement] = session.prepare(updateMessagePayload).map(_.setIdempotent(true))
+
+  def updateEvent(event: Serialized): Future[Done] = {
+    preparedUpdateMessage.flatMap {
+      ps => session.executeWrite(prepareUpdate(ps, event))
+    }
+  }
+
+  private def prepareUpdate(ps: PreparedStatement, s: Serialized): Statement = {
+    val maxPnr = partitionNr(s.sequenceNr, config.targetPartitionSize)
+    val bs = ps.bind()
+
+    // primary key
+    bs.setString("persistence_id", s.persistenceId)
+    bs.setLong("partition_nr", maxPnr)
+    bs.setLong("sequence_nr", s.sequenceNr)
+    bs.setUUID("timestamp", s.timeUuid)
+    bs.setString("timebucket", s.timeBucket.key.toString)
+
+    // fields to update
+    bs.setInt("ser_id", s.serId)
+    bs.setString("ser_manifest", s.serManifest)
+    bs.setString("event_manifest", s.eventAdapterManifest)
+    bs.setBytes("event", s.serialized)
+    bs.setSet("tags", s.tags.asJava, classOf[String])
+    bs
+  }
+}

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -13,7 +13,6 @@ import akka.Done
 import akka.actor.{ ActorRef, ExtendedActorSystem, NoSerializationVerificationNeeded }
 import akka.annotation.InternalApi
 import akka.event.{ Logging, LoggingAdapter }
-import akka.pattern.pipe
 import akka.persistence._
 import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
 import akka.persistence.cassandra._

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -12,20 +12,18 @@ import java.util.{ UUID, HashMap => JHMap, Map => JMap }
 import akka.Done
 import akka.actor.{ ActorRef, ExtendedActorSystem, NoSerializationVerificationNeeded }
 import akka.annotation.InternalApi
-import akka.event.Logging
+import akka.event.{ Logging, LoggingAdapter }
 import akka.pattern.pipe
 import akka.persistence._
 import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.TagWriters.{ BulkTagWrite, TagWrite, TagWritersSession }
-import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.journal.{ AsyncWriteJournal, Tagged }
 import akka.persistence.query.PersistenceQuery
 import akka.serialization.{ Serialization, SerializationExtension }
 import akka.stream.ActorMaterializer
-import akka.stream.scaladsl.Sink
 import com.datastax.driver.core._
 import com.datastax.driver.core.exceptions.DriverException
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
@@ -33,19 +31,19 @@ import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
 import com.datastax.driver.core.utils.{ Bytes, UUIDs }
 import com.typesafe.config.Config
 
-import scala.collection.JavaConversions._
 import scala.collection.immutable.Seq
+import scala.collection.JavaConverters._
 import scala.concurrent._
-import scala.math.min
 import scala.util.{ Failure, Success, Try }
 
 class CassandraJournal(cfg: Config) extends AsyncWriteJournal
   with CassandraRecovery
-  with CassandraStatements with NoSerializationVerificationNeeded {
+  with CassandraStatements
+  with NoSerializationVerificationNeeded {
 
-  val config = new CassandraJournalConfig(context.system, cfg)
-  val serialization = SerializationExtension(context.system)
-  val log = Logging(context.system, getClass)
+  private[akka] val config = new CassandraJournalConfig(context.system, cfg)
+  private[akka] val serialization = SerializationExtension(context.system)
+  private[akka] val log: LoggingAdapter = Logging(context.system, getClass)
 
   import CassandraJournal._
   import config._
@@ -84,26 +82,17 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
         .withDispatcher(context.props.dispatcher), "tagWrites"))
     else None
 
-  def preparedWriteMessage = session.prepare(
-    writeMessage(withMeta = false)
-  ).map(_.setIdempotent(true))
+  def preparedWriteMessage = session.prepare(writeMessage(withMeta = false)).map(_.setIdempotent(true))
 
   def preparedWriteMessageWithMeta = session.prepare(
     writeMessage(withMeta = true)
   ).map(_.setIdempotent(true))
-
-  def preparedDeleteMessages = session.prepare(deleteMessages).map(_.setIdempotent(true))
   def preparedSelectMessages = session.prepare(selectMessages)
     .map(_.setConsistencyLevel(readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
   def preparedWriteInUse = session.prepare(writeInUse).map(_.setIdempotent(true))
-  def preparedSelectHighestSequenceNr = session.prepare(selectHighestSequenceNr)
-    .map(_.setConsistencyLevel(readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
-  def preparedSelectDeletedTo = session.prepare(selectDeletedTo)
-    .map(_.setConsistencyLevel(readConsistency).setIdempotent(true).setRetryPolicy(readRetryPolicy))
-  def preparedInsertDeletedTo = session.prepare(insertDeletedTo)
-    .map(_.setConsistencyLevel(writeConsistency).setIdempotent(true))
 
-  private[akka] implicit val materializer = ActorMaterializer()
+  override implicit val materializer: ActorMaterializer = ActorMaterializer()(context.system)
+
   private[akka] lazy val queries =
     PersistenceQuery(context.system.asInstanceOf[ExtendedActorSystem])
       .readJournalFor[CassandraReadJournal](config.queryPlugin)
@@ -138,9 +127,8 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
       }
   }
 
-  private val writeRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(config.writeRetries))
-  private val deleteRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(config.deleteRetries))
-  private val readRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(config.readRetries))
+  private[akka] val writeRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(config.writeRetries))
+  private[akka] val readRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(config.readRetries))
   private[akka] val someReadRetryPolicy = Some(readRetryPolicy)
   private[akka] val someReadConsistency = Some(config.readConsistency)
 
@@ -256,9 +244,9 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
   }
 
   private def statementGroup(atomicWrites: Seq[SerializedAtomicWrite]): Seq[Future[BoundStatement]] = {
-    val maxPnr = partitionNr(atomicWrites.last.payload.last.sequenceNr)
+    val maxPnr = partitionNr(atomicWrites.last.payload.last.sequenceNr, targetPartitionSize)
     val firstSeq = atomicWrites.head.payload.head.sequenceNr
-    val minPnr = partitionNr(firstSeq)
+    val minPnr = partitionNr(firstSeq, targetPartitionSize)
     val persistenceId: String = atomicWrites.head.persistenceId
     val all = atomicWrites.flatMap(_.payload)
 
@@ -286,7 +274,7 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
           bs.setString("ser_manifest", m.serManifest)
           bs.setString("event_manifest", m.eventAdapterManifest)
           bs.setBytes("event", m.serialized)
-          bs.setSet("tags", m.tags, classOf[String])
+          bs.setSet("tags", m.tags.asJava, classOf[String])
 
           // meta data, if any
           m.meta.foreach(meta => {
@@ -338,80 +326,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
     }
   }
 
-  def asyncDeleteMessagesTo(persistenceId: String, toSequenceNr: Long): Future[Unit] = {
-    asyncHighestDeletedSequenceNumber(persistenceId).flatMap {
-      highestDeletedSequenceNumber =>
-        asyncReadLowestSequenceNr(persistenceId, 1L, highestDeletedSequenceNumber).flatMap {
-          lowestSequenceNr =>
-            asyncReadHighestSequenceNrInternal(persistenceId, lowestSequenceNr).flatMap {
-              highestSequenceNr =>
-                val lowestPartition = partitionNr(lowestSequenceNr)
-                val toSeqNr = math.min(toSequenceNr, highestSequenceNr)
-                val highestPartition = partitionNr(toSeqNr) + 1 // may have been moved to the next partition
-
-                val boundInsertDeletedTo = preparedInsertDeletedTo.map(_.bind(persistenceId, toSeqNr: JLong))
-                val logicalDelete = boundInsertDeletedTo.flatMap(session.executeWrite)
-
-                def partitionInfos = (lowestPartition to highestPartition).map(partitionInfo(persistenceId, _, toSeqNr))
-
-                def physicalDelete(): Unit = {
-                  if (config.cassandra2xCompat) {
-                    def asyncDeleteMessages(partitionNr: Long, messageIds: Seq[MessageId]): Future[Unit] = {
-                      val boundStatements = messageIds.map(mid =>
-                        preparedDeleteMessages.map(_.bind(mid.persistenceId, partitionNr: JLong, mid.sequenceNr: JLong)))
-                      Future.sequence(boundStatements).flatMap {
-                        stmts =>
-                          executeBatch(batch => stmts.foreach(batch.add), deleteRetryPolicy)
-                      }
-                    }
-
-                    partitionInfos.map(future => future.flatMap(pi => {
-                      Future.sequence((pi.minSequenceNr to pi.maxSequenceNr).grouped(config.maxMessageBatchSize).map {
-                        group =>
-                          {
-                            val delete = asyncDeleteMessages(pi.partitionNr, group map (MessageId(persistenceId, _)))
-                            delete.onFailure {
-                              case e => log.warning(s"Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
-                                "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
-                                "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
-                            }
-                            delete
-                          }
-                      })
-                    }))
-
-                  } else {
-                    Future.sequence(partitionInfos.map(future => future.flatMap {
-                      pi =>
-                        val boundDeleteMessages = preparedDeleteMessages.map(_.bind(persistenceId, pi.partitionNr: JLong, toSeqNr: JLong))
-                        boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
-                    }))
-                      .onFailure {
-                        case e => log.warning("Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
-                          "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
-                          "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
-                      }
-                  }
-                }
-
-                logicalDelete.foreach(_ => physicalDelete())
-
-                logicalDelete.map(_ => Done)
-            }
-        }
-    }
-  }
-
-  def partitionNr(sequenceNr: Long): Long =
-    (sequenceNr - 1L) / targetPartitionSize
-
-  private def partitionInfo(persistenceId: String, partitionNr: Long, maxSequenceNr: Long): Future[PartitionInfo] = {
-    val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNr.map(_.bind(persistenceId, partitionNr: JLong))
-    boundSelectHighestSequenceNr.flatMap(session.selectOne)
-      .map(row => row.map(s => PartitionInfo(partitionNr, minSequenceNr(partitionNr), min(s.getLong("sequence_nr"), maxSequenceNr)))
-        .getOrElse(PartitionInfo(partitionNr, minSequenceNr(partitionNr), -1)))
-  }
-
   private def executeBatch(body: BatchStatement ⇒ Unit, retryPolicy: RetryPolicy): Future[Unit] = {
     val batch = new BatchStatement().setConsistencyLevel(writeConsistency).setRetryPolicy(retryPolicy).asInstanceOf[BatchStatement]
     body(batch)
@@ -423,33 +337,8 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
     session.executeWrite(stmt).map(_ => ())
   }
 
-  private def asyncReadLowestSequenceNr(persistenceId: String, fromSequenceNr: Long, highestDeletedSequenceNumber: Long): Future[Long] = {
-    queries
-      .eventsByPersistenceId(
-        persistenceId,
-        fromSequenceNr,
-        highestDeletedSequenceNumber,
-        1,
-        1,
-        None,
-        "asyncReadLowestSequenceNr",
-        someReadConsistency,
-        someReadRetryPolicy,
-        extractor = Extractors.sequenceNumber
-      )
-      .map(_.sequenceNr)
-      .runWith(Sink.headOption)
-      .map {
-        case Some(sequenceNr) => sequenceNr
-        case None             => fromSequenceNr
-      }
-  }
-
   private def partitionNew(sequenceNr: Long): Boolean =
     (sequenceNr - 1L) % targetPartitionSize == 0L
-
-  private def minSequenceNr(partitionNr: Long): Long =
-    partitionNr * targetPartitionSize + 1
 
   protected lazy val transportInformation: Option[Serialization.Information] = {
     val address = context.system.asInstanceOf[ExtendedActorSystem].provider.getDefaultAddress
@@ -471,7 +360,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
   private case object Init
 
   private case class WriteFinished(pid: String, f: Future[Done]) extends NoSerializationVerificationNeeded
-  private case class MessageId(persistenceId: String, sequenceNr: Long)
 
   private case class SerializedAtomicWrite(persistenceId: String, payload: Seq[Serialized])
 
@@ -480,8 +368,6 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
                                       meta: Option[SerializedMeta], timeUuid: UUID, timeBucket: TimeBucket)
 
   private[akka] case class SerializedMeta(serialized: ByteBuffer, serManifest: String, serId: Int)
-
-  private case class PartitionInfo(partitionNr: Long, minSequenceNr: Long, maxSequenceNr: Long)
 
   class EventDeserializer(serialization: Serialization) {
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -39,7 +39,7 @@ private[akka] object BucketSize {
 case class TableSettings(name: String, compactionStrategy: CassandraCompactionStrategy, gcGraceSeconds: Long, ttl: Option[Duration])
 
 class CassandraJournalConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) with NoSerializationVerificationNeeded {
-  val targetPartitionSize: Int = config.getInt(CassandraJournalConfig.TargetPartitionProperty)
+  val targetPartitionSize: Long = config.getLong(CassandraJournalConfig.TargetPartitionProperty)
   val maxResultSize: Int = config.getInt("max-result-size")
   val replayMaxResultSize: Int = config.getInt("max-result-size-replay")
   val maxMessageBatchSize = config.getInt("max-message-batch-size")

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -4,8 +4,6 @@
 
 package akka.persistence.cassandra.journal
 
-import java.lang.{ Long => JLong }
-
 import akka.Done
 import akka.actor.ActorRef
 import akka.persistence.PersistentRepr
@@ -18,15 +16,19 @@ import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.OptionVal
 import scala.concurrent._
 
-trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatements {
+trait CassandraRecovery extends CassandraTagRecovery
+  with TaggedPreparedStatements
+  with CassandraDeletion {
   this: CassandraJournal =>
+
+  private[akka] val config: CassandraJournalConfig
 
   import config._
 
   private[akka] def asyncReadHighestSequenceNrInternal(persistenceId: String, fromSequenceNr: Long): Future[Long] = {
     log.debug("asyncReadHighestSequenceNr {} {}", persistenceId, fromSequenceNr)
     asyncHighestDeletedSequenceNumber(persistenceId).flatMap { h =>
-      asyncFindHighestSequenceNr(persistenceId, math.max(fromSequenceNr, h))
+      asyncFindHighestSequenceNr(persistenceId, math.max(fromSequenceNr, h), targetPartitionSize)
     }
   }
 
@@ -141,36 +143,5 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
       }
     })
     tpr
-  }
-
-  private def asyncFindHighestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long] = {
-
-    def find(currentPnr: Long, currentSnr: Long): Future[Long] = {
-      // if every message has been deleted and thus no sequence_nr the driver gives us back 0 for "null" :(
-      val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNr.map(_.bind(persistenceId, currentPnr: JLong))
-      boundSelectHighestSequenceNr.flatMap(session.selectOne)
-        .map { rowOption =>
-          rowOption.map { row =>
-            (row.getBool("used"), row.getLong("sequence_nr"))
-          }
-        }
-        .flatMap {
-          // never been to this partition
-          case None                   => Future.successful(currentSnr)
-          // don't currently explicitly set false
-          case Some((false, _))       => Future.successful(currentSnr)
-          // everything deleted in this partition, move to the next
-          case Some((true, 0))        => find(currentPnr + 1, currentSnr)
-          case Some((_, nextHighest)) => find(currentPnr + 1, nextHighest)
-        }
-    }
-
-    find(partitionNr(fromSequenceNr), fromSequenceNr)
-  }
-
-  def asyncHighestDeletedSequenceNumber(persistenceId: String): Future[Long] = {
-    val boundSelectDeletedTo = preparedSelectDeletedTo.map(_.bind(persistenceId))
-    boundSelectDeletedTo.flatMap(session.selectOne)
-      .map(rowOption => rowOption.map(_.getLong("deleted_to")).getOrElse(0))
   }
 }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -107,6 +107,25 @@ trait CassandraStatements {
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${if (withMeta) "?, ?, ?, " else ""} true, ?)
     """
 
+  // could just use the write tags statement if we're going to update all the fields.
+  // Fields that are not updated atm: writer_uuid and metadata fields
+  private[akka] def updateMessagePayload =
+    s"""
+       UPDATE $tableName
+       SET
+        event = ?,
+        ser_manifest = ?,
+        ser_id = ?,
+        event_manifest = ?,
+        tags = ?
+       WHERE
+        persistence_id = ? AND
+        partition_nr = ? AND
+        sequence_nr = ? AND
+        timestamp = ? AND
+        timebucket = ?
+     """
+
   private[akka] def writeTags(withMeta: Boolean) =
     s"""
        INSERT INTO $tagTableName(

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
@@ -48,7 +48,7 @@ trait CassandraTagRecovery {
   }
 
   private[akka] def sendMissingTagWriteRaw(tp: Map[Tag, TagProgress], to: ActorRef)(rawEvent: RawEvent): RawEvent = {
-    // FIXME logging before releasing
+    // FIXME logging once stable
     log.debug("Processing tag write for event {} tags {}", rawEvent.sequenceNr, rawEvent.serialized.tags)
     rawEvent.serialized.tags.foreach(tag => {
       tp.get(tag) match {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
@@ -21,7 +21,7 @@ import akka.persistence.cassandra.journal.TagWriters.BulkTagWrite
 
 trait CassandraTagRecovery {
   self: TaggedPreparedStatements =>
-  protected val log: LoggingAdapter
+  private[akka] val log: LoggingAdapter
 
   // used for local asks
   private implicit val timeout = Timeout(10.second)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -85,6 +85,7 @@ import akka.util.ByteString
   }
   private[akka] case class BulkTagWrite(tagWrites: immutable.Seq[TagWrite], withoutTags: immutable.Seq[Serialized])
     extends NoSerializationVerificationNeeded
+
   private[akka] case class TagWrite(tag: Tag, serialised: immutable.Seq[Serialized])
     extends NoSerializationVerificationNeeded
 
@@ -103,7 +104,6 @@ import akka.util.ByteString
 @InternalApi private[akka] class TagWriters(settings: TagWriterSettings, tagWriterSession: TagWritersSession)
   extends Actor with Timers with ActorLogging {
 
-  import context.become
   import context.dispatcher
 
   // eager init and val because used from Future callbacks
@@ -139,6 +139,7 @@ import akka.util.ByteString
       updatePendingScanning(withoutTags)
     case WriteTagScanningTick =>
       writeTagScanning()
+
     case PidRecovering(pid, tagProgresses: Map[Tag, TagProgress]) =>
       val replyTo = sender()
       val missingProgress = tagActors.keySet -- tagProgresses.keySet
@@ -168,7 +169,7 @@ import akka.util.ByteString
       // if this fails (all local actor asks) the recovery will timeout
       recoveryNotificationComplete.foreach { _ => replyTo ! PidRecoveringAck }
 
-    case TagWriteFailed(e) =>
+    case TagWriteFailed(_) =>
       toBeWrittenScanning = Map.empty
       pendingScanning = Map.empty
   }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
@@ -10,8 +10,8 @@ import com.datastax.driver.core.PreparedStatement
 import scala.concurrent.{ ExecutionContext, Future }
 
 trait TaggedPreparedStatements extends CassandraStatements {
-  val session: CassandraSession
-  implicit val ec: ExecutionContext
+  private[akka] val session: CassandraSession
+  private[akka] implicit val ec: ExecutionContext
 
   def preparedWriteToTagViewWithoutMeta: Future[PreparedStatement] = session.prepare(writeTags(false)).map(_.setIdempotent(true))
   def preparedWriteToTagViewWithMeta: Future[PreparedStatement] = session.prepare(writeTags(true)).map(_.setIdempotent(true))

--- a/core/src/main/scala/akka/persistence/cassandra/journal/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/package.scala
@@ -1,0 +1,10 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+package object journal {
+  def partitionNr(sequenceNr: Long, partitionSize: Long): Long =
+    (sequenceNr - 1L) / partitionSize
+}

--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -88,8 +88,14 @@ package object cassandra {
       }
       val serEvent = ByteBuffer.wrap(serialization.serialize(event).get)
 
-      Serialized(p.persistenceId, p.sequenceNr, serEvent, tags, p.manifest, serManifest,
-        serializer.identifier, p.writerUuid, serializeMeta(), uuid, timeBucket)
+      Serialized(p.persistenceId, p.sequenceNr, serEvent, tags,
+        eventAdapterManifest = p.manifest,
+        serManifest = serManifest,
+        serId = serializer.identifier,
+        p.writerUuid,
+        serializeMeta(),
+        uuid,
+        timeBucket)
     }
 
     // serialize actor references with full address information (defaultAddress)

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -56,7 +56,7 @@ import scala.concurrent.duration._
   val pluginDispatcher: String = config.getString("plugin-dispatcher")
 
   val keyspace: String = writePluginConfig.keyspace
-  val targetPartitionSize: Int = writePluginConfig.targetPartitionSize
+  val targetPartitionSize: Long = writePluginConfig.targetPartitionSize
   val table: String = writePluginConfig.table
   val pubsubNotification: Boolean = writePluginConfig.tagWriterSettings.pubsubNotification
   val eventsByPersistenceIdEventTimeout: FiniteDuration = config.getDuration("events-by-persistence-id-gap-timeout", MILLISECONDS).millis

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -491,6 +491,9 @@ import com.datastax.driver.core.utils.UUIDs
       private def extractEvent(row: Row): UUIDPersistentRepr = {
         val pr = UUIDPersistentRepr(
           row.getUUID("timestamp"),
+          //           FIXME, tags aren't currently stored in here :( Will require some kind of data migration to add them
+          //          row.getSet[String]("tags", classOf[String]).asScala.toSet,
+          //          Set.empty[String],
           row.getLong("tag_pid_sequence_nr"),
           PersistentRepr(
             payload = eventDeserializer.deserializeEvent(row),

--- a/core/src/main/scala/akka/persistence/cassandra/query/UUIDPersistentRepr.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/UUIDPersistentRepr.scala
@@ -15,7 +15,8 @@ import akka.persistence.cassandra.journal.CassandraJournal.TagPidSequenceNr
  * `eventsByTag` query, or similar queries.
  */
 @InternalApi private[akka] final case class UUIDPersistentRepr(
-  offset:           UUID,
+  offset: UUID,
+  //  tags:             Set[String], this isn't in the tags table, may need to be added
   tagPidSequenceNr: TagPidSequenceNr,
   persistentRepr:   PersistentRepr
 )

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -265,6 +265,13 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
    * backend journal.
    */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
+    eventsByTagInternal(tag, offset).mapConcat(r => toEventEnvelope(r.persistentRepr, TimeBasedUUID(r.offset)))
+      .mapMaterializedValue(_ => NotUsed)
+      .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
+
+  }
+
+  private[akka] def eventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] = {
     if (!config.eventsByTagEnabled)
       Source.failed(new IllegalStateException("Events by tag queries are disabled"))
     else {
@@ -281,9 +288,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
             usingOffset,
             prereqs._2
           ))
-        }.mapConcat(r => toEventEnvelope(mapEvent(r.persistentRepr), TimeBasedUUID(r.offset)))
+        }
           .mapMaterializedValue(_ => NotUsed)
-          .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
+          .map(upr => upr.copy(persistentRepr = mapEvent(upr.persistentRepr)))
       } catch {
         case NonFatal(e) =>
           // e.g. from cassandraSession, or selectStatement
@@ -376,6 +383,12 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
    *
    */
   override def currentEventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] = {
+    currentEventsByTagInternal(tag, offset)
+      .mapConcat(r => toEventEnvelope(r.persistentRepr, TimeBasedUUID(r.offset)))
+      .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
+  }
+
+  private[akka] def currentEventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] = {
     if (!config.eventsByTagEnabled)
       Source.failed(new IllegalStateException("Events by tag queries are disabled"))
     else {
@@ -387,9 +400,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
         createFutureSource(prereqs) { (s, prereqs) =>
           val session = TagStageSession(tag, s, prereqs._1, queryPluginConfig.fetchSize)
           Source.fromGraph(EventsByTagStage(session, fromOffset, toOffset, queryPluginConfig, None, writePluginConfig.bucketSize, usingOffset, prereqs._2))
-        }.mapConcat(r => toEventEnvelope(mapEvent(r.persistentRepr), TimeBasedUUID(r.offset)))
+        }
           .mapMaterializedValue(_ => NotUsed)
-          .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
+          .map(x => x.copy(persistentRepr = mapEvent(x.persistentRepr)))
       } catch {
         case NonFatal(e) =>
           // e.g. from cassandraSession, or selectStatement
@@ -398,7 +411,6 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       }
     }
   }
-
   /**
    * `eventsByPersistenceId` is used to retrieve a stream of events for a particular persistenceId.
    *

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -21,6 +21,7 @@ import akka.persistence.cassandra.query.EventsByTagStage.TagStageSession
 import akka.persistence.cassandra.query._
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal.CombinedEventsByTagStmts
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.persistence.journal.EventAdapter
 import akka.persistence.query._
 import akka.persistence.query.scaladsl._
 import akka.persistence.{ Persistence, PersistentRepr }

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.snapshot
+
+import java.lang.{ Long => JLong }
+
+import akka.Done
+import akka.persistence.SnapshotMetadata
+import akka.persistence.cassandra.journal.FixedRetryPolicy
+import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import com.datastax.driver.core.policies.LoggingRetryPolicy
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+trait CassandraSnapshotCleanup extends CassandraStatements {
+
+  def snapshotConfig: CassandraSnapshotStoreConfig
+  def session: CassandraSession
+  private[akka] implicit val ec: ExecutionContext
+
+  private lazy val deleteRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(snapshotConfig.deleteRetries))
+
+  def preparedDeleteSnapshot = session.prepare(deleteSnapshot).map(
+    _.setConsistencyLevel(snapshotConfig.writeConsistency).setIdempotent(true).setRetryPolicy(deleteRetryPolicy)
+  )
+
+  def preparedDeleteAllSnapshotsForPid = session.prepare(deleteAllSnapshotForPersistenceId).map(
+    _.setConsistencyLevel(snapshotConfig.writeConsistency).setIdempotent(true).setRetryPolicy(deleteRetryPolicy)
+  )
+
+  def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = {
+    val boundDeleteSnapshot = preparedDeleteSnapshot.map(_.bind(metadata.persistenceId, metadata.sequenceNr: JLong))
+    boundDeleteSnapshot.flatMap(session.executeWrite(_)).map(_ => ())
+  }
+
+  def deleteAllForPersistenceId(pid: String): Future[Done] = {
+    val bound = preparedDeleteAllSnapshotsForPid.map(_.bind(pid))
+    bound.flatMap(session.executeWrite(_)).map(_ => Done)
+  }
+}

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraReadJournalConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraReadJournalConfigSpec.scala
@@ -9,7 +9,7 @@ import akka.persistence.cassandra.journal.{ CassandraJournalConfig, Day, Hour, T
 import akka.persistence.cassandra.query.CassandraReadJournalConfig
 import akka.testkit.TestKit
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpec, WordSpecLike }
+import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
 class CassandraReadJournalConfigSpec extends TestKit(ActorSystem("CassandraReadJournalConfigSpec"))
   with WordSpecLike

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -20,6 +20,7 @@ import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.{ ImplicitSender, TestKit }
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.time.{ Milliseconds, Seconds, Span }
 import org.scalatest.{ Matchers, WordSpecLike }
 
 import scala.collection.immutable
@@ -56,6 +57,8 @@ abstract class CassandraSpec(config: Config) extends TestKit(ActorSystem(getCall
 
   override def systemName = system.name
   implicit val mat = ActorMaterializer()(system)
+
+  implicit val patience = PatienceConfig(timeout = Span(5, Seconds), interval = Span(100, Milliseconds))
 
   val pidCounter = new AtomicInteger()
   def nextPid = s"pid=${pidCounter.incrementAndGet()}"

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+import akka.actor.ActorSystem
+import akka.persistence.cassandra.CassandraSpec._
+import akka.persistence.cassandra.query.EventsByPersistenceIdStage
+import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.query.PersistenceQuery
+import akka.stream.ActorMaterializer
+import akka.stream.scaladsl.{ Keep, Sink }
+import akka.testkit.{ ImplicitSender, TestKit }
+import com.typesafe.config.{ Config, ConfigFactory }
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{ Matchers, WordSpecLike }
+
+import scala.collection.immutable
+
+object CassandraSpec {
+  def getCallerName(clazz: Class[_]): String = {
+    val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)
+      .dropWhile(_ matches "(java.lang.Thread|.*\\.Abstract.*)")
+    val reduced = s.lastIndexWhere(_ == clazz.getName) match {
+      case -1 ⇒ s
+      case z  ⇒ s drop (z + 1)
+    }
+    reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
+  }
+
+  def configWithKeyspace(name: String) = ConfigFactory.parseString(
+    s"""
+      cassandra-journal.keyspace = $name
+    """
+  ).withFallback(CassandraLifecycle.config)
+}
+
+abstract class CassandraSpec(config: Config) extends TestKit(ActorSystem(getCallerName(getClass), config.withFallback(configWithKeyspace(getCallerName(getClass)))))
+  with ImplicitSender
+  with WordSpecLike
+  with Matchers
+  with CassandraLifecycle
+  with ScalaFutures {
+
+  override def systemName = system.name
+  implicit val mat = ActorMaterializer()(system)
+
+  lazy val queries: CassandraReadJournal = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
+
+  def eventsPayloads(pid: String): Seq[Any] =
+    queries.currentEventsByPersistenceId(pid, 0, Long.MaxValue)
+      .map(e => e.event)
+      .toMat(Sink.seq)(Keep.right)
+      .run().futureValue
+
+  def events(pid: String): immutable.Seq[EventsByPersistenceIdStage.TaggedPersistentRepr] =
+    queries.eventsByPersistenceId(pid, 0, Long.MaxValue, Long.MaxValue, 100, None, "test",
+      extractor = Extractors.taggedPersistentRepr)
+      .toMat(Sink.seq)(Keep.right)
+      .run().futureValue
+
+  def eventPayloadsWithTags(pid: String): immutable.Seq[(Any, Set[String])] =
+    queries.eventsByPersistenceId(pid, 0, Long.MaxValue, Long.MaxValue, 100, None, "test",
+      extractor = Extractors.taggedPersistentRepr)
+      .map { tpr => (tpr.pr.payload, tpr.tags) }
+      .toMat(Sink.seq)(Keep.right)
+      .run().futureValue
+
+}

--- a/core/src/test/scala/akka/persistence/cassandra/Persister.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/Persister.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+import akka.actor.ActorRef
+import akka.persistence.{ PersistentActor, SaveSnapshotFailure, SaveSnapshotSuccess, SnapshotOffer }
+import akka.persistence.cassandra.Persister._
+
+object Persister {
+  case class CrapEvent(n: Int)
+  case class Snapshot(s: Any)
+  case object GetSnapshot
+  case object SnapshotAck
+  case object SnapshotNack
+}
+
+class Persister(override val persistenceId: String, probe: Option[ActorRef] = None) extends PersistentActor {
+  def this(pid: String, probe: ActorRef) = this(pid, Some(probe))
+
+  var snapshot: Option[Any] = None
+  var snapshotAck: Option[ActorRef] = None
+
+  override def receiveRecover: Receive = {
+    case SnapshotOffer(_, s) =>
+      snapshot = Some(s)
+    case msg => probe.foreach(_ ! msg)
+  }
+  override def receiveCommand: Receive = {
+    case GetSnapshot =>
+      sender() ! snapshot
+    case Snapshot(s) =>
+      snapshotAck = Some(sender())
+      saveSnapshot(s)
+    case SaveSnapshotSuccess(_) =>
+      snapshotAck.foreach(_ ! SnapshotAck)
+      snapshotAck = None
+    case SaveSnapshotFailure(_, _) =>
+      snapshotAck.foreach(_ ! SnapshotNack)
+      snapshotAck = None
+    case msg => persist(msg) { _ =>
+      probe.foreach(_ ! msg)
+    }
+  }
+
+  override protected def onRecoveryFailure(cause: Throwable, event: Option[Any]): Unit = {
+    probe.foreach(_ ! cause)
+  }
+}
+

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -14,22 +14,29 @@ import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, TestTaggingActor, _ }
 import akka.serialization.SerializationExtension
 import com.typesafe.config.ConfigFactory
+import scala.concurrent.duration._
 
 import scala.concurrent.{ ExecutionContext, Future }
 
 object CassandraEventUpdateSpec {
   val config = ConfigFactory.parseString(
     """
+        akka.loglevel = DEBUG
     """
   ).withFallback(CassandraLifecycle.config)
 }
 
 class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.config) {
+  s =>
 
-  private val log = Logging(system, getClass)
+  private[akka] val log = Logging(system, getClass)
   private val serialization = SerializationExtension(system)
 
+  val shortWait = 10.millis
+
   val updater = new CassandraEventUpdate {
+
+    override private[akka] val log = s.log
     override private[akka] def config: CassandraJournalConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
     override private[akka] implicit val ec: ExecutionContext = system.dispatcher
     override private[akka] val session: CassandraSession = new CassandraSession(
@@ -45,7 +52,7 @@ class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.co
 
   "CassandraEventUpdate" must {
     "update the event in messages" in {
-      val pid = "a"
+      val pid = nextPid
       val a = system.actorOf(TestTaggingActor.props(pid))
       a ! "e-1"
       expectMsgType[TestTaggingActor.Ack.type]
@@ -62,26 +69,59 @@ class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.co
       eventPayloadsWithTags(pid) shouldEqual Seq(("secrets", Set("captain america")))
     }
 
+    // eventsByTag doesn't include the original tags so if used to transform
+    // will wipe out old tags
+    "update the event in messages not wiping out existing tags" in {
+      val pid = nextPid
+      val a = system.actorOf(TestTaggingActor.props(pid, Set("keepme")))
+      a ! "e-1"
+      expectMsgType[TestTaggingActor.Ack.type]
+      expectEventsForTag(tag = "keepme", "e-1")
+
+      val eventsBefore = events(pid)
+      eventsBefore.map(_.pr.payload) shouldEqual Seq("e-1")
+      val originalEvent = eventsBefore.head
+      val modifiedEvent = serialize(
+        originalEvent.pr.withPayload("secrets"),
+        originalEvent.offset, Set.empty
+      )
+
+      updater.updateEvent(modifiedEvent, providingTags = false).futureValue shouldEqual Done
+
+      eventPayloadsWithTags(pid) shouldEqual Seq(("secrets", Set("keepme")))
+    }
+
     "update the event in tag_views" in {
-      val pid = "b"
+      val pid = nextPid
       val b = system.actorOf(TestTaggingActor.props(pid, Set("red", "blue")))
       b ! "e-1"
       expectMsgType[TestTaggingActor.Ack.type]
       val eventsBefore = events(pid).head
-      val modifiedEvnet = serialize(
-        eventsBefore.pr.withPayload("hidden"), eventsBefore.offset, Set("red", "blue")
+      val modifiedEvent = serialize(
+        eventsBefore.pr.withPayload("hidden"), eventsBefore.offset, Set("green", "red", "blue")
       )
 
-      // update the event
+      expectEventsForTag(tag = "red", "e-1")
+      expectEventsForTag(tag = "blue", "e-1")
+
+      updater.updateEvent(modifiedEvent).futureValue shouldEqual Done
+
+      expectEventsForTag(tag = "red", "hidden")
+      expectEventsForTag(tag = "blue", "hidden")
     }
 
-    "remove tags" in {
-      // FIXME, decide if want to do this
+    "deal with tag pid sequence nr not being here" in {
+      /*
+      If running against a live application then events by persistence id will
+      find events that the tag write is buffered. Should deal with that e.g.
+      report which ones haven't been updated, offer an API to start from a given
+      sequenceNr so it can be run again without duplicating work
+       */
       pending
     }
 
-    "add tag" in {
-      // FIXME, we need to do this but decide if we want to do it while the app is running
+    "add tag to existing event" in {
+      // TODO, we need to do this but decide if we want to do it while the app is running
       // will need to be very careful about tag pid sequence nrs
       pending
     }

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import java.util.UUID
+
+import akka.Done
+import akka.event.Logging
+import akka.persistence.PersistentRepr
+import akka.persistence.cassandra.journal.CassandraJournal.Serialized
+import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, TestTaggingActor, _ }
+import akka.serialization.SerializationExtension
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.{ ExecutionContext, Future }
+
+object CassandraEventUpdateSpec {
+  val config = ConfigFactory.parseString(
+    """
+    """
+  ).withFallback(CassandraLifecycle.config)
+}
+
+class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.config) {
+
+  private val log = Logging(system, getClass)
+  private val serialization = SerializationExtension(system)
+
+  val updater = new CassandraEventUpdate {
+    override private[akka] def config: CassandraJournalConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+    override private[akka] implicit val ec: ExecutionContext = system.dispatcher
+    override private[akka] val session: CassandraSession = new CassandraSession(
+      system,
+      config.sessionProvider,
+      config.sessionSettings,
+      ec,
+      log,
+      systemName,
+      init = _ => Future.successful(Done)
+    )
+  }
+
+  "CassandraEventUpdate" must {
+    "update the event" in {
+      val pid = "a"
+      val a = system.actorOf(TestTaggingActor.props(pid))
+      a ! "e-1"
+      expectMsgType[TestTaggingActor.Ack.type]
+      val eventsBefore = events("a")
+      eventsBefore.map(_.pr.payload) shouldEqual Seq("e-1")
+      val originalEvent = eventsBefore.head
+      val modifiedEvent = serialize(
+        originalEvent.pr.withPayload("secrets"),
+        originalEvent.offset, Set("captain america")
+      )
+
+      updater.updateEvent(modifiedEvent).futureValue shouldEqual Done
+
+      eventPayloadsWithTags(pid) shouldEqual Seq(("secrets", Set("captain america")))
+    }
+
+    def serialize(pr: PersistentRepr, offset: UUID, tags: Set[String]): Serialized = {
+      serializeEvent(pr, tags, offset, Hour, serialization, None)
+    }
+  }
+}

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 object CassandraEventUpdateSpec {
   val config = ConfigFactory.parseString(
     """
-        akka.loglevel = DEBUG
+        akka.loglevel = INFO
     """
   ).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -96,7 +96,6 @@ class EventWithMetaDataTagger extends WriteEventAdapter {
   override def manifest(event: Any) = ""
   override def toJournal(event: Any) = event match {
     case evm: EventWithMetaData =>
-      println("Tagging evm: " + evm)
       Tagged(evm, Set("gotmeta"))
     case _ => event
   }

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.snapshot
+
+import akka.Done
+import akka.actor.Props
+import akka.event.Logging
+import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.persistence.cassandra.{ CassandraSpec, Persister }
+import com.typesafe.config.ConfigFactory
+
+import scala.concurrent.{ ExecutionContext, Future }
+import Persister._
+
+object CassandraSnapshotCleanupSpec {
+  val config = ConfigFactory.parseString(
+    """
+      akka.loglevel = INFO
+    """.stripMargin
+  )
+}
+
+class CassandraSnapshotCleanupSpec extends CassandraSpec(CassandraSnapshotCleanupSpec.config) {
+
+  private val log = Logging(system, getClass)
+  val snapshotCleanup = new CassandraSnapshotCleanup {
+    override def snapshotConfig: CassandraSnapshotStoreConfig =
+      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-snapshot-store"))
+    override val session: CassandraSession = new CassandraSession(
+      system,
+      snapshotConfig.sessionProvider,
+      snapshotConfig.sessionSettings,
+      system.dispatcher,
+      log,
+      systemName,
+      init = _ => Future.successful(Done)
+    )
+    override implicit val ec: ExecutionContext = system.dispatcher
+  }
+
+  "Snapshot cleanup" must {
+    "delete all snapshots for a given persistenceId" in {
+      val pid = "pid"
+      val a = system.actorOf(Props(new Persister(pid)))
+      a ! Snapshot("cat")
+      expectMsgType[SnapshotAck.type]
+
+      val a2 = system.actorOf(Props(new Persister(pid)))
+      a2 ! GetSnapshot
+      expectMsg(Option("cat"))
+
+      snapshotCleanup.deleteAllForPersistenceId(pid).futureValue shouldEqual Done
+
+      val a3 = system.actorOf(Props(new Persister(pid)))
+      a3 ! GetSnapshot
+      expectMsg(None)
+    }
+  }
+}

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -40,7 +40,7 @@ object CassandraSnapshotStoreConfiguration {
 class CassandraSnapshotStoreSpec extends SnapshotStoreSpec(CassandraSnapshotStoreConfiguration.config) with CassandraLifecycle {
 
   val storeConfig = new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-snapshot-store"))
-  val storeStatements = new CassandraStatements { def config = storeConfig }
+  val storeStatements = new CassandraStatements { def snapshotConfig = storeConfig }
 
   var session: Session = _
 


### PR DESCRIPTION
Makes uisng the delete functionality possible without creating a journal
as well as an update event that uses the same serialization logic.

Current limitations:
* New tags aren't created in tag_views
* Tags are not deleted

