### PR TITLE
Fix dot syntax handling for configuration lists (contact points and DC replication factors)

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/package.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/package.scala
@@ -139,6 +139,9 @@ package object cassandra {
   @InternalApi private[cassandra] def getListFromConfig(config: Config, key: String): List[String] = {
     config.getValue(key).valueType() match {
       case ConfigValueType.LIST   => config.getStringList(key).asScala.toList
+      // case ConfigValueType.OBJECT is needed to handle dot notation (x.0=y x.1=z) due to Typesafe Config implementation quirk.
+      // https://github.com/lightbend/config/blob/master/config/src/main/java/com/typesafe/config/impl/DefaultTransformer.java#L83
+      case ConfigValueType.OBJECT => config.getStringList(key).asScala.toList
       case ConfigValueType.STRING => config.getString(key).split(",").toList
     }
   }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
@@ -124,6 +124,20 @@ class CassandraPluginConfigSpec extends TestKit(ActorSystem("CassandraPluginConf
           new InetSocketAddress("127.0.0.2", 9042)))
     }
 
+    "parse config with a list of contact points using dot syntax" in {
+      lazy val configWithHosts = ConfigFactory.parseString(
+        """
+          |contact-points.0 = "127.0.0.1"
+          |contact-points.1 = "127.0.0.2"
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new CassandraPluginConfig(system, configWithHosts)
+      val sessionProvider = config.sessionProvider.asInstanceOf[ConfigSessionProvider]
+      Await.result(sessionProvider.lookupContactPoints(""), 3.seconds) must be(
+        List(
+          new InetSocketAddress("127.0.0.1", 9042),
+          new InetSocketAddress("127.0.0.2", 9042)))
+    }
+
     "parse config with comma-separated contact-points" in {
       lazy val configWithHosts = ConfigFactory.parseString("""contact-points = "127.0.0.1,127.0.0.2"""").withFallback(defaultConfig)
       val config = new CassandraPluginConfig(system, configWithHosts)
@@ -200,6 +214,17 @@ class CassandraPluginConfigSpec extends TestKit(ActorSystem("CassandraPluginConf
         """
           |replication-strategy = "NetworkTopologyStrategy"
           |data-center-replication-factors = ["dc1:3", "dc2:2"]
+        """.stripMargin).withFallback(defaultConfig)
+      val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
+      config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
+    }
+
+    "parse config with a list of datacenters configured for NetworkTopologyStrategy using dot syntax" in {
+      lazy val configWithNetworkStrategy = ConfigFactory.parseString(
+        """
+          |replication-strategy = "NetworkTopologyStrategy"
+          |data-center-replication-factors.0 = "dc1:3"
+          |data-center-replication-factors.1 = "dc2:2"
         """.stripMargin).withFallback(defaultConfig)
       val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")


### PR DESCRIPTION
This fixes the issue reported here https://github.com/akka/akka-persistence-cassandra/pull/417#issuecomment-458363423.

Basically, dot syntax like
```
contact-points.0="1.1.1.1"
contact-points.1="2.2.2.2"
```
handling was unintentionally broken with https://github.com/akka/akka-persistence-cassandra/pull/417. This PR fixes it.
