### PR TITLE
Only rely on sender from asyncReadHighestSequenceNr for watching pers…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,47 +18,40 @@ val akkaPersistenceCassandraDependencies = Seq(
   "com.typesafe.akka" %% "akka-persistence-tck" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
   "com.typesafe.akka" %% "akka-multi-node-testkit" % AkkaVersion % Test,
+  "com.typesafe.akka" %% "akka-cluster-sharding" % AkkaVersion % Test,
   "ch.qos.logback" % "logback-classic" % "1.2.3" % Test,
   "org.scalatest" %% "scalatest" % "3.0.5" % Test,
   "org.pegdown" % "pegdown" % "1.6.0" % Test,
-  "org.osgi" % "org.osgi.core" % "5.0.0" % Provided
-)
+  "org.osgi" % "org.osgi.core" % "5.0.0" % Provided)
 
 def common: Seq[Setting[_]] = Seq(
   organization := "com.typesafe.akka",
   organizationName := "Lightbend Inc.",
   startYear := Some(2016),
-  licenses := Seq(
-    ("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
+  licenses := Seq(("Apache-2.0", url("https://www.apache.org/licenses/LICENSE-2.0"))),
   crossScalaVersions := Seq("2.11.12", "2.13.0-M5", "2.12.8"),
   scalaVersion := crossScalaVersions.value.last,
   crossVersion := CrossVersion.binary,
   scalacOptions ++= Seq(
-    "-encoding",
-    "UTF-8",
-    "-feature",
-    "-unchecked",
-    "-deprecation",
-    "-Xlint",
-    "-Ywarn-dead-code",
-    "-Xfuture"
-  ),
-  headerLicense := Some(
-    HeaderLicense.Custom(
-      """Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>"""
-    )),
+      "-encoding",
+      "UTF-8",
+      "-feature",
+      "-unchecked",
+      "-deprecation",
+      "-Xlint",
+      "-Ywarn-dead-code",
+      "-Xfuture"),
+  headerLicense := Some(HeaderLicense.Custom("""Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>""")),
   scalafmtOnCompile := true,
   releaseCrossBuild := true,
-  logBuffered in Test := System
-    .getProperty("akka.logBufferedTests", "false")
-    .toBoolean,
+  logBuffered in Test := System.getProperty("akka.logBufferedTests", "false").toBoolean,
   // show full stack traces and test case durations
   testOptions in Test += Tests.Argument("-oDF"),
   // -v Log "test run started" / "test started" / "test run finished" events on log level "info" instead of "debug".
   // -a Show stack traces and exception class name for AssertionErrors.
   testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
   // disable parallel tests
-  parallelExecution in Test := false,
+  parallelExecution in Test := false
 )
 
 lazy val root = (project in file("."))
@@ -67,11 +60,9 @@ lazy val root = (project in file("."))
   .settings(
     name := "akka-persistence-cassandra-root",
     publishArtifact := false,
-    publishTo := Some(
-      Resolver.file("Unused transient repository", file("target/unusedrepo"))),
+    publishTo := Some(Resolver.file("Unused transient repository", file("target/unusedrepo"))),
     publish := {},
-    PgpKeys.publishSigned := {}
-  )
+    PgpKeys.publishSigned := {})
 
 lazy val core = (project in file("core"))
   .enablePlugins(AutomateHeaderPlugin, SbtOsgi, MultiJvmPlugin)
@@ -82,14 +73,11 @@ lazy val core = (project in file("core"))
     name := "akka-persistence-cassandra",
     libraryDependencies ++= akkaPersistenceCassandraDependencies,
     OsgiKeys.exportPackage := Seq("akka.persistence.cassandra.*"),
-    OsgiKeys.importPackage := Seq(akkaImport(),
-                                  optionalImport("org.apache.cassandra.*"),
-                                  "*"),
+    OsgiKeys.importPackage := Seq(akkaImport(), optionalImport("org.apache.cassandra.*"), "*"),
     OsgiKeys.privatePackage := Nil,
     testOptions in Test ++= Seq(
-      Tests.Argument(TestFrameworks.ScalaTest, "-o"),
-      Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test-reports"))
-  )
+        Tests.Argument(TestFrameworks.ScalaTest, "-o"),
+        Tests.Argument(TestFrameworks.ScalaTest, "-h", "target/test-reports")))
   .configs(MultiJvm)
 
 lazy val cassandraLauncher = (project in file("cassandra-launcher"))
@@ -97,8 +85,7 @@ lazy val cassandraLauncher = (project in file("cassandra-launcher"))
   .settings(
     name := "akka-persistence-cassandra-launcher",
     managedResourceDirectories in Compile += (target in cassandraBundle).value / "bundle",
-    managedResources in Compile += (assembly in cassandraBundle).value
-  )
+    managedResources in Compile += (assembly in cassandraBundle).value)
 
 // This project doesn't get published directly, rather the assembled artifact is included as part of cassandraLaunchers
 // resources
@@ -109,10 +96,10 @@ lazy val cassandraBundle = (project in file("cassandra-bundle"))
     name := "akka-persistence-cassandra-bundle",
     crossPaths := false,
     autoScalaLibrary := false,
-    libraryDependencies += "org.apache.cassandra" % "cassandra-all" % "3.11.3" exclude ("commons-logging", "commons-logging"),
+    libraryDependencies += ("org.apache.cassandra" % "cassandra-all" % "3.11.3")
+        .exclude("commons-logging", "commons-logging"),
     target in assembly := target.value / "bundle" / "akka" / "persistence" / "cassandra" / "launcher",
-    assemblyJarName in assembly := "cassandra-bundle.jar"
-  )
+    assemblyJarName in assembly := "cassandra-bundle.jar")
 
 def akkaImport(packageName: String = "akka.*") =
   versionedImport(packageName, "2.4", "2.5")

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -201,7 +201,7 @@ class EventsByTagMigration(
           val startingSeqFut = tagScanningStartingSequenceNr(pid)
           for {
             tp <- lookupTagProgress(pid)
-            _ <- persistenceIdStarting(pid, tp, tagWriters, system.deadLetters)
+            _ <- setTagProgress(pid, tp, tagWriters)
             startingSeq <- startingSeqFut
           } yield (tp, startingSeq)
         }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -107,8 +107,13 @@ import akka.util.ByteString
   final case class TagFlush(tag: String)
   case object FlushAllTagWriters
   case object AllFlushed
-  final case class PersistentActorStarting(pid: String, tagProgresses: Map[Tag, TagProgress], persistentActor: ActorRef)
+
+  final case class SetTagProgress(pid: String, tagProgresses: Map[Tag, TagProgress])
+  case object TagProcessAck
+
+  final case class PersistentActorStarting(pid: String, persistentActor: ActorRef)
   case object PersistentActorStartingAck
+
   final case class TagWriteFailed(reason: Throwable)
   private case object WriteTagScanningTick
 
@@ -160,23 +165,26 @@ import akka.util.ByteString
         tagActor(tw.tag).forward(tw)
       }
       updatePendingScanning(withoutTags)
+
     case WriteTagScanningTick =>
       writeTagScanning()
 
-    case PersistentActorStarting(pid, tagProgresses: Map[Tag, TagProgress], persistentActor) =>
+    case PersistentActorStarting(pid, persistentActor) =>
+      currentPersistentActors.get(pid).foreach { ref =>
+        log.debug("Persistent actor starting for pid [{}]. Old ref hasn't terminated yet: [{}]", pid, ref)
+      }
+      currentPersistentActors += (pid -> persistentActor)
+      log.debug("Watching pid [{}] actor [{}]", pid, persistentActor)
+      context.watchWith(persistentActor, PersistentActorTerminated(pid, persistentActor))
+      sender() ! PersistentActorStartingAck
+
+    case SetTagProgress(pid, tagProgresses: Map[Tag, TagProgress]) =>
       val missingProgress = tagActors.keySet -- tagProgresses.keySet
       log.debug(
-        "Persistent actor [{}] with pid [{}] starting with progress [{}]. Tags to reset as not in progress: [{}]",
-        persistentActor,
+        "Pid [{}] set tag progress [{}]. Tags to reset as not in progress: [{}]",
         pid,
         tagProgresses,
         missingProgress)
-
-      // EventsByTagMigration uses dead letters are there are no real actors
-      if (persistentActor != context.system.deadLetters) {
-        currentPersistentActors += (pid -> persistentActor)
-        context.watchWith(persistentActor, PersistentActorTerminated(pid, persistentActor))
-      }
 
       val replyTo = sender()
       pendingScanning -= pid
@@ -199,7 +207,7 @@ import akka.util.ByteString
 
       // if this fails (all local actor asks) the recovery will timeout
       recoveryNotificationComplete.foreach { _ =>
-        replyTo ! PersistentActorStartingAck
+        replyTo ! TagProcessAck
       }
 
     case TagWriteFailed(_) =>

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -84,14 +84,14 @@ class TagWritersSpec
       tagWriters ! redTagWrite
       redProbe.expectMsg(redTagWrite)
 
-      tagWriters ! PersistentActorStarting("p1", Map("red" -> TagProgress("p1", 2, 1)), system.deadLetters)
+      tagWriters ! SetTagProgress("p1", Map("red" -> TagProgress("p1", 2, 1)))
       redProbe.expectMsg(ResetPersistenceId("red", TagProgress("p1", 2, 1)))
       blueProbe.expectMsg(ResetPersistenceId("blue", TagProgress("p1", 0, 0)))
       expectNoMessage(smallWait)
       redProbe.reply(ResetPersistenceIdComplete)
       expectNoMessage(smallWait)
       blueProbe.reply(ResetPersistenceIdComplete)
-      expectMsg(PersistentActorStartingAck)
+      expectMsg(TagProcessAck)
     }
 
     "informs tag writers when persistent actor terminates" in {
@@ -103,7 +103,7 @@ class TagWritersSpec
       val persistentActor = system.actorOf(Props(new Actor {
         override def receive: Receive = { case _ => }
       }))
-      tagWriters ! PersistentActorStarting("pid1", Map.empty, persistentActor)
+      tagWriters ! PersistentActorStarting("pid1", persistentActor)
       expectMsg(PersistentActorStartingAck)
 
       val blueTagWrite = TagWrite("blue", Vector.empty)

--- a/core/src/test/scala/akka/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.sharding
+
+import akka.actor.{ ActorLogging, ActorRef, Props, ReceiveTimeout }
+import akka.cluster.{ Cluster, MemberStatus }
+import akka.cluster.sharding.{ ClusterSharding, ClusterShardingSettings, ShardRegion }
+import akka.persistence.PersistentActor
+import akka.persistence.cassandra.{ CassandraSpec, TestTaggingActor }
+import akka.testkit.TestProbe
+
+import scala.concurrent.duration._
+
+object ClusterShardingQuickTerminationSpec {
+
+  case object Increment
+  case object Decrement
+  final case class Get(counterId: Long)
+  final case class EntityEnvelope(id: Long, payload: Any)
+  case object Ack
+
+  case object Stop
+  final case class CounterChanged(delta: Int)
+
+  class Counter extends PersistentActor with ActorLogging {
+    import ShardRegion.Passivate
+
+    context.setReceiveTimeout(5.seconds)
+
+    // self.path.name is the entity identifier (utf-8 URL-encoded)
+    override def persistenceId: String = "Counter-" + self.path.name
+
+    var count = 0
+
+    def updateState(event: CounterChanged): Unit =
+      count += event.delta
+
+    override def receiveRecover: Receive = {
+      case evt: CounterChanged => updateState(evt)
+      case other               => log.info("Other: {}", other)
+    }
+
+    override def receiveCommand: Receive = {
+      case Increment      => persist(CounterChanged(+1))(updateState)
+      case Decrement      => persist(CounterChanged(-1))(updateState)
+      case Get(_)         => sender() ! count
+      case ReceiveTimeout => context.parent ! Passivate(stopMessage = Stop)
+      case Stop =>
+        sender() ! Ack
+        context.stop(self)
+    }
+  }
+  val extractEntityId: ShardRegion.ExtractEntityId = {
+    case EntityEnvelope(id, payload) => (id.toString, payload)
+    case msg @ Get(id)               => (id.toString, msg)
+  }
+
+  val numberOfShards = 100
+
+  val extractShardId: ShardRegion.ExtractShardId = {
+    case EntityEnvelope(id, _) => (id % numberOfShards).toString
+    case Get(id)               => (id % numberOfShards).toString
+  }
+
+}
+
+class ClusterShardingQuickTerminationSpec
+    extends CassandraSpec("""
+    akka.loglevel = DEBUG                                                 
+    akka.actor.provider = cluster
+  """.stripMargin) {
+
+  import ClusterShardingQuickTerminationSpec._
+
+  "Cassandra Plugin with Cluster Sharding" should {
+    "clear state if persistent actor shuts down" in {
+      Cluster(system).join(Cluster(system).selfMember.address)
+      awaitAssert {
+        Cluster(system).selfMember.status shouldEqual MemberStatus.Up
+      }
+      ClusterSharding(system).start(
+        typeName = "tagging",
+        entityProps = Props[Counter],
+        settings = ClusterShardingSettings(system),
+        extractEntityId = extractEntityId,
+        extractShardId = extractShardId)
+
+      (0 to 100).foreach { i =>
+        val counterRegion: ActorRef = ClusterSharding(system).shardRegion("tagging")
+        awaitAssert {
+          val sender = TestProbe()
+          counterRegion.tell(Get(123), sender.ref)
+          sender.expectMsg(500.millis, i)
+        }
+
+        counterRegion ! EntityEnvelope(123, Increment)
+        counterRegion ! Get(123)
+        expectMsg(i + 1)
+
+        counterRegion ! EntityEnvelope(123, Stop)
+        expectMsg(Ack)
+      }
+    }
+  }
+}


### PR DESCRIPTION
…istnet actors

This didn't reproduce the issue in #444 but is related as the watches
didn't when the sender() was captured from asyncReplayMessages

Refs #444

Previously the watch was on the back of the setting of the TagProgress sent to the TagWriters. This happens in different journal call backs depending on whether it is a new persistenceId, if there is a current snapshot so no reply will happen or during normal recovery. This PR separates out the watwching from the tag progress setting so that the watching can always be triggered from asyncReadHighestSequenceNr