### PR TITLE
Add lower boundaries for delete messages query

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -241,6 +241,7 @@ trait CassandraStatements {
       DELETE FROM ${tableName} WHERE
         persistence_id = ? AND
         partition_nr = ? AND
+        sequence_nr >= 0 AND
         sequence_nr <= ?
     """
   }


### PR DESCRIPTION
This fixing #395. Adding lower boundaries for delete messages query give the ability to delete them from ScyllaDB as well.