### PR TITLE
Remove internal state for tag writer when persistent actor shuts down

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -186,7 +186,7 @@ class EventsByTagMigration(system: ActorSystem)
           val startingSeqFut = tagScanningStartingSequenceNr(pid)
           for {
             tp <- lookupTagProgress(pid)
-            _ <- sendTagProgress(pid, tp, tagWriters)
+            _ <- persistenceIdStarting(pid, tp, tagWriters, system.deadLetters)
             startingSeq <- startingSeqFut
           } yield (tp, startingSeq)
         }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -43,12 +43,14 @@ trait CassandraRecovery extends CassandraTagRecovery
     max:            Long)(replayCallback: PersistentRepr => Unit): Future[Unit] = {
     log.debug("Recovering pid {} from {} to {}", persistenceId, fromSequenceNr, toSequenceNr)
 
+    val persistentActor = sender()
+
     if (config.eventsByTagEnabled) {
       val recoveryPrep: Future[Map[String, TagProgress]] = {
         val scanningSeqNrFut = tagScanningStartingSequenceNr(persistenceId)
         for {
           tp <- lookupTagProgress(persistenceId)
-          _ <- sendTagProgress(persistenceId, tp, tagWrites.get)
+          _ <- persistenceIdStarting(persistenceId, tp, tagWrites.get, persistentActor)
           scanningSeqNr <- scanningSeqNrFut
           _ <- sendPreSnapshotTagWrites(scanningSeqNr, fromSequenceNr, persistenceId, max, tp)
         } yield tp
@@ -126,7 +128,7 @@ trait CassandraRecovery extends CassandraTagRecovery
   }
 
   // TODO migrate this to using raw, maybe after offering a way to migrate old events in message?
-  private def sendMissingTagWrite(tp: Map[Tag, TagProgress], to: ActorRef)(tpr: TaggedPersistentRepr): Future[TaggedPersistentRepr] = {
+  private def sendMissingTagWrite(tp: Map[Tag, TagProgress], tagWriters: ActorRef)(tpr: TaggedPersistentRepr): Future[TaggedPersistentRepr] = {
     if (tpr.tags.isEmpty) Future.successful(tpr)
     else {
       val completed: List[Future[Done]] =
@@ -136,12 +138,12 @@ trait CassandraRecovery extends CassandraTagRecovery
               tp.get(tag) match {
                 case None =>
                   log.debug("Tag write not in progress. Sending to TagWriter. Tag {} Sequence Nr {}.", tag, tpr.sequenceNr)
-                  to ! TagWrite(tag, serialized :: Nil)
+                  tagWriters ! TagWrite(tag, serialized :: Nil)
                   Done
                 case Some(progress) =>
                   if (tpr.sequenceNr > progress.sequenceNr) {
                     log.debug("Sequence nr > than write progress. Sending to TagWriter. Tag {} Sequence Nr {}. ", tag, tpr.sequenceNr)
-                    to ! TagWrite(tag, serialized :: Nil)
+                    tagWriters ! TagWrite(tag, serialized :: Nil)
                   }
                   Done
               }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -72,7 +72,7 @@ import scala.concurrent.duration._
   private case object FlushKey
   sealed trait TagWriteFinished
   final case class TagWriteDone(summary: TagWriteSummary, doneNotify: Option[ActorRef]) extends TagWriteFinished
-  private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[Serialized], previousTagSequenceNrs: Map[String, Long]) extends TagWriteFinished
+  private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[(Serialized, TagPidSequenceNr)]) extends TagWriteFinished
 
   private[akka] case class DropState(pid: PersistenceId)
 
@@ -109,9 +109,9 @@ import scala.concurrent.duration._
     log.debug("Running TagWriter for [{}] with settings {}", tag, settings)
   }
 
-  override def receive: Receive = idle(Vector.empty[Serialized], Map.empty[String, Long])
+  override def receive: Receive = idle(Vector.empty[(Serialized, TagPidSequenceNr)], Map.empty[String, Long])
 
-  private def idle(buffer: Vector[Serialized], tagPidSequenceNrs: Map[PersistenceId, TagPidSequenceNr]): Receive = {
+  private def idle(buffer: Vector[(Serialized, TagPidSequenceNr)], tagPidSequenceNrs: Map[PersistenceId, TagPidSequenceNr]): Receive = {
     case DropState(pid) =>
       log.debug("Dropping state for pid: {}", pid)
       context.become(idle(buffer, tagPidSequenceNrs - pid))
@@ -124,7 +124,7 @@ import scala.concurrent.duration._
       if (buffer.nonEmpty) {
         // FIXME, this should br broken into batches https://github.com/akka/akka-persistence-cassandra/issues/405
         log.debug("External flush request. Flushing.")
-        write(buffer, Vector.empty[Serialized], tagPidSequenceNrs, Some(sender()))
+        write(buffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagPidSequenceNrs, Some(sender()))
       } else {
         log.debug("External flush request, buffer empty.")
         sender() ! FlushComplete
@@ -132,40 +132,43 @@ import scala.concurrent.duration._
     case TagWrite(_, payload) =>
       // FIXME, keeping this sorted is over kill. We only need to know if a new timebucket is
       // reached to force a flush or that the batch size is met
-      flushIfRequired((buffer ++ payload).sortBy(_.timeUuid)(timeUuidOrdering), tagPidSequenceNrs)
+      val (newTagPidSequenceNrs, events) = assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
+      log.debug("Assigned tag pid sequence nrs: {}", events)
+      val newBuffer = (buffer ++ events).sortBy(_._1.timeUuid)(timeUuidOrdering)
+      flushIfRequired(newBuffer, newTagPidSequenceNrs)
     case twd: TagWriteDone =>
       log.error("Received Done when in idle state. This is a bug. Please report with DEBUG logs: {}", twd)
     case ResetPersistenceId(_, tp @ TagProgress(pid, _, tagPidSequenceNr)) =>
-      log.debug("Resetting persistence id {}. TagProgress {}", pid, tp)
-      become(idle(buffer.filterNot(_.persistenceId == pid), tagPidSequenceNrs + (pid -> tagPidSequenceNr)))
+      log.debug("Resetting pid {}. TagProgress {}", pid, tp)
+      become(idle(buffer.filterNot(_._1.persistenceId == pid), tagPidSequenceNrs + (pid -> tagPidSequenceNr)))
       sender() ! ResetPersistenceIdComplete
   }
 
   private def writeInProgress(
-    buffer:             Vector[Serialized],
-    tagPidSequenceNrs:  Map[PersistenceId, TagPidSequenceNr],
-    updatedTagProgress: Map[PersistenceId, TagPidSequenceNr],
-    awaitingFlush:      Option[ActorRef]                     = None): Receive = {
+    buffer:            Vector[(Serialized, TagPidSequenceNr)],
+    tagPidSequenceNrs: Map[PersistenceId, TagPidSequenceNr],
+    awaitingFlush:     Option[ActorRef]                       = None): Receive = {
     case DropState(pid) =>
       log.debug("Dropping state for pid: [{}]", pid)
-      become(writeInProgress(buffer, tagPidSequenceNrs - pid, updatedTagProgress - pid, awaitingFlush))
+      become(writeInProgress(buffer, tagPidSequenceNrs - pid, awaitingFlush))
     case InternalFlush =>
     // Ignore, we will check when the write is done
     case Flush =>
       log.debug("External flush while write in progress. Will flush after write complete")
-      become(writeInProgress(buffer, tagPidSequenceNrs, updatedTagProgress, Some(sender())))
+      become(writeInProgress(buffer, tagPidSequenceNrs, Some(sender())))
     case TagWrite(_, payload) =>
+      val (updatedTagPidSequenceNrs, events) = assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
       val now = System.nanoTime()
       if (buffer.size > (4 * settings.maxBatchSize) && now > (lastLoggedBufferNs + bufferWarningMinDurationNs)) {
         lastLoggedBufferNs = now
         log.warning("Buffer for tagged events is getting too large ({}), is Cassandra responsive? Are writes failing? " +
-          "If events are buffered for longer than the eventual-consistency-delay they won't be picked up by live queries. The oldest event in the buffer is offset: {}", buffer.size, formatOffset(buffer.head.timeUuid))
+          "If events are buffered for longer than the eventual-consistency-delay they won't be picked up by live queries. The oldest event in the buffer is offset: {}", buffer.size, formatOffset(buffer.head._1.timeUuid))
       }
       // buffer until current query is finished
-      // Don't sort until the write has finished
-      become(writeInProgress(buffer ++ payload, tagPidSequenceNrs, updatedTagProgress))
+      // Don't sort until the write has finishe
+      become(writeInProgress(buffer ++ events, updatedTagPidSequenceNrs))
     case TagWriteDone(summary, doneNotify) =>
-      val sortedBuffer = buffer.sortBy(_.timeUuid)(timeUuidOrdering)
+      val sortedBuffer = buffer.sortBy(_._1.timeUuid)(timeUuidOrdering)
       log.debug("Tag write done: {}", summary)
       summary.foreach {
         case (id, PidProgress(_, seqNrTo, tagPidSequenceNr, offset)) =>
@@ -188,40 +191,39 @@ import scala.concurrent.duration._
         log.debug("External flush request")
         if (sortedBuffer.nonEmpty) {
           // FIXME, break into batches
-          write(sortedBuffer, Vector.empty[Serialized], tagPidSequenceNrs ++ updatedTagProgress, awaitingFlush)
+          write(sortedBuffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagPidSequenceNrs, awaitingFlush)
         } else {
           sender() ! FlushComplete
-          context.become(idle(sortedBuffer, tagPidSequenceNrs ++ updatedTagProgress))
+          context.become(idle(sortedBuffer, tagPidSequenceNrs))
         }
       } else {
-        flushIfRequired(sortedBuffer, tagPidSequenceNrs ++ updatedTagProgress)
+        flushIfRequired(sortedBuffer, tagPidSequenceNrs)
       }
       pubsub.foreach {
         _.mediator ! DistributedPubSubMediator.Publish("akka.persistence.cassandra.journal.tag", tag)
       }
       doneNotify.foreach(_ ! FlushComplete)
 
-    case TagWriteFailed(t, events, previousTagPidSequenceNrs) =>
+    case TagWriteFailed(t, events) =>
       log.warning("Writing tags has failed. This means that any eventsByTag query will be out of date. " +
         "The write will be retried. Reason {}", t)
-      log.debug("Setting tag sequence nrs back to {}", previousTagPidSequenceNrs)
       timers.startSingleTimer(FlushKey, InternalFlush, settings.flushInterval)
       parent ! TagWriters.TagWriteFailed(t)
-      context.become(idle(events ++ buffer, previousTagPidSequenceNrs ++ updatedTagProgress))
+      context.become(idle(events ++ buffer, tagPidSequenceNrs))
 
     case ResetPersistenceId(_, tp @ TagProgress(pid, _, _)) =>
       log.debug("Resetting persistence id {}. TagProgress {}", pid, tp)
-      become(writeInProgress(buffer.filterNot(_.persistenceId == pid), tagPidSequenceNrs, updatedTagProgress + (pid -> tp.pidTagSequenceNr)))
+      become(writeInProgress(buffer.filterNot(_._1.persistenceId == pid), tagPidSequenceNrs + (pid -> tp.pidTagSequenceNr)))
       sender() ! ResetPersistenceIdComplete
   }
 
-  private def flushIfRequired(buffer: Vector[Serialized], tagSequenceNrs: Map[String, Long]): Unit = {
+  private def flushIfRequired(buffer: Vector[(Serialized, TagPidSequenceNr)], tagSequenceNrs: Map[String, Long]): Unit = {
     if (buffer.isEmpty) {
       context.become(idle(buffer, tagSequenceNrs))
-    } else if (buffer.head.timeBucket < buffer.last.timeBucket) {
-      val (currentBucket, rest) = buffer.span(_.timeBucket == buffer.head.timeBucket)
+    } else if (buffer.head._1.timeBucket < buffer.last._1.timeBucket) {
+      val (currentBucket, rest) = buffer.span(_._1.timeBucket == buffer.head._1.timeBucket)
       if (log.isDebugEnabled) {
-        log.debug("Switching time buckets: head: {} last: {}. Number in current bucket: {}", buffer.head.timeBucket, buffer.last.timeBucket, currentBucket.size)
+        log.debug("Switching time buckets: head: {} last: {}. Number in current bucket: {}", buffer.head._1.timeBucket, buffer.last._1.timeBucket, currentBucket.size)
       }
 
       if (currentBucket.size > settings.maxBatchSize) {
@@ -235,7 +237,7 @@ import scala.concurrent.duration._
     } else if (settings.flushInterval == Duration.Zero) {
       log.debug("Flushing right away as interval is zero")
       // Should always be a buffer of 1
-      write(buffer, Vector.empty[Serialized], tagSequenceNrs)
+      write(buffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagSequenceNrs)
     } else {
       timers.startSingleTimer(FlushKey, InternalFlush, settings.flushInterval)
       context.become(idle(buffer, tagSequenceNrs))
@@ -260,34 +262,33 @@ import scala.concurrent.duration._
    * Events should be ordered by sequence nr per pid
    */
   private def write(
-    events:                 Vector[Serialized],
-    remainingBuffer:        Vector[Serialized],
-    existingTagSequenceNrs: Map[Tag, TagPidSequenceNr],
-    notifyWhenDone:         Option[ActorRef]           = None): Unit = {
-    val (newTagSequenceNrs, withPidTagSeqNr) = assignTagPidSequenceNumbers(events, existingTagSequenceNrs)
-    val writeSummary = createTagWriteSummary(withPidTagSeqNr, events)
+    events:            Vector[(Serialized, TagPidSequenceNr)],
+    remainingBuffer:   Vector[(Serialized, TagPidSequenceNr)],
+    tagPidSequenceNrs: Map[String, TagPidSequenceNr],
+    notifyWhenDone:    Option[ActorRef]                       = None): Unit = {
+    val writeSummary = createTagWriteSummary(events)
     log.debug("Starting tag write of {} events. Summary: {}", events.size, writeSummary)
-    val withFailure = session.writeBatch(tag, withPidTagSeqNr)
+    val withFailure = session.writeBatch(tag, events)
       .map(_ => TagWriteDone(writeSummary, notifyWhenDone))
       .recover {
         case NonFatal(t) =>
-          TagWriteFailed(t, events, existingTagSequenceNrs)
+          TagWriteFailed(t, events)
       }
 
     import context.dispatcher
     withFailure pipeTo self
 
-    context.become(writeInProgress(remainingBuffer, newTagSequenceNrs, Map.empty[String, Long]))
+    context.become(writeInProgress(remainingBuffer, tagPidSequenceNrs))
   }
 
-  private def createTagWriteSummary(writes: Seq[(Serialized, TagPidSequenceNr)], events: Vector[Serialized]): Map[PersistenceId, PidProgress] = {
+  private def createTagWriteSummary(writes: Seq[(Serialized, TagPidSequenceNr)]): Map[PersistenceId, PidProgress] = {
     writes.foldLeft(Map.empty[PersistenceId, PidProgress])((acc, next) => {
       val (event, tagPidSequenceNr) = next
       acc.get(event.persistenceId) match {
         case Some(PidProgress(from, to, _, _)) =>
           if (event.sequenceNr <= to)
             throw new IllegalStateException(s"Expected events to be ordered by seqNr. ${event.persistenceId} " +
-              s"Events: ${events.map(e => (e.persistenceId, e.sequenceNr, e.timeUuid))}")
+              s"Events: ${writes.map(e => (e._1.persistenceId, e._1.sequenceNr, e._1.timeUuid))}")
           acc + (event.persistenceId -> PidProgress(from, event.sequenceNr, tagPidSequenceNr, event.timeUuid))
         case None =>
           acc + (event.persistenceId -> PidProgress(event.sequenceNr, event.sequenceNr, tagPidSequenceNr, event.timeUuid))

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
@@ -10,7 +10,6 @@ import akka.Done
 import akka.persistence.SnapshotMetadata
 import akka.persistence.cassandra.journal.FixedRetryPolicy
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
-import com.datastax.driver.core.PreparedStatement
 import com.datastax.driver.core.policies.LoggingRetryPolicy
 
 import scala.concurrent.{ ExecutionContext, Future }

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -9,7 +9,6 @@ import scala.collection.immutable
 import com.typesafe.config.Config
 import akka.persistence.cassandra.CassandraPluginConfig
 import akka.actor.ActorSystem
-import akka.persistence.cassandra.journal.CassandraJournalConfig
 
 class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) {
   val maxLoadAttempts = config.getInt("max-load-attempts")

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -84,6 +84,8 @@ abstract class CassandraSpec(config: Config, val journalName: String = getCaller
 
   lazy val randomPort = SocketUtil.temporaryLocalPort()
 
+  val shortWait = 10.millis
+
   lazy val queryJournal = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
 
   override def port(): Int = CassandraLifecycle.mode match {

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -23,7 +23,7 @@ object EventsByTagRecoverySpec {
   val config = ConfigFactory.parseString(
     s"""
        |akka {
-       |  loglevel = INFO
+       |  loglevel = DEBUG
        |  actor.debug.unhandled = on
        |}
        |cassandra-journal {
@@ -75,7 +75,7 @@ class EventsByTagRecoverySpec extends CassandraSpec(EventsByTagRecoverySpec.conf
           expectMsg(Ack)
         }
         p1 ! PoisonPill
-
+        system.log.info("Starting p1 on other actor system")
         val p1take2 = system.actorOf(TestTaggingActor.props("p1", Set("blue")))
         (5 to 8) foreach { i =>
           p1take2 ! s"e-$i"

--- a/core/src/test/scala/akka/persistence/cassandra/TestTaggingActor.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/TestTaggingActor.scala
@@ -15,7 +15,7 @@ object TestTaggingActor {
   case object Stop
 
   def props(pId: String, tags: Set[String] = Set(), probe: Option[ActorRef] = None): Props =
-    Props(classOf[TestTaggingActor], pId, tags, probe)
+    Props(new TestTaggingActor(pId, tags, probe))
 }
 
 class TestTaggingActor(val persistenceId: String, tags: Set[String], probe: Option[ActorRef]) extends PersistentActor with ActorLogging {

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -16,7 +16,6 @@ import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, TestTaggingActor, _ }
 import akka.serialization.SerializationExtension
 import com.typesafe.config.ConfigFactory
-import scala.concurrent.duration._
 import scala.concurrent.{ ExecutionContext, Future }
 
 object CassandraEventUpdateSpec {
@@ -30,8 +29,6 @@ class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.co
 
   private[akka] val log = Logging(system, getClass)
   private val serialization = SerializationExtension(system)
-
-  val shortWait = 10.millis
 
   val updater = new CassandraEventUpdate {
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.6


### PR DESCRIPTION
* Removes tag pid sequence nr state from each TagWriter
* Removes sequenceNrs which was there for debugging messages from the
journal that came out of order. This has never happend since initial
version.