### PR TITLE
EventsByTag: Use a separate timeout for when a new persitenceId is found

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -635,6 +635,14 @@ cassandra-query-journal {
     # then the missing events won't be found
     gap-timeout = 10s
 
+    # When a new persistenceId is found in an eventsByTag query that wasn't found in the initial offset scanning
+    # period as it didn't have any events in the current time bucket, this is how long the stage will delay events
+    # looking for any smaller tag pid sequence nrs. 0s means that the found event is assumed to be the first.
+    # The edge case is if events for a not previously seen persistenceId come out of order then if this is set to
+    # 0s the newer event will be delivered and when the older event is found the stream will fail as events have
+    # to be delivered in order.
+    new-persistence-id-scan-timeout = 100ms
+
     # For offset queries that start in the current time bucket a period of scanning
     # takes place before deliverying events to look for the lowest sequence number
     # for each persistenceId. Any value above 0 will result in at least one scan from

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -63,6 +63,8 @@ import scala.concurrent.duration._
   val pubsubNotification: Boolean = writePluginConfig.tagWriterSettings.pubsubNotification
   val eventsByPersistenceIdEventTimeout: FiniteDuration = config.getDuration("events-by-persistence-id-gap-timeout", MILLISECONDS).millis
 
-  val eventsByTagTimeout: FiniteDuration = config.getDuration("events-by-tag.gap-timeout", MILLISECONDS).millis
+  val eventsByTagGapTimeout: FiniteDuration = config.getDuration("events-by-tag.gap-timeout", MILLISECONDS).millis
+  val eventsByTagNewPersistenceIdScanTimeout = config.getDuration("events-by-tag.new-persistence-id-scan-timeout", MILLISECONDS).millis
   val eventsByTagOffsetScanning: FiniteDuration = config.getDuration("events-by-tag.offset-scanning-period", MILLISECONDS).millis
+
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -13,9 +13,9 @@ import akka.persistence.cassandra.journal.{ BucketSize, TimeBucket }
 import akka.persistence.cassandra.query.EventsByTagStage._
 import akka.stream.stage.{ GraphStage, _ }
 import akka.stream.{ ActorMaterializer, Attributes, Outlet, SourceShape }
-import com.datastax.driver.core._
 
 import scala.annotation.tailrec
+import scala.concurrent.duration.Duration
 import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
 import scala.util.{ Failure, Success, Try }
@@ -24,6 +24,7 @@ import java.lang.{ Long => JLong }
 import akka.cluster.pubsub.{ DistributedPubSub, DistributedPubSubMediator }
 import akka.persistence.cassandra.journal.CassandraJournal._
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal.CombinedEventsByTagStmts
+import com.datastax.driver.core.{ ResultSet, Row, Session }
 import com.datastax.driver.core.utils.UUIDs
 
 /**
@@ -301,7 +302,7 @@ import com.datastax.driver.core.utils.UUIDs
           tagPidSequenceNrs += (repr.persistenceId -> ((1, repr.offset)))
           push(out, repr)
           false
-        } else if (usingOffset && (currTimeBucket.inPast || settings.eventsByTagNewPersistenceIdScanTimeout == scala.concurrent.duration.Duration.Zero)) {
+        } else if (usingOffset && (currTimeBucket.inPast || settings.eventsByTagNewPersistenceIdScanTimeout == Duration.Zero)) {
           // If we're in the past and this is an offset query we assume this is
           // the first tagPidSequenceNr
           log.debug("New persistence id: {}. Timebucket: {}. Tag pid sequence nr: {}", repr.persistenceId, currTimeBucket, repr.tagPidSequenceNr)

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -66,7 +66,14 @@ object EventsByTagSpec {
   val strictConfig = ConfigFactory.parseString(
     s"""
     akka.loglevel = INFO
-    cassandra-query-journal.events-by-tag-gap-timeout = 5s
+    cassandra-query-journal {
+      refresh-interval = 100ms
+      events-by-tag {
+        gap-timeout = 5s
+        new-persistence-id-scan-timeout = 200s
+      }
+
+    }
     """
   ).withFallback(config)
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -277,7 +277,6 @@ class EventsByTagStageSpec extends CassandraSpec(EventsByTagStageSpec.config)
       sub.expectComplete()
     }
 
-
   }
 
   "Live EventsByTag" must {
@@ -506,7 +505,7 @@ class EventsByTagStageSpec extends CassandraSpec(EventsByTagStageSpec.config)
       sub.expectNoMessage(100.millis)
       writeTaggedEvent(nowTime, PersistentRepr("p1e11", 11, "p-1"), Set(tag), 11, bucketSize)
       // wait more than the new persistence id timeout but less than the gap-timeout
-      sub.expectNextWithTimeoutPF(1.second, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
+      sub.expectNextWithTimeoutPF(2.seconds, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
       sub.cancel()
     }
   }


### PR DESCRIPTION
This only happens when the initial scan didn't find an existing tag pid
sequenceNr in the current time bucket.

Refs #347 