### PR TITLE
Akka and Cassandra driver update

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ val akkaPersistenceCassandraDependencies = Seq(
   "com.typesafe.akka"      %% "akka-persistence-tck"                % AkkaVersion     % "test",
   "com.typesafe.akka"      %% "akka-stream-testkit"                 % AkkaVersion     % "test",
   "ch.qos.logback"          % "logback-classic"                     % "1.2.3"         % "test",
-  "org.scalatest"          %% "scalatest"                           % "3.0.4"         % "test",
+  "org.scalatest"          %% "scalatest"                           % "3.0.5"         % "test",
   "org.pegdown"             % "pegdown"                             % "1.6.0"         % "test",
   "org.osgi"                % "org.osgi.core"                       % "5.0.0"         % "provided"
 )

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ import sbt.Keys._
 import sbtassembly.AssemblyPlugin.autoImport._
 import net.virtualvoid.optimizer._
 
-val AkkaVersion = "2.5.13"
+val AkkaVersion = "2.5.16"
 
 val akkaPersistenceCassandraDependencies = Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.3.1",

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ import net.virtualvoid.optimizer._
 val AkkaVersion = "2.5.16"
 
 val akkaPersistenceCassandraDependencies = Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.3.1",
+  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.6.0",
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
   "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query"              % AkkaVersion,


### PR DESCRIPTION
- Akka 2.5.16 
- Cassandra Driver Core 3.6.0 https://github.com/datastax/java-driver/tree/3.x/changelog
- Scalatest 3.0.5