### PR TITLE
allow to customize UUID generation

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -4,14 +4,13 @@
 
 package akka.persistence.cassandra.journal
 
-import scala.collection.immutable
 import java.lang.{ Long => JLong }
 import java.nio.ByteBuffer
 import java.util.{ UUID, HashMap => JHMap, Map => JMap }
 
 import akka.Done
 import akka.actor.{ ActorRef, ActorSystem, ExtendedActorSystem, NoSerializationVerificationNeeded }
-import akka.annotation.InternalApi
+import akka.annotation.{ DoNotInherit, InternalApi }
 import akka.event.{ Logging, LoggingAdapter }
 import akka.persistence._
 import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
@@ -21,31 +20,36 @@ import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.journal.{ AsyncWriteJournal, Tagged }
 import akka.persistence.query.PersistenceQuery
-import akka.serialization.{ Serialization, SerializationExtension }
+import akka.serialization.{ AsyncSerializer, Serialization, SerializationExtension }
 import akka.stream.ActorMaterializer
+import akka.util.OptionVal
 import com.datastax.driver.core._
 import com.datastax.driver.core.exceptions.DriverException
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
 import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
 import com.datastax.driver.core.utils.{ Bytes, UUIDs }
 import com.typesafe.config.Config
-import scala.collection.immutable.Seq
+
 import scala.collection.JavaConverters._
+import scala.collection.immutable
+import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 
-import akka.serialization.AsyncSerializer
-import akka.util.OptionVal
-
+/**
+ * Journal implementation of the cassandra plugin.
+ * Inheritance is possible but without any guarantees for future source compatibility.
+ */
+@DoNotInherit
 class CassandraJournal(cfg: Config) extends AsyncWriteJournal
   with CassandraRecovery
   with CassandraStatements
   with NoSerializationVerificationNeeded {
 
-  private[akka] val config = new CassandraJournalConfig(context.system, cfg)
-  private[akka] val serialization = SerializationExtension(context.system)
-  private[akka] val log: LoggingAdapter = Logging(context.system, getClass)
+  val config = new CassandraJournalConfig(context.system, cfg)
+  val serialization = SerializationExtension(context.system)
+  val log: LoggingAdapter = Logging(context.system, getClass)
 
   import CassandraJournal._
   import config._
@@ -168,7 +172,7 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
     }
 
     val writesWithUuids: Seq[Seq[(PersistentRepr, UUID)]] = messages
-      .map(aw => aw.payload.map(pr => (pr, UUIDs.timeBased())))
+      .map(aw => aw.payload.map(pr => (pr, generateUUID(pr))))
 
     val p = Promise[Done]
     val pid = messages.head.persistenceId
@@ -204,6 +208,12 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
     //Nil == all good
     tws.map(_ => Nil)(akka.dispatch.ExecutionContexts.sameThreadExecutionContext)
   }
+
+  /**
+   * UUID generation is deliberately externalized to allow subclasses to customize the time based uuid for special cases.
+   * see https://discuss.lightbend.com/t/akka-persistence-cassandra-events-by-tags-bucket-size-based-on-time-vs-burst-load/1411 and make sure you understand the risk of doing this wrong.
+   */
+  protected def generateUUID(pr: PersistentRepr): UUID = UUIDs.timeBased()
 
   private def extractTagWrites(serialized: Seq[SerializedAtomicWrite]): BulkTagWrite = {
     if (serialized.isEmpty) BulkTagWrite(Nil, Nil)


### PR DESCRIPTION
-change the cassandra journal actor so a custom subclass can overwrite the TimebasedUUID generation and therefore store the tags in the correct bucket
see https://discuss.lightbend.com/t/akka-persistence-cassandra-events-by-tags-bucket-size-based-on-time-vs-burst-load/1411

 example:
```
 class TimestampAwareCassandraJournal(cfg: Config) extends CassandraJournal(cfg) {
   private val random = new Random()

  override protected def generateUUID(pr: PersistentRepr): UUID = {
    val timestamp = extractTimestamp(pr.payload)
    //manually create a timebased UUID as described by cassandra see com.datastax.driver.core.utils.UUIDs.timeBased
    new UUID(UUIDs.startOf(timestamp.toInstant.toEpochMilli).getMostSignificantBits, random.nextLong())
  }

  private def extractTimestamp(data: Any): ZonedDateTime = {
      data match {
        case Tagged(t: Timestamped, _) =>
          log.debug("extract timestamp {} from tagged timestamped", t.timestamp.nonCid, t)
          t.timestamp
        case Tagged(o, _) =>
          log.warning("cannot determine timestamp from tagged {} - fallback to now", o)
          TimeProvider.timestamp
        case t: Timestamped =>
          log.debug("extract timestamp {} from timestamped", t.timestamp.nonCid, t)
          t.timestamp
        case o =>
          log.info("cannot determine timestamp from {} - fallback to now", o)
          TimeProvider.timestamp
      }
    }
  }
```