### PR TITLE
Move session to a separate module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,80 +1,10 @@
 import sbt.Keys._
 import sbtassembly.AssemblyPlugin.autoImport._
 
-val AkkaVersion = "2.5.23"
-val CassandraVersionInDocs = "4.0"
-
-val akkaCassandraSessionDependencies = Seq(
-  "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
-  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test)
-
-val akkaPersistenceCassandraDependencies = Seq(
-  "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
-  // Specifying guava dependency because older transitive dependency has security vulnerability
-  "com.google.guava" % "guava" % "27.0.1-jre",
-  // Specifying jnr-posix version for licensing reasons: cassandra-driver-core
-  // depends on version 3.0.44, but for this version the LICENSE.txt and the
-  // pom.xml have conflicting licensing information. 3.0.45 fixes this and
-  // makes it clear this library is available under (among others) the EPL
-  "com.github.jnr" % "jnr-posix" % "3.0.45",
-  "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
-  "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test,
-  "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion % Test,
-  "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
-  "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test,
-  "org.pegdown" % "pegdown" % "1.6.0" % Test,
-  "org.osgi" % "org.osgi.core" % "5.0.0" % Provided)
-
-def common: Seq[Setting[_]] =
-  Seq(
-    organization := "com.typesafe.akka",
-    organizationName := "Lightbend Inc.",
-    startYear := Some(2016),
-    licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
-    crossScalaVersions := Seq("2.12.8", "2.13.0-RC2"),
-    scalaVersion := crossScalaVersions.value.last,
-    crossVersion := CrossVersion.binary,
-    scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlint", "-Ywarn-dead-code", "-deprecation"),
-    scalacOptions ++= {
-      // define scalac options that are only valid or desirable for 2.12
-      if (scalaVersion.value.startsWith("2.13"))
-        Seq()
-      else
-        Seq(
-          // -deprecation causes some warnings on 2.13 because of collection converters.
-          // We only enable `fatal-warnings` on 2.12 and accept the warning on 2.13
-          "-Xfatal-warnings",
-          "-Xfuture" // invalid in 2.13
-        )
-    },
-    Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
-    Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
-    headerLicense := Some(
-        HeaderLicense.Custom("""Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>""")),
-    scalafmtOnCompile := true,
-    releaseCrossBuild := true,
-    logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
-    // show full stack traces and test case durations
-    testOptions in Test += Tests.Argument("-oDF"),
-    // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
-    // -a Show stack traces and exception class name for AssertionErrors.
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-    // disable parallel tests
-    parallelExecution in Test := false)
-
 lazy val root = (project in file("."))
-  .enablePlugins(ScalaUnidocPlugin)
+  .enablePlugins(Common, ScalaUnidocPlugin)
   .disablePlugins(SitePlugin)
   .aggregate(core, cassandraLauncher, session)
-  .settings(common: _*)
   .settings(
     name := "akka-persistence-cassandra-root",
     publishArtifact := false,
@@ -83,16 +13,14 @@ lazy val root = (project in file("."))
     PgpKeys.publishSigned := {})
 
 lazy val session = (project in file("session"))
-  .enablePlugins(AutomateHeaderPlugin, SbtOsgi)
+  .enablePlugins(Common, AutomateHeaderPlugin, SbtOsgi)
   .dependsOn(cassandraLauncher % Test)
-  .settings(common: _*)
   .settings(osgiSettings: _*)
-  .settings(name := "akka-cassandra-session", libraryDependencies ++= akkaCassandraSessionDependencies)
+  .settings(name := "akka-cassandra-session", libraryDependencies ++= Dependencies.akkaCassandraSessionDependencies)
 
 lazy val core = (project in file("core"))
-  .enablePlugins(AutomateHeaderPlugin, SbtOsgi, MultiJvmPlugin)
+  .enablePlugins(Common, AutomateHeaderPlugin, SbtOsgi, MultiJvmPlugin)
   .dependsOn(cassandraLauncher % Test, session)
-  .settings(common: _*)
   .settings(osgiSettings: _*)
   .settings({
     val silencerVersion = "1.4.0"
@@ -105,7 +33,7 @@ lazy val core = (project in file("core"))
   })
   .settings(
     name := "akka-persistence-cassandra",
-    libraryDependencies ++= akkaPersistenceCassandraDependencies,
+    libraryDependencies ++= Dependencies.akkaPersistenceCassandraDependencies,
     OsgiKeys.exportPackage := Seq("akka.persistence.cassandra.*"),
     OsgiKeys.importPackage := Seq(akkaImport(), optionalImport("org.apache.cassandra.*"), "*"),
     OsgiKeys.privatePackage := Nil,
@@ -115,7 +43,7 @@ lazy val core = (project in file("core"))
   .configs(MultiJvm)
 
 lazy val cassandraLauncher = (project in file("cassandra-launcher"))
-  .settings(common: _*)
+  .enablePlugins(Common)
   .settings(
     name := "akka-persistence-cassandra-launcher",
     managedResourceDirectories in Compile += (target in cassandraBundle).value / "bundle",
@@ -124,8 +52,7 @@ lazy val cassandraLauncher = (project in file("cassandra-launcher"))
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers
 // resources
 lazy val cassandraBundle = (project in file("cassandra-bundle"))
-  .enablePlugins(AutomateHeaderPlugin)
-  .settings(common: _*)
+  .enablePlugins(Common, AutomateHeaderPlugin)
   .settings(
     name := "akka-persistence-cassandra-bundle",
     crossPaths := false,
@@ -137,7 +64,7 @@ lazy val cassandraBundle = (project in file("cassandra-bundle"))
     assemblyJarName in assembly := "cassandra-bundle.jar")
 
 lazy val docs = project
-  .enablePlugins(AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
+  .enablePlugins(Common, AkkaParadoxPlugin, ParadoxSitePlugin, PreprocessPlugin, PublishRsyncPlugin)
   .settings(
     name := "Akka Persistence Cassandra",
     publish / skip := true,
@@ -150,13 +77,13 @@ lazy val docs = project
     Preprocess / preprocessRules := Seq(("\\.java\\.scala".r, _ => ".java")),
     Paradox / siteSubdirName := s"docs/akka-persistence-cassandra/${if (isSnapshot.value) "snapshot" else version.value}",
     paradoxProperties ++= Map(
-        "akka.version" -> AkkaVersion,
+        "akka.version" -> Dependencies.AkkaVersion,
         // Akka
-        "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${AkkaVersion}/%s",
-        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${AkkaVersion}/",
-        "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${AkkaVersion}/",
+        "extref.akka.base_url" -> s"https://doc.akka.io/docs/akka/${Dependencies.AkkaVersion}/%s",
+        "scaladoc.akka.base_url" -> s"https://doc.akka.io/api/akka/${Dependencies.AkkaVersion}/",
+        "javadoc.akka.base_url" -> s"https://doc.akka.io/japi/akka/${Dependencies.AkkaVersion}/",
         // Cassandra
-        "extref.cassandra.base_url" -> s"https://cassandra.apache.org/doc/${CassandraVersionInDocs}/%s",
+        "extref.cassandra.base_url" -> s"https://cassandra.apache.org/doc/${Dependencies.CassandraVersionInDocs}/%s",
         // Java
         "javadoc.base_url" -> "https://docs.oracle.com/javase/8/docs/api/",
         // Scala

--- a/build.sbt
+++ b/build.sbt
@@ -5,10 +5,9 @@ val AkkaVersion = "2.5.23"
 val CassandraVersionInDocs = "4.0"
 
 val akkaCassandraSessionDependencies = Seq(
-  "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.7.1",
-  "com.typesafe.akka"      %% "akka-stream"                    % AkkaVersion,
-  "com.typesafe.akka"      %% "akka-stream-testkit"                 % AkkaVersion     % Test
-)
+  "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
+  "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+  "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test)
 
 val akkaPersistenceCassandraDependencies = Seq(
   "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
@@ -32,57 +31,41 @@ val akkaPersistenceCassandraDependencies = Seq(
   "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
   "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test,
   "org.pegdown" % "pegdown" % "1.6.0" % Test,
-  "org.osgi" % "org.osgi.core" % "5.0.0" % Provided
-)
+  "org.osgi" % "org.osgi.core" % "5.0.0" % Provided)
 
-def common: Seq[Setting[_]] = Seq(
-  organization := "com.typesafe.akka",
-  organizationName := "Lightbend Inc.",
-  startYear := Some(2016),
-  licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
-  crossScalaVersions := Seq("2.12.8", "2.13.0-RC2"),
-  scalaVersion := crossScalaVersions.value.last,
-  crossVersion := CrossVersion.binary,
-  scalacOptions ++= Seq(
-    "-encoding",
-    "UTF-8",
-    "-feature",
-    "-unchecked",
-    "-Xlint",
-    "-Ywarn-dead-code",
-    "-deprecation"
-  ),
-  scalacOptions ++= {
-    // define scalac options that are only valid or desirable for 2.12
-    if (scalaVersion.value.startsWith("2.13"))
-      Seq(
-      )
-    else
-      Seq(
-        // -deprecation causes some warnings on 2.13 because of collection converters. 
-        // We only enable `fatal-warnings` on 2.12 and accept the warning on 2.13
-        "-Xfatal-warnings", 
-        "-Xfuture", // invalid in 2.13
-      )
-  },
-  Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
-  Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
-  headerLicense := Some(
-    HeaderLicense.Custom(
-      """Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>"""
-    )),
-  scalafmtOnCompile := true,
-  releaseCrossBuild := true,
-  logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
-  // show full stack traces and test case durations
-  testOptions in Test += Tests.Argument("-oDF"),
-  // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
-  // -a Show stack traces and exception class name for AssertionErrors.
-  testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
-  // disable parallel tests
-  parallelExecution in Test := false)
-
-
+def common: Seq[Setting[_]] =
+  Seq(
+    organization := "com.typesafe.akka",
+    organizationName := "Lightbend Inc.",
+    startYear := Some(2016),
+    licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
+    crossScalaVersions := Seq("2.11.12", "2.13.0-M5", "2.12.8"),
+    scalaVersion := crossScalaVersions.value.last,
+    crossVersion := CrossVersion.binary,
+    scalacOptions ++= Seq(
+        "-encoding",
+        "UTF-8",
+        "-feature",
+        "-unchecked",
+        "-deprecation",
+        "-Xlint",
+        "-Ywarn-dead-code",
+        "-Xfuture",
+        "-Xfatal-warnings"),
+    Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
+    Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
+    headerLicense := Some(
+        HeaderLicense.Custom("""Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>""")),
+    scalafmtOnCompile := true,
+    releaseCrossBuild := true,
+    logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
+    // show full stack traces and test case durations
+    testOptions in Test += Tests.Argument("-oDF"),
+    // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
+    // -a Show stack traces and exception class name for AssertionErrors.
+    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
+    // disable parallel tests
+    parallelExecution in Test := false)
 
 lazy val root = (project in file("."))
   .enablePlugins(ScalaUnidocPlugin)
@@ -92,22 +75,16 @@ lazy val root = (project in file("."))
   .settings(
     name := "akka-persistence-cassandra-root",
     publishArtifact := false,
-    publishTo := Some(
-      Resolver.file("Unused transient repository", file("target/unusedrepo"))),
+    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))),
     publish := {},
-    PgpKeys.publishSigned := {}
-  )
+    PgpKeys.publishSigned := {})
 
 lazy val session = (project in file("session"))
   .enablePlugins(AutomateHeaderPlugin, SbtOsgi)
-  .dependsOn(
-    cassandraLauncher % Test)
+  .dependsOn(cassandraLauncher % Test)
   .settings(common: _*)
   .settings(osgiSettings: _*)
-  .settings(
-     name := "akka-cassandra-session",
-     libraryDependencies ++=  akkaCassandraSessionDependencies
-  )
+  .settings(name := "akka-cassandra-session", libraryDependencies ++= akkaCassandraSessionDependencies)
 
 lazy val core = (project in file("core"))
   .enablePlugins(AutomateHeaderPlugin, SbtOsgi, MultiJvmPlugin)
@@ -118,24 +95,20 @@ lazy val core = (project in file("core"))
     val silencerVersion = "1.4.0"
     Seq(
       libraryDependencies ++= Seq(
-        compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion),
-        "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided),
+          compilerPlugin("com.github.ghik" %% "silencer-plugin" % silencerVersion),
+          "com.github.ghik" %% "silencer-lib" % silencerVersion % Provided),
       // Hack because 'provided' dependencies by default are not picked up by the multi-jvm plugin:
-      managedClasspath in MultiJvm ++= (managedClasspath in Compile).value.filter(_.data.name.contains("silencer-lib"))
-      )
+      managedClasspath in MultiJvm ++= (managedClasspath in Compile).value.filter(_.data.name.contains("silencer-lib")))
   })
   .settings(
     name := "akka-persistence-cassandra",
     libraryDependencies ++= akkaPersistenceCassandraDependencies,
     OsgiKeys.exportPackage := Seq("akka.persistence.cassandra.*"),
-    OsgiKeys.importPackage := Seq(akkaImport(),
-                                  optionalImport("org.apache.cassandra.*"),
-                                  "*"),
+    OsgiKeys.importPackage := Seq(akkaImport(), optionalImport("org.apache.cassandra.*"), "*"),
     OsgiKeys.privatePackage := Nil,
     testOptions in Test ++= Seq(
-      Tests.Argument(TestFrameworks.ScalaTest, "-o"),
-      Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test-reports"))
-  )
+        Tests.Argument(TestFrameworks.ScalaTest, "-o"),
+        Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test-reports")))
   .configs(MultiJvm)
 
 lazy val cassandraLauncher = (project in file("cassandra-launcher"))
@@ -143,8 +116,7 @@ lazy val cassandraLauncher = (project in file("cassandra-launcher"))
   .settings(
     name := "akka-persistence-cassandra-launcher",
     managedResourceDirectories in Compile += (target in cassandraBundle).value / "bundle",
-    managedResources in Compile += (assembly in cassandraBundle).value
-  )
+    managedResources in Compile += (assembly in cassandraBundle).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers
 // resources

--- a/cassandra-launcher/src/main/scala/akka/persistence/cassandra/testkit/CassandraLauncher.scala
+++ b/cassandra-launcher/src/main/scala/akka/persistence/cassandra/testkit/CassandraLauncher.scala
@@ -118,7 +118,7 @@ object CassandraLauncher {
         }
       }
       .distinct
-      .to[immutable.Seq]
+      .toList
       .filterNot(_.endsWith("assembly.jar")) // TODO required?
   }
 

--- a/cassandra-launcher/src/main/scala/akka/persistence/cassandra/testkit/CassandraLauncher.scala
+++ b/cassandra-launcher/src/main/scala/akka/persistence/cassandra/testkit/CassandraLauncher.scala
@@ -118,8 +118,8 @@ object CassandraLauncher {
         }
       }
       .distinct
-      .toList
-      .filterNot(_.endsWith("assembly.jar"))
+      .to[immutable.Seq]
+      .filterNot(_.endsWith("assembly.jar")) // TODO required?
   }
 
   /**

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -27,7 +27,7 @@ cassandra-journal {
   # Will be ignored if the contact point list is defined by host:port pairs.
   port = 9042
 
-  # The implementation of akka.persistence.cassandra.SessionProvider
+  # The implementation of akka.cassandra.session.SessionProvider
   # is used for creating the Cassandra Session. By default the 
   # the ConfigSessionProvider is building the Cluster from configuration properties
   # but it is possible to replace the implementation of the SessionProvider
@@ -379,7 +379,7 @@ cassandra-snapshot-store {
   # Will be ignored if the contact point list is defined by host:port pairs.
   port = 9042
 
-  # The implementation of akka.persistence.cassandra.SessionProvider
+  # The implementation of akka.cassandra.session.SessionProvider
   # is used for creating the Cassandra Session. By default the
   # the ConfigSessionProvider is building the Cluster from configuration properties
   # but it is possible to replace the implementation of the SessionProvider

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -10,7 +10,7 @@ import com.typesafe.config.Config
 
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
-import akka.persistence.cassandra.session.CassandraSessionSettings
+import akka.cassandra.session.{ CassandraSessionSettings, SessionProvider }
 
 case class StorePathPasswordConfig(path: String, password: String)
 

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -29,8 +29,8 @@ class CassandraPluginConfig(system: ActorSystem, config: Config) {
   val metadataTable: String = config.getString("metadata-table")
   val configTable: String = validateTableName(config.getString("config-table"))
 
-  val tableCompactionStrategy: CassandraCompactionStrategy = CassandraCompactionStrategy(
-    config.getConfig("table-compaction-strategy"))
+  val tableCompactionStrategy: CassandraCompactionStrategy =
+    CassandraCompactionStrategy(config.getConfig("table-compaction-strategy"))
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
   val tablesAutoCreate: Boolean = config.getBoolean("tables-autocreate")

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -29,8 +29,8 @@ class CassandraPluginConfig(system: ActorSystem, config: Config) {
   val metadataTable: String = config.getString("metadata-table")
   val configTable: String = validateTableName(config.getString("config-table"))
 
-  val tableCompactionStrategy: CassandraCompactionStrategy =
-    CassandraCompactionStrategy(config.getConfig("table-compaction-strategy"))
+  val tableCompactionStrategy: CassandraCompactionStrategy = CassandraCompactionStrategy(
+    config.getConfig("table-compaction-strategy"))
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
   val tablesAutoCreate: Boolean = config.getBoolean("tables-autocreate")

--- a/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -139,12 +139,14 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
 
       val truststorePath = config.getString("ssl.truststore.path")
       if (truststorePath != "") {
-        val trustStore = StorePathPasswordConfig(truststorePath, config.getString("ssl.truststore.password"))
+        val trustStore =
+          StorePathPasswordConfig(truststorePath, config.getString("ssl.truststore.password"))
 
         val keystorePath = config.getString("ssl.keystore.path")
         val keyStore: Option[StorePathPasswordConfig] =
           if (keystorePath != "") {
-            val keyStore = StorePathPasswordConfig(keystorePath, config.getString("ssl.keystore.password"))
+            val keyStore =
+              StorePathPasswordConfig(keystorePath, config.getString("ssl.keystore.password"))
             Some(keyStore)
           } else None
 

--- a/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -15,6 +15,8 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
 import akka.actor.ActorSystem
+import akka.cassandra.session.SessionProvider
+import akka.cassandra.session._
 import com.datastax.driver.core._
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
 import com.datastax.driver.core.policies.ExponentialReconnectionPolicy
@@ -47,7 +49,7 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
         case Some(logger) => cluster.register(logger)
         case None         =>
       }
-      cluster.connectAsync()
+      cluster.connectAsync().asScala
     }
   }
 

--- a/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -139,14 +139,12 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
 
       val truststorePath = config.getString("ssl.truststore.path")
       if (truststorePath != "") {
-        val trustStore =
-          StorePathPasswordConfig(truststorePath, config.getString("ssl.truststore.password"))
+        val trustStore = StorePathPasswordConfig(truststorePath, config.getString("ssl.truststore.password"))
 
         val keystorePath = config.getString("ssl.keystore.path")
         val keyStore: Option[StorePathPasswordConfig] =
           if (keystorePath != "") {
-            val keyStore =
-              StorePathPasswordConfig(keystorePath, config.getString("ssl.keystore.password"))
+            val keyStore = StorePathPasswordConfig(keystorePath, config.getString("ssl.keystore.password"))
             Some(keyStore)
           } else None
 

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -17,7 +17,7 @@ import akka.persistence.cassandra.journal._
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.RawEvent
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors.Extractor
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.query.PersistenceQuery
 import akka.serialization.SerializationExtension
 import akka.stream.{ ActorMaterializer, OverflowStrategy }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -7,7 +7,7 @@ package akka.persistence.cassandra.journal
 import akka.Done
 import akka.event.LoggingAdapter
 import akka.persistence.cassandra.journal.CassandraJournal.{ Serialized, TagPidSequenceNr }
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import com.datastax.driver.core.{ PreparedStatement, Row, Statement }
 
 import scala.collection.JavaConverters._

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -523,11 +523,12 @@ class CassandraJournal(cfg: Config)
         deleteResult.map(_ => Done)
 
       } else {
-        val deleteResult = Future.sequence((lowestPartition to highestPartition).map { partitionNr =>
-          val boundDeleteMessages =
-            preparedDeleteMessages.map(_.bind(persistenceId, partitionNr: JLong, toSeqNr: JLong))
-          boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
-        })
+        val deleteResult =
+          Future.sequence((lowestPartition to highestPartition).map { partitionNr =>
+            val boundDeleteMessages =
+              preparedDeleteMessages.map(_.bind(persistenceId, partitionNr: JLong, toSeqNr: JLong))
+            boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
+          })
         deleteResult.failed.foreach { e =>
           log.warning(
             "Unable to complete deletes for persistence id {}, toSequenceNr {}. " +

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -18,6 +18,7 @@ import akka.actor.NoSerializationVerificationNeeded
 import akka.actor.OneForOneStrategy
 import akka.actor.SupervisorStrategy
 import akka.annotation.{ DoNotInherit, InternalApi }
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.event.{ Logging, LoggingAdapter }
 import akka.persistence._
 import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
@@ -25,7 +26,6 @@ import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.TagWriters.{ BulkTagWrite, TagWrite, TagWritersSession }
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.journal.{ AsyncWriteJournal, Tagged }
 import akka.persistence.query.PersistenceQuery
 import akka.serialization.{ AsyncSerializer, Serialization, SerializationExtension }
@@ -38,6 +38,7 @@ import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
 import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
 import com.datastax.driver.core.utils.{ Bytes, UUIDs }
 import com.typesafe.config.Config
+import akka.cassandra.session._
 
 import scala.collection.JavaConverters._
 import scala.collection.immutable
@@ -98,7 +99,8 @@ class CassandraJournal(cfg: Config)
     context.dispatcher,
     log,
     metricsCategory = s"${self.path.name}",
-    init = session => executeCreateKeyspaceAndTables(session, config))
+    init = (session: Session) =>
+      executeCreateKeyspaceAndTables(session, config))
 
   private val tagWriterSession = TagWritersSession(
     () => preparedWriteToTagViewWithoutMeta,
@@ -667,7 +669,7 @@ class CassandraJournal(cfg: Config)
       .setRetryPolicy(retryPolicy)
       .asInstanceOf[BatchStatement]
     body(batch)
-    session.underlying().flatMap(_.executeAsync(batch)).map(_ => ())
+    session.underlying().flatMap(_.executeAsync(batch).asScala).map(_ => ())
   }
 
   private def minSequenceNr(partitionNr: Long): Long =

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -99,8 +99,7 @@ class CassandraJournal(cfg: Config)
     context.dispatcher,
     log,
     metricsCategory = s"${self.path.name}",
-    init = (session: Session) =>
-      executeCreateKeyspaceAndTables(session, config))
+    init = (session: Session) => executeCreateKeyspaceAndTables(session, config))
 
   private val tagWriterSession = TagWritersSession(
     () => preparedWriteToTagViewWithoutMeta,
@@ -524,12 +523,11 @@ class CassandraJournal(cfg: Config)
         deleteResult.map(_ => Done)
 
       } else {
-        val deleteResult =
-          Future.sequence((lowestPartition to highestPartition).map { partitionNr =>
-            val boundDeleteMessages =
-              preparedDeleteMessages.map(_.bind(persistenceId, partitionNr: JLong, toSeqNr: JLong))
-            boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
-          })
+        val deleteResult = Future.sequence((lowestPartition to highestPartition).map { partitionNr =>
+          val boundDeleteMessages =
+            preparedDeleteMessages.map(_.bind(persistenceId, partitionNr: JLong, toSeqNr: JLong))
+          boundDeleteMessages.flatMap(execute(_, deleteRetryPolicy))
+        })
         deleteResult.failed.foreach { e =>
           log.warning(
             "Unable to complete deletes for persistence id {}, toSequenceNr {}. " +

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -15,6 +15,7 @@ import akka.persistence.cassandra.query.EventsByPersistenceIdStage.{ Extractors,
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.OptionVal
 import scala.concurrent._
+import akka.cassandra.session._
 
 trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatements {
   this: CassandraJournal =>

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -312,7 +312,8 @@ trait CassandraStatements {
         } else FutureDone
 
       val keyspace: Future[Done] =
-        if (config.keyspaceAutoCreate) session.executeAsync(createKeyspace).asScala.map(_ => Done)
+        if (config.keyspaceAutoCreate)
+          session.executeAsync(createKeyspace).asScala.map(_ => Done)
         else Future.successful(Done)
 
       if (config.tablesAutoCreate) {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -5,11 +5,10 @@
 package akka.persistence.cassandra.journal
 
 import akka.Done
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import com.datastax.driver.core.Session
-import scala.concurrent.{ ExecutionContext, Future }
 
-import akka.persistence.cassandra.FutureDone
+import scala.concurrent.{ ExecutionContext, Future }
 import akka.persistence.cassandra.indent
 
 trait CassandraStatements {
@@ -299,29 +298,28 @@ trait CassandraStatements {
    */
   private[akka] def executeCreateKeyspaceAndTables(session: Session, config: CassandraJournalConfig)(
       implicit ec: ExecutionContext): Future[Done] = {
-    import akka.persistence.cassandra.listenableFutureToFuture
+    import akka.cassandra.session._
 
     def create(): Future[Done] = {
 
       def tagStatements: Future[Done] =
         if (config.eventsByTagEnabled) {
           for {
-            _ <- session.executeAsync(createTagsTable)
-            _ <- session.executeAsync(createTagsProgressTable)
-            _ <- session.executeAsync(createTagScanningTable)
+            _ <- session.executeAsync(createTagsTable).asScala
+            _ <- session.executeAsync(createTagsProgressTable).asScala
+            _ <- session.executeAsync(createTagScanningTable).asScala
           } yield Done
         } else FutureDone
 
       val keyspace: Future[Done] =
-        if (config.keyspaceAutoCreate)
-          session.executeAsync(createKeyspace).map(_ => Done)
+        if (config.keyspaceAutoCreate) session.executeAsync(createKeyspace).asScala.map(_ => Done)
         else Future.successful(Done)
 
       if (config.tablesAutoCreate) {
         for {
           _ <- keyspace
-          _ <- session.executeAsync(createTable)
-          _ <- session.executeAsync(createMetadataTable)
+          _ <- session.executeAsync(createTable).asScala
+          _ <- session.executeAsync(createMetadataTable).asScala
           done <- tagStatements
         } yield done
       } else keyspace

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
@@ -4,7 +4,7 @@
 
 package akka.persistence.cassandra.journal
 
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import com.datastax.driver.core.PreparedStatement
 
 import scala.concurrent.{ ExecutionContext, Future }

--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -42,8 +42,13 @@ package object cassandra {
     timestampFormatter.format(time)
   }
 
-  def serializeEvent(p: PersistentRepr, tags: Set[String], uuid: UUID,
-                     bucketSize: BucketSize, serialization: Serialization, system: ActorSystem)(implicit executionContext: ExecutionContext): Future[Serialized] = {
+  def serializeEvent(
+      p: PersistentRepr,
+      tags: Set[String],
+      uuid: UUID,
+      bucketSize: BucketSize,
+      serialization: Serialization,
+      system: ActorSystem)(implicit executionContext: ExecutionContext): Future[Serialized] = {
     try {
       // use same clock source as the UUID for the timeBucket
       val timeBucket = TimeBucket(UUIDs.unixTimestamp(uuid), bucketSize)
@@ -110,6 +115,7 @@ package object cassandra {
     } catch {
       case NonFatal(e) => Future.failed(e)
     }
+  }
 
   /**
    * INTERNAL API

--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -48,7 +48,7 @@ package object cassandra {
       uuid: UUID,
       bucketSize: BucketSize,
       serialization: Serialization,
-      system: ActorSystem)(implicit executionContext: ExecutionContext): Future[Serialized] = {
+      system: ActorSystem)(implicit executionContext: ExecutionContext): Future[Serialized] =
     try {
       // use same clock source as the UUID for the timeBucket
       val timeBucket = TimeBucket(UUIDs.unixTimestamp(uuid), bucketSize)
@@ -115,7 +115,6 @@ package object cassandra {
     } catch {
       case NonFatal(e) => Future.failed(e)
     }
-  }
 
   /**
    * INTERNAL API

--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -30,29 +30,7 @@ import akka.Done
 import akka.annotation.InternalApi
 
 package object cassandra {
-  private val timestampFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS")
-
-  // TODO we should use the more explicit ListenableFutureConverter asScala instead
-  implicit def listenableFutureToFuture[A](lf: ListenableFuture[A])(
-      implicit executionContext: ExecutionContext): Future[A] = {
-    val promise = Promise[A]
-    lf.addListener(new Runnable {
-      def run() = promise.complete(Try(lf.get()))
-    }, executionContext.asInstanceOf[Executor])
-    promise.future
-  }
-
-  implicit class ListenableFutureConverter[A](val lf: ListenableFuture[A]) extends AnyVal {
-    def asScala(implicit ec: ExecutionContext): Future[A] = {
-      val promise = Promise[A]
-      lf.addListener(new Runnable {
-        def run() = promise.complete(Try(lf.get()))
-      }, ec.asInstanceOf[Executor])
-      promise.future
-    }
-  }
-
+  private val timestampFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss:SSS")
   def formatOffset(uuid: UUID): String = {
     val time = LocalDateTime.ofInstant(Instant.ofEpochMilli(UUIDs.unixTimestamp(uuid)), ZoneOffset.UTC)
     s"$uuid (${timestampFormatter.format(time)})"
@@ -64,15 +42,8 @@ package object cassandra {
     timestampFormatter.format(time)
   }
 
-  val FutureDone: Future[Done] = Future.successful(Done)
-
-  def serializeEvent(
-      p: PersistentRepr,
-      tags: Set[String],
-      uuid: UUID,
-      bucketSize: BucketSize,
-      serialization: Serialization,
-      system: ActorSystem)(implicit executionContext: ExecutionContext): Future[Serialized] =
+  def serializeEvent(p: PersistentRepr, tags: Set[String], uuid: UUID,
+                     bucketSize: BucketSize, serialization: Serialization, system: ActorSystem)(implicit executionContext: ExecutionContext): Future[Serialized] = {
     try {
       // use same clock source as the UUID for the timeBucket
       val timeBucket = TimeBucket(UUIDs.unixTimestamp(uuid), bucketSize)

--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -8,16 +8,12 @@ import java.nio.ByteBuffer
 import java.time.{ Instant, LocalDateTime, ZoneOffset }
 import java.time.format.DateTimeFormatter
 import java.util.UUID
-import java.util.concurrent.Executor
 
 import akka.persistence.cassandra.journal.{ BucketSize, TimeBucket }
 import akka.persistence.cassandra.journal.CassandraJournal.{ Serialized, SerializedMeta }
 import akka.serialization.Serialization
 import com.datastax.driver.core.utils.UUIDs
-import com.google.common.util.concurrent.ListenableFuture
 import scala.concurrent._
-import scala.language.implicitConversions
-import scala.util.Try
 import scala.util.control.NonFatal
 import scala.collection.JavaConverters._
 import com.typesafe.config.{ Config, ConfigValueType }
@@ -26,7 +22,6 @@ import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
 import akka.serialization.AsyncSerializer
 import akka.serialization.Serializers
-import akka.Done
 import akka.annotation.InternalApi
 
 package object cassandra {

--- a/core/src/main/scala/akka/persistence/cassandra/query/AllPersistenceIdsPublisher.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/AllPersistenceIdsPublisher.scala
@@ -8,7 +8,6 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import akka.actor.Props
 import com.datastax.driver.core.{ PreparedStatement, ResultSet, Row, Session }
-import akka.persistence.cassandra._
 import akka.persistence.cassandra.query.AllPersistenceIdsPublisher._
 import akka.persistence.cassandra.query.QueryActorPublisher._
 import akka.actor.NoSerializationVerificationNeeded
@@ -69,9 +68,10 @@ import akka.annotation.InternalApi
     requestNext(state, resultSet)
 
   private[this] def query(state: AllPersistenceIdsState): Future[Action] = {
+    import akka.cassandra.session._
     val boundStatement = session.selectDistinctPersistenceIds.bind()
     boundStatement.setFetchSize(config.fetchSize)
 
-    listenableFutureToFuture(session.session.executeAsync(boundStatement)).map(Finished)
+    session.session.executeAsync(boundStatement).asScala.map(Finished)
   }
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -12,10 +12,10 @@ import java.util.concurrent.ThreadLocalRandom
 import akka.Done
 import akka.annotation.InternalApi
 import akka.persistence.PersistentRepr
-import akka.persistence.cassandra.ListenableFutureConverter
 import akka.persistence.cassandra.journal.CassandraJournal.{ EventDeserializer, Serialized }
 import akka.serialization.Serialization
 import akka.stream.{ Attributes, Outlet, SourceShape }
+import akka.cassandra.session._
 import akka.stream.stage._
 import com.datastax.driver.core._
 import com.datastax.driver.core.policies.RetryPolicy

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -322,6 +322,7 @@ import com.datastax.driver.core.utils.UUIDs
               s"lookingForMissingCalled for tag ${session.tag} when there " +
               s"is no missing. Raise a bug with debug logging.")
         }
+
         if (missing.deadline.isOverdue()) {
           if (missing.failIfNotFound) {
             fail(

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -13,6 +13,7 @@ import akka.persistence.cassandra.journal.{ BucketSize, TimeBucket }
 import akka.persistence.cassandra.query.EventsByTagStage._
 import akka.stream.stage.{ GraphStage, _ }
 import akka.stream.{ ActorMaterializer, Attributes, Outlet, SourceShape }
+import akka.cassandra.session._
 import akka.util.PrettyDuration._
 
 import scala.annotation.tailrec

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -464,7 +464,7 @@ import com.datastax.driver.core.utils.UUIDs
           false
         } else if (repr.tagPidSequenceNr > expectedSequenceNr) {
           log.info(
-            s"[${stageUuid}] [{}]: Missing event for persistence id: [{}]. Expected sequence nr: [{}], actual: [{}].",
+            s"[${stageUuid}] " + "{}: Missing event for persistence id: {}. Expected sequence nr: {}, actual: {}.",
             session.tag,
             pid,
             expectedSequenceNr,
@@ -488,7 +488,7 @@ import com.datastax.driver.core.utils.UUIDs
           // this is per row so put behind a flag. Per query logging is on at debug without this flag
           if (verboseDebug)
             log.debug(
-              s"[${stageUuid}] Updating offset to [{}] from pId [{}] seqNr [{}] tagPidSequenceNr [{}]",
+              s"[${stageUuid}] " + " Updating offset to {} from pId {} seqNr {} tagPidSequenceNr {}",
               formatOffset(stageState.fromOffset),
               pid,
               repr.sequenceNr,

--- a/core/src/main/scala/akka/persistence/cassandra/query/QueryActorPublisher.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/QueryActorPublisher.scala
@@ -14,7 +14,7 @@ import akka.pattern.pipe
 import akka.stream.actor.ActorPublisher
 import akka.stream.actor.ActorPublisherMessage.{ Cancel, Request, SubscriptionTimeoutExceeded }
 import com.datastax.driver.core.{ ResultSet, Row }
-import akka.persistence.cassandra._
+import akka.cassandra.session._
 import akka.persistence.cassandra.query.QueryActorPublisher._
 
 import scala.util.control.NonFatal
@@ -152,8 +152,11 @@ import com.github.ghik.silencer.silent
     val availableWithoutFetching = resultSet.getAvailableWithoutFetching
     val isFullyFetched = resultSet.isFullyFetched
 
-    if (shouldFetchMore(availableWithoutFetching, isFullyFetched, totalDemand, state, finished, continue)) {
-      listenableFutureToFuture(resultSet.fetchMoreResults()).map(FetchedResultSet).pipeTo(self)
+    if (shouldFetchMore(
+      availableWithoutFetching, isFullyFetched, totalDemand, state, finished, continue)) {
+      resultSet.fetchMoreResults().asScala
+        .map(FetchedResultSet)
+        .pipeTo(self)
       awaiting(resultSet, state, finished)
     } else if (shouldIdle(availableWithoutFetching, state)) {
       idle(resultSet, state, finished)

--- a/core/src/main/scala/akka/persistence/cassandra/query/QueryActorPublisher.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/QueryActorPublisher.scala
@@ -152,11 +152,8 @@ import com.github.ghik.silencer.silent
     val availableWithoutFetching = resultSet.getAvailableWithoutFetching
     val isFullyFetched = resultSet.isFullyFetched
 
-    if (shouldFetchMore(
-      availableWithoutFetching, isFullyFetched, totalDemand, state, finished, continue)) {
-      resultSet.fetchMoreResults().asScala
-        .map(FetchedResultSet)
-        .pipeTo(self)
+    if (shouldFetchMore(availableWithoutFetching, isFullyFetched, totalDemand, state, finished, continue)) {
+      resultSet.fetchMoreResults().asScala.map(FetchedResultSet).pipeTo(self)
       awaiting(resultSet, state, finished)
     } else if (shouldIdle(availableWithoutFetching, state)) {
       idle(resultSet, state, finished)

--- a/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
@@ -8,10 +8,10 @@ import java.lang.{ Long => JLong }
 import java.util.UUID
 
 import akka.annotation.InternalApi
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.event.Logging
 import akka.persistence.cassandra.journal.CassandraJournal._
 import akka.persistence.cassandra.journal.TimeBucket
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.cassandra.formatOffset
 import akka.stream.ActorMaterializer
 import com.datastax.driver.core.PreparedStatement
@@ -75,10 +75,10 @@ private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: 
       // Make a fake UUID for this tagPidSequenceNr that will be used to search for this tagPidSequenceNr in the unlikely
       // event that the stage can't find the event found during this scan
       doIt().map { progress =>
-        progress.map {
-          case (key, ((tagPidSequenceNr, uuid))) =>
+        progress.mapValues {
+          case (tagPidSequenceNr, uuid) =>
             val unixTime = UUIDs.unixTimestamp(uuid)
-            (key, (tagPidSequenceNr - 1, UUIDs.startOf(unixTime - 1)))
+            (tagPidSequenceNr - 1, UUIDs.startOf(unixTime - 1))
         }
       }
     })

--- a/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
@@ -75,10 +75,10 @@ private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: 
       // Make a fake UUID for this tagPidSequenceNr that will be used to search for this tagPidSequenceNr in the unlikely
       // event that the stage can't find the event found during this scan
       doIt().map { progress =>
-        progress.mapValues {
-          case (tagPidSequenceNr, uuid) =>
+        progress.map {
+          case (key, ((tagPidSequenceNr, uuid))) =>
             val unixTime = UUIDs.unixTimestamp(uuid)
-            (tagPidSequenceNr - 1, UUIDs.startOf(unixTime - 1))
+            (key, (tagPidSequenceNr - 1, UUIDs.startOf(unixTime - 1)))
         }
       }
     })

--- a/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -7,8 +7,8 @@ package akka.persistence.cassandra.query.javadsl
 import java.util.UUID
 import java.util.concurrent.CompletionStage
 
+import akka.cassandra.session.javadsl.CassandraSession
 import akka.{ Done, NotUsed }
-import akka.persistence.cassandra.session.javadsl.CassandraSession
 import akka.persistence.query.EventEnvelope
 import akka.persistence.query.Offset
 import akka.persistence.query.TimeBasedUUID

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -20,7 +20,7 @@ import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors.Ex
 import akka.persistence.cassandra.query.EventsByTagStage.TagStageSession
 import akka.persistence.cassandra.query._
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal.EventByTagStatements
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.query._
 import akka.persistence.query.scaladsl._
 import akka.persistence.{ Persistence, PersistentRepr }

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
@@ -7,9 +7,9 @@ package akka.persistence.cassandra.snapshot
 import java.lang.{ Long => JLong }
 
 import akka.Done
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.SnapshotMetadata
 import akka.persistence.cassandra.journal.FixedRetryPolicy
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import com.datastax.driver.core.policies.LoggingRetryPolicy
 
 import scala.concurrent.{ ExecutionContext, Future }

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -19,9 +19,10 @@ import akka.actor._
 import akka.persistence._
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.FixedRetryPolicy
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.serialization.Snapshot
 import akka.persistence.snapshot.SnapshotStore
+import akka.cassandra.session._
 import akka.serialization.AsyncSerializer
 import akka.serialization.Serialization
 import akka.serialization.SerializationExtension
@@ -249,7 +250,7 @@ class CassandraSnapshotStore(cfg: Config)
   def executeBatch(body: BatchStatement => Unit): Future[Unit] = {
     val batch = new BatchStatement().setConsistencyLevel(writeConsistency).asInstanceOf[BatchStatement]
     body(batch)
-    session.underlying().flatMap(_.executeAsync(batch)).map(_ => ())
+    session.underlying().flatMap(_.executeAsync(batch).asScala).map(_ => ())
   }
 
   private def serialize(payload: Any): Future[Serialized] =

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -95,10 +95,12 @@ trait CassandraStatements {
 
     def create(): Future[Done] = {
       val keyspace: Future[Done] =
-        if (config.keyspaceAutoCreate) session.executeAsync(createKeyspace).asScala.map(_ => Done)
+        if (config.keyspaceAutoCreate)
+          session.executeAsync(createKeyspace).asScala.map(_ => Done)
         else FutureDone
 
-      if (config.tablesAutoCreate) keyspace.flatMap(_ => session.executeAsync(createTable).asScala).map(_ => Done)
+      if (config.tablesAutoCreate)
+        keyspace.flatMap(_ => session.executeAsync(createTable).asScala).map(_ => Done)
       else keyspace
     }
 

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -8,9 +8,10 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 
 import akka.Done
-import akka.persistence.cassandra.FutureDone
+import akka.cassandra.session.FutureDone
+import akka.cassandra.session._
 import com.datastax.driver.core.Session
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.cassandra.indent
 
 trait CassandraStatements {
@@ -89,18 +90,14 @@ trait CassandraStatements {
    * Those statements are retried, because that could happen across different
    * nodes also but serializing those statements gives a better "experience".
    */
-  def executeCreateKeyspaceAndTables(session: Session, config: CassandraSnapshotStoreConfig)(
-      implicit ec: ExecutionContext): Future[Done] = {
-    import akka.persistence.cassandra.listenableFutureToFuture
+  def executeCreateKeyspaceAndTables(session: Session, config: CassandraSnapshotStoreConfig)(implicit ec: ExecutionContext): Future[Done] = {
 
     def create(): Future[Done] = {
       val keyspace: Future[Done] =
-        if (config.keyspaceAutoCreate)
-          session.executeAsync(createKeyspace).map(_ => Done)
+        if (config.keyspaceAutoCreate) session.executeAsync(createKeyspace).asScala.map(_ => Done)
         else FutureDone
 
-      if (config.tablesAutoCreate)
-        keyspace.flatMap(_ => session.executeAsync(createTable)).map(_ => Done)
+      if (config.tablesAutoCreate) keyspace.flatMap(_ => session.executeAsync(createTable).asScala).map(_ => Done)
       else keyspace
     }
 

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -90,7 +90,8 @@ trait CassandraStatements {
    * Those statements are retried, because that could happen across different
    * nodes also but serializing those statements gives a better "experience".
    */
-  def executeCreateKeyspaceAndTables(session: Session, config: CassandraSnapshotStoreConfig)(implicit ec: ExecutionContext): Future[Done] = {
+  def executeCreateKeyspaceAndTables(session: Session, config: CassandraSnapshotStoreConfig)(
+      implicit ec: ExecutionContext): Future[Done] = {
 
     def create(): Future[Done] = {
       val keyspace: Future[Done] =

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
@@ -23,12 +23,12 @@ import org.scalatest.BeforeAndAfterAll
 object CassandraPluginConfigSpec {
   class TestContactPointsProvider(system: ActorSystem, config: Config) extends ConfigSessionProvider(system, config) {
     override def lookupContactPoints(clusterId: String)(
-        implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] =
+        implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] = {
       if (clusterId == "cluster1")
         Future.successful(List(new InetSocketAddress("host1", 9041)))
       else
         Future.successful(List(new InetSocketAddress("host1", 9041), new InetSocketAddress("host2", 9042)))
-
+    }
   }
 }
 
@@ -37,8 +37,10 @@ class CassandraPluginConfigSpec
     with WordSpecLike
     with MustMatchers
     with BeforeAndAfterAll {
+
   import CassandraPluginConfigSpec._
   import system.dispatcher
+
   lazy val defaultConfig = ConfigFactory.load().getConfig("cassandra-journal")
 
   lazy val keyspaceNames = {
@@ -206,9 +208,9 @@ class CassandraPluginConfigSpec
     "parse config with a list of datacenters configured for NetworkTopologyStrategy" in {
       lazy val configWithNetworkStrategy =
         ConfigFactory.parseString("""
-          |replication-strategy = "NetworkTopologyStrategy"
-          |data-center-replication-factors = ["dc1:3", "dc2:2"]
-        """.stripMargin).withFallback(defaultConfig)
+            |replication-strategy = "NetworkTopologyStrategy"
+            |data-center-replication-factors = ["dc1:3", "dc2:2"]
+          """.stripMargin).withFallback(defaultConfig)
       val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
     }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
@@ -23,12 +23,11 @@ import org.scalatest.BeforeAndAfterAll
 object CassandraPluginConfigSpec {
   class TestContactPointsProvider(system: ActorSystem, config: Config) extends ConfigSessionProvider(system, config) {
     override def lookupContactPoints(clusterId: String)(
-        implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] = {
+        implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] =
       if (clusterId == "cluster1")
         Future.successful(List(new InetSocketAddress("host1", 9041)))
       else
         Future.successful(List(new InetSocketAddress("host1", 9041), new InetSocketAddress("host2", 9042)))
-    }
   }
 }
 
@@ -208,9 +207,9 @@ class CassandraPluginConfigSpec
     "parse config with a list of datacenters configured for NetworkTopologyStrategy" in {
       lazy val configWithNetworkStrategy =
         ConfigFactory.parseString("""
-            |replication-strategy = "NetworkTopologyStrategy"
-            |data-center-replication-factors = ["dc1:3", "dc2:2"]
-          """.stripMargin).withFallback(defaultConfig)
+          |replication-strategy = "NetworkTopologyStrategy"
+          |data-center-replication-factors = ["dc1:3", "dc2:2"]
+        """.stripMargin).withFallback(defaultConfig)
       val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
     }

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -12,7 +12,7 @@ import akka.Done
 import akka.event.Logging
 import akka.persistence.PersistentRepr
 import akka.persistence.cassandra.journal.CassandraJournal.Serialized
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, TestTaggingActor, _ }
 import akka.serialization.SerializationExtension
 import com.typesafe.config.ConfigFactory

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -5,12 +5,13 @@
 package akka.persistence.cassandra.journal
 
 import akka.actor.Actor
+import akka.cassandra.session.CassandraMetricsRegistry
 import akka.persistence.{ AtomicWrite, PersistentRepr }
 import akka.persistence.JournalProtocol.{ ReplayMessages, WriteMessageFailure, WriteMessages, WriteMessagesFailed }
 
 import scala.concurrent.duration._
 import akka.persistence.journal._
-import akka.persistence.cassandra.{ CassandraLifecycle, CassandraMetricsRegistry }
+import akka.persistence.cassandra.CassandraLifecycle
 import akka.testkit.TestProbe
 import com.typesafe.config.ConfigFactory
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -538,9 +538,10 @@ class EventsByTagStageSpec
       val nowTime = LocalDateTime.now(ZoneOffset.UTC)
       val tag = "CurrentOffsetMissingInInitialBucket"
 
-      val tagStream = queries.eventsByTag(
-        tag,
-        queries.timeBasedUUIDFrom(nowTime.minusSeconds(1).toInstant(ZoneOffset.UTC).toEpochMilli))
+      val tagStream =
+        queries.eventsByTag(
+          tag,
+          queries.timeBasedUUIDFrom(nowTime.minusSeconds(1).toInstant(ZoneOffset.UTC).toEpochMilli))
       val sub = tagStream.runWith(TestSink.probe[EventEnvelope])
 
       sub.request(4)

--- a/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -4,8 +4,9 @@
 
 package akka.persistence.cassandra.query.scaladsl
 
+import akka.cassandra.session.CassandraMetricsRegistry
 import akka.persistence.cassandra.query.TestActor
-import akka.persistence.cassandra.{ CassandraLifecycle, CassandraMetricsRegistry, CassandraSpec }
+import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec }
 import akka.persistence.journal.{ Tagged, WriteEventAdapter }
 import akka.persistence.query.NoOffset
 import akka.stream.testkit.scaladsl.TestSink

--- a/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
@@ -9,9 +9,10 @@ import java.util.concurrent.CompletionStage
 
 import akka.Done
 import akka.actor.ExtendedActorSystem
+import akka.cassandra.session.javadsl.CassandraSession
+import akka.cassandra.session.{ CassandraSessionSettings, SessionProvider, _ }
 import akka.event.Logging
-import akka.persistence.cassandra.session.CassandraSessionSettings
-import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, ListenableFutureConverter, SessionProvider }
+import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec }
 import akka.stream.testkit.scaladsl.TestSink
 import com.datastax.driver.core.{ BatchStatement, Session, SimpleStatement }
 import com.typesafe.config.ConfigFactory

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
@@ -7,7 +7,7 @@ package akka.persistence.cassandra.snapshot
 import akka.Done
 import akka.actor.Props
 import akka.event.Logging
-import akka.persistence.cassandra.session.scaladsl.CassandraSession
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.cassandra.{ CassandraSpec, Persister }
 import com.typesafe.config.ConfigFactory
 

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -8,10 +8,9 @@ import java.lang.{ Integer => JInteger, Long => JLong }
 import java.nio.ByteBuffer
 
 import akka.cassandra.session.CassandraMetricsRegistry
-import akka.persistence._
 import akka.persistence.SnapshotProtocol._
 import akka.persistence._
-import akka.persistence.cassandra.{ CassandraLifecycle, CassandraMetricsRegistry, SnapshotWithMetaData }
+import akka.persistence.cassandra.{ CassandraLifecycle, SnapshotWithMetaData }
 import akka.persistence.snapshot.SnapshotStoreSpec
 import akka.testkit.TestProbe
 import com.datastax.driver.core._

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -7,6 +7,8 @@ package akka.persistence.cassandra.snapshot
 import java.lang.{ Integer => JInteger, Long => JLong }
 import java.nio.ByteBuffer
 
+import akka.cassandra.session.CassandraMetricsRegistry
+import akka.persistence._
 import akka.persistence.SnapshotProtocol._
 import akka.persistence._
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraMetricsRegistry, SnapshotWithMetaData }
@@ -148,6 +150,7 @@ class CassandraSnapshotStoreSpec
       // no 4th attempt has been made
       probe.expectMsgType[LoadSnapshotFailed]
     }
+
     "store and load additional meta" in {
       val probe = TestProbe()
 
@@ -163,6 +166,7 @@ class CassandraSnapshotStoreSpec
       val loaded = probe.expectMsgPF() { case LoadSnapshotResult(Some(snapshot), _) => snapshot }
       loaded.snapshot should equal(SnapshotWithMetaData("snap", "meta"))
     }
+
     "delete all snapshots matching upper sequence number and no timestamp bounds" in {
       val probe: TestProbe = TestProbe()
       val subProbe: TestProbe = TestProbe()

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -1,0 +1,81 @@
+import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
+import de.heikoseeberger.sbtheader._
+import org.scalafmt.sbt.ScalafmtPlugin.autoImport._
+import sbt.Keys._
+import sbt._
+import sbt.plugins.JvmPlugin
+import sbtrelease.ReleasePlugin.autoImport.releaseCrossBuild
+
+object Common extends AutoPlugin {
+
+  override def trigger = allRequirements
+
+  override def requires = JvmPlugin && HeaderPlugin
+
+  override def globalSettings = Seq(
+    organization := "com.lightbend.akka",
+    organizationName := "Lightbend Inc.",
+    organizationHomepage := Some(url("https://www.lightbend.com/")),
+    startYear := Some(2016),
+    homepage := Some(url("https://akka.io")),
+    apiURL := Some(url(s"https://doc.akka.io/api/akka-persistence-cassandra/${version.value}")),
+    scmInfo := Some(
+        ScmInfo(
+          url("https://github.com/akka/akka-persistence-cassandra-1.x"),
+          "git@github.com:akka/akka-persistence-cassandra-1.x.git")),
+    developers += Developer(
+        "contributors",
+        "Contributors",
+        "https://gitter.im/akka/dev",
+        url("https://github.com/akka/akka-persistence-cassandra-1.x/graphs/contributors")),
+    licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
+    description := "A Cassandra plugin for Akka Persistence.")
+
+  override lazy val projectSettings = Seq(
+    //      projectInfoVersion := (if (isSnapshot.value) "snapshot" else version.value),
+    crossVersion := CrossVersion.binary,
+    crossScalaVersions := Dependencies.ScalaVersions,
+    scalaVersion := Dependencies.Scala212,
+    scalacOptions ++= Seq("-encoding", "UTF-8", "-feature", "-unchecked", "-Xlint", "-Ywarn-dead-code", "-deprecation"),
+    scalacOptions ++= {
+      // define scalac options that are only valid or desirable for 2.12
+      if (scalaVersion.value.startsWith("2.13"))
+        Seq()
+      else
+        Seq(
+          // -deprecation causes some warnings on 2.13 because of collection converters.
+          // We only enable `fatal-warnings` on 2.12 and accept the warning on 2.13
+          "-Xfatal-warnings",
+          "-Xfuture" // invalid in 2.13
+        )
+    },
+    Compile / console / scalacOptions --= Seq("-deprecation", "-Xfatal-warnings", "-Xlint", "-Ywarn-unused:imports"),
+    Compile / doc / scalacOptions --= Seq("-Xfatal-warnings"),
+    Compile / doc / scalacOptions := scalacOptions.value ++ Seq(
+        "-doc-title",
+        "Akka Persistence Cassandra",
+        "-doc-version",
+        version.value,
+        "-sourcepath",
+        (baseDirectory in ThisBuild).value.toString,
+        "-doc-source-url", {
+          val branch = if (isSnapshot.value) "master" else s"v${version.value}"
+          s"https://github.com/akka/akka-persistence-cassandra-1.x/tree/${branch}€{FILE_PATH}.scala#L1"
+        },
+        "-skip-packages",
+        "akka.pattern" // for some reason Scaladoc creates this
+      ),
+    scalafmtOnCompile := true,
+    releaseCrossBuild := true,
+    autoAPIMappings := true,
+    headerLicense := Some(
+        HeaderLicense.Custom("""Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>""")),
+    Test / logBuffered := System.getProperty("akka.logBufferedTests", "false").toBoolean,
+    // show full stack traces and test case durations
+    Test / testOptions += Tests.Argument("-oDF"),
+    // -a Show stack traces and exception class name for AssertionErrors.
+    // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
+    // -q Suppress stdout for successful tests.
+    Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-v", "-q"),
+    Test / parallelExecution := false)
+}

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,40 @@
+import sbt._
+import Keys._
+
+object Dependencies {
+  val Scala212 = "2.12.8"
+  val Scala213 = "2.13.0-RC2"
+  val ScalaVersions = Seq(Scala212, Scala213)
+
+  val AkkaVersion = "2.5.23"
+  val CassandraVersionInDocs = "4.0"
+
+  val akkaCassandraSessionDependencies = Seq(
+    "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
+    "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test)
+
+  val akkaPersistenceCassandraDependencies = Seq(
+    "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
+    // Specifying guava dependency because older transitive dependency has security vulnerability
+    "com.google.guava" % "guava" % "27.0.1-jre",
+    // Specifying jnr-posix version for licensing reasons: cassandra-driver-core
+    // depends on version 3.0.44, but for this version the LICENSE.txt and the
+    // pom.xml have conflicting licensing information. 3.0.45 fixes this and
+    // makes it clear this library is available under (among others) the EPL
+    "com.github.jnr" % "jnr-posix" % "3.0.45",
+    "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-cluster-typed" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test,
+    "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion % Test,
+    "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
+    "org.scalatest" %% "scalatest" % "3.0.8-RC2" % Test,
+    "org.pegdown" % "pegdown" % "1.6.0" % Test,
+    "org.osgi" % "org.osgi.core" % "5.0.0" % Provided)
+}

--- a/project/Publish.scala
+++ b/project/Publish.scala
@@ -1,6 +1,6 @@
 /**
-  * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
-  */
+ * Copyright (C) 2009-2015 Typesafe Inc. <http://www.typesafe.com>
+ */
 package akka
 
 import sbt._
@@ -29,8 +29,7 @@ object Publish extends AutoPlugin {
       false
     },
     defaultPublishTo := crossTarget.value / "repository",
-    releasePublishArtifactsAction := PgpKeys.publishSigned.value
-  )
+    releasePublishArtifactsAction := PgpKeys.publishSigned.value)
 
   def akkaPomExtra = {
     /* The scm info is automatic from the sbt-git plugin
@@ -50,24 +49,21 @@ object Publish extends AutoPlugin {
   }
 
   private def akkaPublishTo = Def.setting {
-    sonatypeRepo(version.value) orElse localRepo(defaultPublishTo.value)
+    sonatypeRepo(version.value).orElse(localRepo(defaultPublishTo.value))
   }
 
   private def sonatypeRepo(version: String): Option[Resolver] =
-    Option(sys.props("publish.maven.central")) filter (_.toLowerCase == "true") map {
-      _ =>
-        val nexus = "https://oss.sonatype.org/"
-        if (version endsWith "-SNAPSHOT")
-          "snapshots" at nexus + "content/repositories/snapshots"
-        else "releases" at nexus + "service/local/staging/deploy/maven2"
+    Option(sys.props("publish.maven.central")).filter(_.toLowerCase == "true").map { _ =>
+      val nexus = "https://oss.sonatype.org/"
+      if (version.endsWith("-SNAPSHOT"))
+        "snapshots".at(nexus + "content/repositories/snapshots")
+      else "releases".at(nexus + "service/local/staging/deploy/maven2")
     }
 
   private def localRepo(repository: File) =
     Some(Resolver.file("Default Local Repository", repository))
 
   private def akkaCredentials: Seq[Credentials] =
-    Option(System.getProperty("akka.publish.credentials", null))
-      .map(f => Credentials(new File(f)))
-      .toSeq
+    Option(System.getProperty("akka.publish.credentials", null)).map(f => Credentials(new File(f))).toSeq
 
 }

--- a/project/Whitesource.scala
+++ b/project/Whitesource.scala
@@ -20,14 +20,12 @@ object Whitesource extends AutoPlugin {
                              else "adhoc"
                            else
                              CrossVersion
-                               .partialVersion(
-                                 (version in LocalRootProject).value)
+                               .partialVersion((version in LocalRootProject).value)
                                .map {
                                  case (major, minor) => s"$major.$minor-stable"
                                }
                                .getOrElse("adhoc"))
     },
     whitesourceForceCheckAllDependencies := true,
-    whitesourceFailOnError := true
-  )
+    whitesourceFailOnError := true)
 }

--- a/session/src/main/scala/akka/cassandra/session/CassandraMetricsRegistry.scala
+++ b/session/src/main/scala/akka/cassandra/session/CassandraMetricsRegistry.scala
@@ -2,12 +2,13 @@
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.cassandra
+package akka.cassandra.session
 
 import akka.actor._
-import com.codahale.metrics.MetricRegistry
-import scala.collection.JavaConverters._
 import akka.annotation.InternalApi
+import com.codahale.metrics.MetricRegistry
+
+import scala.collection.JavaConverters._
 
 /**
  * Retrieves Cassandra metrics registry for an actor system

--- a/session/src/main/scala/akka/cassandra/session/CassandraSessionSettings.scala
+++ b/session/src/main/scala/akka/cassandra/session/CassandraSessionSettings.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.cassandra.session
+package akka.cassandra.session
 
 import java.util.concurrent.TimeUnit
 

--- a/session/src/main/scala/akka/cassandra/session/SessionProvider.scala
+++ b/session/src/main/scala/akka/cassandra/session/SessionProvider.scala
@@ -2,15 +2,14 @@
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.cassandra
+package akka.cassandra.session
 
-import scala.collection.immutable
-import scala.concurrent.Future
+import akka.actor.{ ActorSystem, ExtendedActorSystem }
 import com.datastax.driver.core.Session
 import com.typesafe.config.Config
-import scala.concurrent.ExecutionContext
-import akka.actor.ExtendedActorSystem
-import akka.actor.ActorSystem
+
+import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Failure
 
 /**

--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.cassandra.session.javadsl
+package akka.cassandra.session.javadsl
 
 import java.util.{ List => JList }
 import java.util.Optional
@@ -18,9 +18,8 @@ import scala.concurrent.ExecutionContext
 import akka.Done
 import akka.NotUsed
 import akka.actor.ActorSystem
+import akka.cassandra.session.{ CassandraSessionSettings, SessionProvider }
 import akka.event.LoggingAdapter
-import akka.persistence.cassandra.SessionProvider
-import akka.persistence.cassandra.session.CassandraSessionSettings
 import akka.stream.javadsl.Source
 import com.datastax.driver.core.BatchStatement
 import com.datastax.driver.core.PreparedStatement
@@ -38,7 +37,7 @@ import com.datastax.driver.core.Statement
  *
  * All methods are non-blocking.
  */
-final class CassandraSession(delegate: akka.persistence.cassandra.session.scaladsl.CassandraSession) {
+final class CassandraSession(delegate: akka.cassandra.session.scaladsl.CassandraSession) {
 
   /**
    * Use this constructor if you want to create a stand-alone `CassandraSession`.

--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
@@ -51,7 +51,7 @@ final class CassandraSession(delegate: akka.cassandra.session.scaladsl.Cassandra
       metricsCategory: String,
       init: JFunction[Session, CompletionStage[Done]]) =
     this(
-      new akka.persistence.cassandra.session.scaladsl.CassandraSession(
+      new akka.cassandra.session.scaladsl.CassandraSession(
         system,
         sessionProvider,
         settings,

--- a/session/src/main/scala/akka/cassandra/session/package.scala
+++ b/session/src/main/scala/akka/cassandra/session/package.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
 package akka.cassandra

--- a/session/src/main/scala/akka/cassandra/session/package.scala
+++ b/session/src/main/scala/akka/cassandra/session/package.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <http://www.lightbend.com>
+ */
+
+package akka.cassandra
+
+import java.util.concurrent.Executor
+
+import akka.Done
+import com.google.common.util.concurrent.ListenableFuture
+
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.util.Try
+
+package object session {
+
+  val FutureDone: Future[Done] = Future.successful(Done)
+
+  implicit class ListenableFutureConverter[A](val lf: ListenableFuture[A]) extends AnyVal {
+    def asScala(implicit ec: ExecutionContext): Future[A] = {
+      val promise = Promise[A]
+      lf.addListener(new Runnable {
+        def run() = promise.complete(Try(lf.get()))
+      }, ec.asInstanceOf[Executor])
+      promise.future
+    }
+  }
+
+}

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
@@ -2,7 +2,7 @@
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
-package akka.persistence.cassandra.session.scaladsl
+package akka.cassandra.session.scaladsl
 
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicReference
@@ -16,15 +16,10 @@ import scala.concurrent.Promise
 import scala.util.Failure
 import scala.util.Success
 import scala.util.control.NonFatal
-
 import akka.Done
 import akka.NotUsed
 import akka.actor.{ ActorSystem, NoSerializationVerificationNeeded }
 import akka.event.LoggingAdapter
-import akka.persistence.cassandra.CassandraMetricsRegistry
-import akka.persistence.cassandra.ListenableFutureConverter
-import akka.persistence.cassandra.SessionProvider
-import akka.persistence.cassandra.session.CassandraSessionSettings
 import akka.stream.ActorMaterializer
 import akka.stream.Attributes
 import akka.stream.Outlet
@@ -44,7 +39,8 @@ import com.datastax.driver.core.Row
 import com.datastax.driver.core.Session
 import com.datastax.driver.core.Statement
 import akka.annotation.InternalApi
-import akka.persistence.cassandra.FutureDone
+import akka.cassandra.session.{ CassandraSessionSettings, SessionProvider }
+import akka.cassandra.session._
 
 /**
  * Data Access Object for Cassandra. The statements are expressed in
@@ -94,7 +90,7 @@ final class CassandraSession(
    * Can be used in case you need to do something that is not provided by the
    * API exposed by this class. Be careful to not use blocking calls.
    */
-  final def underlying(): Future[Session] = {
+  def underlying(): Future[Session] = {
 
     def initialize(session: Future[Session]): Future[Session] =
       session.flatMap { s =>
@@ -457,7 +453,7 @@ final class CassandraSession(
 /**
  * INTERNAL API
  */
-@InternalApi private[akka] final object CassandraSession {
+@InternalApi private[akka] object CassandraSession {
   private val serializedExecutionProgress =
     new AtomicReference[Future[Done]](FutureDone)
 

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
@@ -67,20 +67,18 @@ final class CassandraSession(
   private lazy implicit val materializer = ActorMaterializer()(system)
 
   // cache of PreparedStatement (PreparedStatement should only be prepared once)
-  private val preparedStatements =
-    new ConcurrentHashMap[String, Future[PreparedStatement]]
-  private val computePreparedStatement =
-    new JFunction[String, Future[PreparedStatement]] {
-      override def apply(key: String): Future[PreparedStatement] =
-        underlying().flatMap { s =>
-          val prepared = s.prepareAsync(key).asScala
-          prepared.failed.foreach(
-            _ =>
-              // this is async, i.e. we are not updating the map from the compute function
-              preparedStatements.remove(key))
-          prepared
-        }
-    }
+  private val preparedStatements = new ConcurrentHashMap[String, Future[PreparedStatement]]
+  private val computePreparedStatement = new JFunction[String, Future[PreparedStatement]] {
+    override def apply(key: String): Future[PreparedStatement] =
+      underlying().flatMap { s =>
+        val prepared = s.prepareAsync(key).asScala
+        prepared.failed.foreach(
+          _ =>
+            // this is async, i.e. we are not updating the map from the compute function
+            preparedStatements.remove(key))
+        prepared
+      }
+  }
 
   private val _underlyingSession = new AtomicReference[Future[Session]]()
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.99-SNAPSHOT"
+version in ThisBuild := "1.0-SNAPSHOT"


### PR DESCRIPTION
* Remove implicit conversion from ListenableFuture to Future
* Package is currently `akka.cassandra.session`

I gave this a go as I want to use it outside of akka-persistence for some experiments. 

This is the first step before moving this out to Alpakka. I'd like to keep it as an internal module so we can iterate on the API for a while longer before moving to the Alpakka project. It would be nice to promote this as an API that is used outside of `akka-persistence` to promote streams. 

Questions:
* Should we use an alpakka package now so users don't need to change twice? Perhaps `akka.cassandra.session` is still okay even after moving it to Alpakka
* What about just keeping the namespace the same? 

@TimMoore I am guessing Lagom uses this internally so if we do change the package we'll need to coordinate when the next release 

Before we move this to Alpakka we need to add testing of the session. Atm it is just done throught he plugin.