### PR TITLE
Deliver duplicate seqeunce numbers for replay filter to work

### DIFF
--- a/core/src/test/scala/akka/persistence/cassandra/CassandraCorruptJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraCorruptJournalSpec.scala
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+import akka.actor.{ ActorRef, PoisonPill }
+import akka.persistence.cassandra.query.{ DirectWriting, TestActor }
+import akka.testkit.EventFilter
+
+class CassandraCorruptJournalSpec extends CassandraSpec(
+  """
+    akka {
+      loglevel = DEBUG
+      loggers = ["akka.testkit.TestEventListener"]
+    }
+
+    cassandra-journal.replay-filter {
+   # What the filter should do when detecting invalid events.
+   # Supported values:
+   # `repair-by-discard-old` : discard events from old writers,
+   #                           warning is logged
+   # `fail` : fail the replay, error is logged
+   # `warn` : log warning but emit events untouched
+   # `off` : disable this feature completely
+      mode = repair-by-discard-old
+    }
+
+    cassandra-journal-fail = ${cassandra-journal}
+    cassandra-journal-fail {
+      replay-filter.mode = fail
+    }
+
+    cassandra-journal-warn = ${cassandra-journal}
+    cassandra-journal-warn {
+      replay-filter.mode = warn
+    }
+  """.stripMargin
+) with DirectWriting {
+
+  def setup(persistenceId: String, journalId: String = "cassandra-journal"): ActorRef = {
+    val ref = system.actorOf(TestActor.props(persistenceId, journalId))
+    ref
+  }
+
+  "Cassandra recovery" must {
+    "work with replay-filter = repair-by-discard-old" in {
+      val pid = nextPid
+      val p1a = setup(pid)
+      val p1b = setup(pid)
+
+      p1a ! "p1a-1"
+      expectMsg("p1a-1-done")
+      p1a ! "p1a-2"
+      expectMsg("p1a-2-done")
+      p1b ! "p1b-1"
+      expectMsg("p1b-1-done")
+
+      p1a ! PoisonPill
+      p1b ! PoisonPill
+
+      // Two logs. One for the new writer sequenceNr 1, another for the old writer sequenceNr 2
+      EventFilter.warning(pattern = "Invalid replayed event", occurrences = 2) intercept {
+        val p1c = setup(pid)
+        p1c ! "p1c-1"
+        expectMsg("p1c-1-done")
+      }
+    }
+
+    "work with replay-filter = fail" in {
+      val pid = nextPid
+      val p1a = setup(pid, journalId = "cassandra-journal-fail")
+      val p1b = setup(pid, journalId = "cassandra-journal-fail")
+
+      p1a ! "p1a-1"
+      expectMsg("p1a-1-done")
+      p1a ! "p1a-2"
+      expectMsg("p1a-2-done")
+      p1b ! "p1b-1"
+      expectMsg("p1b-1-done")
+
+      p1a ! PoisonPill
+      p1b ! PoisonPill
+
+      EventFilter[IllegalStateException](pattern = "Invalid replayed event", occurrences = 1) intercept {
+        setup(pid, journalId = "cassandra-journal-fail")
+      }
+    }
+
+    "work with replay-filter = warn" in {
+      val pid = nextPid
+      val p1a = setup(pid, journalId = "cassandra-journal-warn")
+      val p1b = setup(pid, journalId = "cassandra-journal-warn")
+
+      p1a ! "p1a-1"
+      expectMsg("p1a-1-done")
+      p1a ! "p1a-2"
+      expectMsg("p1a-2-done")
+      p1b ! "p1b-1"
+      expectMsg("p1b-1-done")
+
+      p1a ! PoisonPill
+      p1b ! PoisonPill
+
+      EventFilter.warning(pattern = "Invalid replayed event", occurrences = 2) intercept {
+        val p1c = setup(pid)
+        p1c ! "p1c-1"
+        expectMsg("p1c-1-done")
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -35,13 +35,14 @@ import scala.util.Try
 object CassandraSpec {
   val today = LocalDateTime.now(ZoneOffset.UTC)
   def getCallerName(clazz: Class[_]): String = {
-    val s = (Thread.currentThread.getStackTrace map (_.getClassName) drop 1)
-      .dropWhile(_ matches "(java.lang.Thread|.*Abstract.*)")
+    val s = (Thread.currentThread.getStackTrace map (_.getClassName))
+      .dropWhile(_ matches "(java.lang.Thread|.*Abstract.*|akka.persistence.cassandra.CassandraSpec\\$|.*CassandraSpec)")
     val reduced = s.lastIndexWhere(_ == clazz.getName) match {
       case -1 ⇒ s
       case z  ⇒ s drop (z + 1)
     }
     reduced.head.replaceFirst(""".*\.""", "").replaceAll("[^a-zA-Z_0-9]", "_")
+      .take(48) // Max length of a c* keyspace
   }
 
   def configOverrides(journalKeyspace: String, snapshotStoreKeyspace: String, port: Int): Config = ConfigFactory.parseString(

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -96,6 +96,10 @@ class EventsByTagMigrationProvidePersistenceIds extends AbstractEventsByTagMigra
 class EventsByTagMigrationSpec extends AbstractEventsByTagMigrationSpec {
 
   "Events by tag migration with no metadata" must {
+
+    if (CassandraLifecycle.isExternal)
+      pending
+
     val pidOne = "p-1"
     val pidTwo = "p-2"
     val pidWithMeta = "pidMeta"

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -20,7 +20,6 @@ import scala.concurrent.duration._
 object EventsByPersistenceIdSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
-    cassandra-journal.keyspace=EventsByPersistenceIdSpec
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 2
     cassandra-query-journal.events-by-persistence-id-gap-timeout = 4 seconds
@@ -29,8 +28,7 @@ object EventsByPersistenceIdSpec {
     """).withFallback(CassandraLifecycle.config)
 }
 
-class EventsByPersistenceIdSpec
-  extends CassandraSpec(EventsByPersistenceIdSpec.config)
+class EventsByPersistenceIdSpec extends CassandraSpec(EventsByPersistenceIdSpec.config)
   with DirectWriting {
 
   val noMsgTimeout = 100.millis

--- a/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
@@ -13,14 +13,14 @@ import akka.persistence.cassandra.EventWithMetaData
 import akka.persistence.journal.Tagged
 
 object TestActor {
-  def props(persistenceId: String): Props =
-    Props(new TestActor(persistenceId))
+  def props(persistenceId: String, journalId: String = "cassandra-journal"): Props =
+    Props(new TestActor(persistenceId, journalId))
 
   final case class PersistAll(events: immutable.Seq[String])
   final case class DeleteTo(seqNr: Long)
 }
 
-class TestActor(override val persistenceId: String) extends PersistentActor {
+class TestActor(override val persistenceId: String, override val journalPluginId: String) extends PersistentActor {
 
   var lastDelete: ActorRef = _
 
@@ -47,7 +47,7 @@ class TestActor(override val persistenceId: String) extends PersistentActor {
       val size = events.size
       val handler = {
         var count = 0
-        (evt: String) => {
+        evt: String => {
           count += 1
           if (count == size)
             sender() ! "PersistAll-done"

--- a/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
@@ -4,7 +4,6 @@
 
 package akka.persistence.cassandra.query.javadsl
 
-import akka.actor.Props
 import akka.persistence.cassandra.query.{ TestActor, javadsl, scaladsl }
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec }
 import akka.persistence.journal.{ Tagged, WriteEventAdapter }
@@ -44,7 +43,7 @@ class CassandraReadJournalSpec extends CassandraSpec(CassandraReadJournalSpec.co
 
   "Cassandra Read Journal Java API" must {
     "start eventsByPersistenceId query" in {
-      val a = system.actorOf(Props(new TestActor("a")))
+      val a = system.actorOf(TestActor.props("a"))
       a ! "a-1"
       expectMsg("a-1-done")
 
@@ -56,7 +55,7 @@ class CassandraReadJournalSpec extends CassandraSpec(CassandraReadJournalSpec.co
     }
 
     "start current eventsByPersistenceId query" in {
-      val a = system.actorOf(Props(new TestActor("b")))
+      val a = system.actorOf(TestActor.props("b"))
       a ! "b-1"
       expectMsg("b-1-done")
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -47,7 +47,7 @@ class CassandraReadJournalSpec extends CassandraSpec(CassandraReadJournalSpec.co
 
   "Cassandra Read Journal Scala API" must {
     "start eventsByPersistenceId query" in {
-      val a = system.actorOf(Props(new TestActor("a")))
+      val a = system.actorOf(TestActor.props("a"))
       a ! "a-1"
       expectMsg("a-1-done")
 
@@ -59,7 +59,7 @@ class CassandraReadJournalSpec extends CassandraSpec(CassandraReadJournalSpec.co
     }
 
     "start current eventsByPersistenceId query" in {
-      val a = system.actorOf(Props(new TestActor("b")))
+      val a = system.actorOf(TestActor.props("b"))
       a ! "b-1"
       expectMsg("b-1-done")
 


### PR DESCRIPTION
* Disable fast forward for recovery queries
* Delivery duplicates, previously they fell into either a fast-forward
case when it was not a fast-forward or a missing sequence nr search that
wasn't needed

Fixes #372