### PR TITLE
Improve performance of deletes over many partitions, #384

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -403,7 +403,8 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
   }
 
   private def delete(persistenceId: String, toSequenceNr: Long): Future[Unit] = {
-    def physicalDelete(lowestPartition: Long, highestPartition: Long, toSeqNr: Long): Unit = {
+
+    def physicalDelete(lowestPartition: Long, highestPartition: Long, toSeqNr: Long): Future[Done] = {
       if (config.cassandra2xCompat) {
         def asyncDeleteMessages(partitionNr: Long, messageIds: Seq[MessageId]): Future[Unit] = {
           val boundStatements = messageIds.map(mid =>
@@ -414,59 +415,58 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
         }
 
         val partitionInfos = (lowestPartition to highestPartition).map(partitionInfo(persistenceId, _, toSeqNr))
-        partitionInfos.map(future => future.flatMap(pi => {
-          Future.sequence((pi.minSequenceNr to pi.maxSequenceNr).grouped(config.maxMessageBatchSize).map {
-            group =>
-              {
-                val delete = asyncDeleteMessages(pi.partitionNr, group map (MessageId(persistenceId, _)))
-                delete.failed.foreach { e =>
-                  log.warning(s"Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
-                    "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
-                    "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
+        val deleteResult =
+          Future.sequence(partitionInfos.map(future => future.flatMap(pi => {
+            Future.sequence((pi.minSequenceNr to pi.maxSequenceNr).grouped(config.maxMessageBatchSize).map {
+              group =>
+                {
+                  val groupDeleteResult = asyncDeleteMessages(pi.partitionNr, group map (MessageId(persistenceId, _)))
+                  groupDeleteResult.failed.foreach { e =>
+                    log.warning(s"Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
+                      "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
+                      "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
+                  }
+                  groupDeleteResult
                 }
-                delete
-              }
-          })
-        }))
+            })
+          })))
+        deleteResult.map(_ => Done)
 
       } else {
-        Future.sequence((lowestPartition to highestPartition).map { partitionNr =>
+        val deleteResult = Future.sequence((lowestPartition to highestPartition).map { partitionNr =>
           val boundDeleteMessages = preparedDeleteMessages.map(_.bind(persistenceId, partitionNr: JLong, toSeqNr: JLong))
           boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
-        }).failed.foreach { e =>
+        })
+        deleteResult.failed.foreach { e =>
           log.warning("Unable to complete deletes for persistence id {}, toSequenceNr {}. " +
             "The plugin will continue to function correctly but you will need to manually delete the old messages. " +
             "Caused by: [{}: {}]", persistenceId, toSequenceNr, e.getClass.getName, e.getMessage)
         }
+        deleteResult.map(_ => Done)
       }
     }
 
     /**
      * Deletes the events by inserting into the metadata table deleted_to
      * and physically deletes the rows.
-     *
-     * The Future completes once the logical delete is complete as
-     * that is when future reads won't see the events.
      */
-    def logicalDeleteWithAsyncPhysicalDelete(highestDeletedSequenceNumber: Long, highestSequenceNr: Long): Future[Done] = {
+    def logicalAndPhysicalDelete(highestDeletedSequenceNumber: Long, highestSequenceNr: Long): Future[Done] = {
       val lowestPartition = partitionNr(highestDeletedSequenceNumber + 1, config.targetPartitionSize)
       val toSeqNr = math.min(toSequenceNr, highestSequenceNr)
       val highestPartition = partitionNr(toSeqNr, config.targetPartitionSize) + 1 // may have been moved to the next partition
       val logicalDelete =
         if (toSeqNr <= highestDeletedSequenceNumber) {
           // already deleted same or higher sequence number, don't update highestDeletedSequenceNumber,
-          // but perform the physical delete (again), may be a retry request since to may fail
+          // but perform the physical delete (again), may be a retry request
           Future.successful(())
         } else {
           val boundInsertDeletedTo = preparedInsertDeletedTo.map(_.bind(persistenceId, toSeqNr: JLong))
           boundInsertDeletedTo.flatMap(session.executeWrite)
         }
-      // Done async as the plugin won't see the events once the logical delete is complete
-      logicalDelete.foreach(_ => physicalDelete(lowestPartition, highestPartition, toSeqNr))
-      logicalDelete.map(_ => Done)
+      logicalDelete.flatMap(_ => physicalDelete(lowestPartition, highestPartition, toSeqNr))
     }
 
-    val logicalDelete = for {
+    val deleteResult = for {
       highestDeletedSequenceNumber <- asyncHighestDeletedSequenceNumber(persistenceId)
       highestSequenceNr <- {
         // MaxValue may be used as magic value to delete all events without specifying actual toSequenceNr
@@ -475,13 +475,13 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal
         else
           Future.successful(toSequenceNr)
       }
-      _ <- logicalDeleteWithAsyncPhysicalDelete(highestDeletedSequenceNumber, highestSequenceNr)
+      _ <- logicalAndPhysicalDelete(highestDeletedSequenceNumber, highestSequenceNr)
     } yield ()
 
-    // Kick off any pending deletes when finished. The physical deletes can work concurrently.
-    logicalDelete.onComplete { result => self ! DeleteFinished(persistenceId, toSequenceNr, result) }
+    // Kick off any pending deletes when finished.
+    deleteResult.onComplete { result => self ! DeleteFinished(persistenceId, toSequenceNr, result) }
 
-    logicalDelete
+    deleteResult
   }
 
   private def partitionInfo(persistenceId: String, partitionNr: Long, maxSequenceNr: Long): Future[PartitionInfo] = {

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -38,6 +38,7 @@ object CassandraLifecycle {
     akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
     cassandra-journal.circuit-breaker.call-timeout = 30s
     akka.test.single-expect-default = 20s
+    akka.test.filter-leeway = 20s
     akka.actor.serialize-messages=on
     """
     )

--- a/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
@@ -22,6 +22,7 @@ object MultiPluginSpec {
   val config = ConfigFactory.parseString(
     s"""
        |akka.test.single-expect-default = 20s
+       |akka.test.filter-leeway = 20s
        |
        |cassandra-journal.keyspace = $journalKeyspace
        |cassandra-journal.keyspace-autocreate=false


### PR DESCRIPTION
* The lowest sequence number is always the stored highestDeletedSequenceNumber,
  instead of 1
* Use the given toSequenceNumber as highest instead of searching for highest,
  but Long.MaxValue can be used for deleting all events without knowing the
  highest
* The main problem was that it was searching for highest sequence number in
  all partitions.

Refs #384