### PR TITLE
Specify guava dependency because of security vulnerability in transitive dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,6 +7,8 @@ val AkkaVersion = "2.5.17"
 
 val akkaPersistenceCassandraDependencies = Seq(
   "com.datastax.cassandra"  % "cassandra-driver-core"               % "3.6.0",
+  // Specifying guava dependency because older transitive dependency has security vulnerability
+  "com.google.guava"        % "guava"                               % "27.0.1-jre",
   "com.typesafe.akka"      %% "akka-persistence"                    % AkkaVersion,
   "com.typesafe.akka"      %% "akka-cluster-tools"                  % AkkaVersion,
   "com.typesafe.akka"      %% "akka-persistence-query"              % AkkaVersion,


### PR DESCRIPTION
* Guava before 24.1.1 has seurity vulnerability CVE-2018-10237

Don't merge until we have confirmed with @marcospereira that latest Guava 27.0.1-jre is what we should use to be compatible with Play/Lagom.