### PR TITLE
Add sequence nr starting point for snapshot metadata query

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
@@ -10,6 +10,7 @@ import akka.Done
 import akka.persistence.SnapshotMetadata
 import akka.persistence.cassandra.journal.FixedRetryPolicy
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import com.datastax.driver.core.PreparedStatement
 import com.datastax.driver.core.policies.LoggingRetryPolicy
 
 import scala.concurrent.{ ExecutionContext, Future }
@@ -22,7 +23,7 @@ trait CassandraSnapshotCleanup extends CassandraStatements {
 
   private lazy val deleteRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(snapshotConfig.deleteRetries))
 
-  def preparedDeleteSnapshot = session.prepare(deleteSnapshot).map(
+  def preparedDeleteSnapshot: Future[PreparedStatement] = session.prepare(deleteSnapshot).map(
     _.setConsistencyLevel(snapshotConfig.writeConsistency).setIdempotent(true).setRetryPolicy(deleteRetryPolicy)
   )
 

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -65,7 +65,8 @@ trait CassandraStatements {
   def selectSnapshotMetadata(limit: Option[Int] = None) = s"""
       SELECT persistence_id, sequence_nr, timestamp FROM ${tableName} WHERE
         persistence_id = ? AND
-        sequence_nr <= ?
+        sequence_nr <= ? AND
+        sequence_nr >= ?
         ${limit.map(l => s"LIMIT ${l}").getOrElse("")}
     """
 

--- a/core/src/test/scala/akka/persistence/cassandra/Persister.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/Persister.scala
@@ -5,7 +5,7 @@
 package akka.persistence.cassandra
 
 import akka.actor.ActorRef
-import akka.persistence.{ PersistentActor, SaveSnapshotFailure, SaveSnapshotSuccess, SnapshotOffer }
+import akka.persistence._
 import akka.persistence.cassandra.Persister._
 
 object Persister {
@@ -14,6 +14,8 @@ object Persister {
   case object GetSnapshot
   case object SnapshotAck
   case object SnapshotNack
+  case class DeleteSnapshot(sequenceNr: Long)
+  case class DeleteSnapshots(sequenceNr: Long)
 }
 
 class Persister(override val persistenceId: String, probe: Option[ActorRef] = None) extends PersistentActor {
@@ -21,11 +23,12 @@ class Persister(override val persistenceId: String, probe: Option[ActorRef] = No
 
   var snapshot: Option[Any] = None
   var snapshotAck: Option[ActorRef] = None
+  var deleteSnapshotAck: Option[ActorRef] = None
 
   override def receiveRecover: Receive = {
     case SnapshotOffer(_, s) =>
       snapshot = Some(s)
-    case msg => probe.foreach(_ ! msg)
+    case msg               => probe.foreach(_ ! msg)
   }
   override def receiveCommand: Receive = {
     case GetSnapshot =>
@@ -39,6 +42,19 @@ class Persister(override val persistenceId: String, probe: Option[ActorRef] = No
     case SaveSnapshotFailure(_, _) =>
       snapshotAck.foreach(_ ! SnapshotNack)
       snapshotAck = None
+    case DeleteSnapshot(nr) =>
+      deleteSnapshot(nr)
+      deleteSnapshotAck = Some(sender())
+    case DeleteSnapshots(nr) =>
+      deleteSnapshots(SnapshotSelectionCriteria(maxSequenceNr = nr))
+      deleteSnapshotAck = Some(sender())
+    case DeleteSnapshotsSuccess(cri) =>
+      deleteSnapshotAck.foreach(_ ! cri)
+    case DeleteSnapshotSuccess(cri) =>
+      deleteSnapshotAck.foreach(_ ! cri)
+      deleteSnapshotAck = None
+    case DeleteSnapshotFailure(m, c) =>
+      println(s"$m -> $c")
     case msg => persist(msg) { _ =>
       probe.foreach(_ ! msg)
     }


### PR DESCRIPTION
No functional difference but will stop reading over tombstones
that are before the min sequence nr of the snapshot criteria.

I tried to create a test re-producer but it isn't deterministic and tombstones don't happen unless memtables are flushed.