### PR TITLE
Compatibility check for ScyllaDB 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,45 @@
+version: 2
+jobs:
+  build:
+    working_directory: ~/repo
+
+    environment:
+      TERM: dumb
+      CASSANDRA_MODE: external
+      AKKA_TEST_TIMEFACTOR: 10
+
+    docker:
+      - image: bartektomala/scala-sbt:8u181_2.12.6_0.13.17
+
+      - image: scylladb/scylla:2.2.0
+        command: --listen-address 0.0.0.0 --broadcast-rpc-address 0.0.0.0 --experimental 1
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          name: Restoring sbt cache
+          keys:
+            - sbt
+
+      - run:
+          name: Update sbt cache
+          command: sbt update
+
+      - save_cache:
+          name: Save updated sbt cache
+          key: sbt
+          paths:
+            - "/root/.sbt"
+            - "/root/.ivy2"
+
+      - run:
+          name: tests
+          command: |
+            sbt ';set testOptions in Global += Tests.Argument(TestFrameworks.ScalaTest, "-u", "./target/xml-reports/scylladb");test'
+
+      - store_test_results:
+          path: ./target/xml-reports
+
+      - store_artifacts:
+          path: ./target/test-reports

--- a/README.md
+++ b/README.md
@@ -224,6 +224,10 @@ ScyllaDB
 
 **This project is not continuously tested against ScyllaDB.**
 
+Some of tests are run on CircleCI in External mode only.
+
+[![CircleCI](https://circleci.com/gh/btomala/akka-persistence-cassandra.svg?style=svg)](https://circleci.com/gh/btomala/akka-persistence-cassandra)
+
 ScyllaDB is a wire compatible replacement for Cassandra. You can run the tests
 by setting `akka.persistence.cassandra.CassandraLifecycle.mode = External` and having a ScyllaDB instance accessible on localhost port 9042.
 Initial testing shows that there are issues when using Scylla with persistent query which is also used for recovery. Users

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ ScyllaDB
 
 Some of tests are run on CircleCI in External mode only.
 
-[![CircleCI](https://circleci.com/gh/btomala/akka-persistence-cassandra.svg?style=svg)](https://circleci.com/gh/btomala/akka-persistence-cassandra)
+[![CircleCI](https://circleci.com/gh/akka/akka-persistence-cassandra.svg?style=svg)](https://circleci.com/gh/btomala/akka-persistence-cassandra)
 
 ScyllaDB is a wire compatible replacement for Cassandra. You can run the tests
 by setting `akka.persistence.cassandra.CassandraLifecycle.mode = External` and having a ScyllaDB instance accessible on localhost port 9042.


### PR DESCRIPTION
Hi, I run tests with ScyllaDB in External mode on CircleCI. Only what you need is to turn on the CircleCI integration, is free for FOSS.

Here [![CircleCI](https://circleci.com/gh/btomala/akka-persistence-cassandra.svg?style=svg)](https://circleci.com/gh/btomala/akka-persistence-cassandra) you can see how it looks like; there is a short report from tests. I also publish as an artefact HTML report which is more detailed, but it is only available for the project owner.

For now, there are two permanently failing tests and two which are flaky.

I hope this will help integrate plugin with ScyllaDB.