### PR TITLE
Add possiblity of providing "contact-points" and "data-center-replication-factors" as a comma-separated string

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -17,8 +17,10 @@ cassandra-journal {
   # FQCN of the cassandra journal plugin
   class = "akka.persistence.cassandra.journal.CassandraJournal"
 
-  # Comma-separated list of contact points in the Cassandra cluster.
+  # List of contact points in the Cassandra cluster.
   # Host:Port pairs are also supported. In that case the port parameter will be ignored.
+  # The value can be either a proper list, e.g. ["127.0.0.1", "127.0.0.2"],
+  # or a comma-separated list within a single string, e.g. "127.0.0.1,127.0.0.2".
   contact-points = ["127.0.0.1"]
 
   # Port of contact points in the Cassandra cluster.
@@ -234,7 +236,9 @@ cassandra-journal {
   # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
   replication-factor = 1
 
-  # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
+  # Replication factor list for data centers. Is only used when replication-strategy is NetworkTopologyStrategy.
+  # The value can be either a proper list, e.g. ["dc1:3", "dc2:2"],
+  # or a comma-separated list within a single string, e.g. "dc1:3,dc2:2".
   data-center-replication-factors = []
 
   # To limit the Cassandra hosts this plugin connects with to a specific datacenter.

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -7,7 +7,7 @@ package akka.persistence.cassandra
 import akka.persistence.cassandra.compaction.CassandraCompactionStrategy
 import com.datastax.driver.core._
 import com.typesafe.config.Config
-import scala.collection.JavaConverters._
+
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
 import akka.persistence.cassandra.session.CassandraSessionSettings
@@ -37,7 +37,7 @@ class CassandraPluginConfig(system: ActorSystem, config: Config) {
   val replicationStrategy: String = getReplicationStrategy(
     config.getString("replication-strategy"),
     config.getInt("replication-factor"),
-    config.getStringList("data-center-replication-factors").asScala)
+    getListFromConfig(config, "data-center-replication-factors"))
 
   val readConsistency: ConsistencyLevel = sessionSettings.readConsistency
   val writeConsistency: ConsistencyLevel = sessionSettings.writeConsistency

--- a/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/ConfigSessionProvider.scala
@@ -14,6 +14,7 @@ import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
 import scala.concurrent.duration.FiniteDuration
+
 import akka.actor.ActorSystem
 import com.datastax.driver.core._
 import com.datastax.driver.core.policies.DCAwareRoundRobinPolicy
@@ -187,7 +188,7 @@ class ConfigSessionProvider(system: ActorSystem, config: Config) extends Session
    * @param clusterId the configured `cluster-id` to lookup
    */
   def lookupContactPoints(clusterId: String)(implicit ec: ExecutionContext): Future[immutable.Seq[InetSocketAddress]] = {
-    val contactPoints = config.getStringList("contact-points").asScala.toList
+    val contactPoints = getListFromConfig(config, "contact-points")
     Future.successful(buildContactPoints(contactPoints, port))
   }
 

--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -19,6 +19,8 @@ import scala.concurrent._
 import scala.language.implicitConversions
 import scala.util.Try
 import scala.util.control.NonFatal
+import scala.collection.JavaConverters._
+import com.typesafe.config.{ Config, ConfigValueType }
 
 import akka.actor.ActorSystem
 import akka.actor.ExtendedActorSystem
@@ -129,6 +131,16 @@ package object cassandra {
    */
   @InternalApi private[akka] def indent(stmt: String, prefix: String): String = {
     stmt.split('\n').mkString("\n" + prefix)
+  }
+
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[cassandra] def getListFromConfig(config: Config, key: String): List[String] = {
+    config.getValue(key).valueType() match {
+      case ConfigValueType.LIST   => config.getStringList(key).asScala.toList
+      case ConfigValueType.STRING => config.getString(key).split(",").toList
+    }
   }
 
 }


### PR DESCRIPTION
In configuration, `contact-points` and `data-center-replication-factors` are parsed as a proper string list (https://github.com/lightbend/config/blob/ea45ea3767a201933eeeb9c3f0f13eacc9b51f07/config/src/main/java/com/typesafe/config/Config.java#L939). This change adds a possibility of providing them in form of a comma-separated string.

Rationale:
Sometimes it's desirable to pass those values via environment variables, for example within a k8s multi-cluster setting (dev,sit,prod) where we want to have one universal configuration parametrized with values from the environment. It's already possible to pass single elements of a list this way (`"contact-points.0 =${?CONTACT_POINTS_0}"`, etc.), but we have to know the amount of elements in advance and it's just cumbersome.