### PR TITLE
Optimization to avoid metadata query if deletes are not used, #449

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -104,6 +104,12 @@ cassandra-journal {
   # Deleting should be used with snapshots for efficiency for recovery thus deleting should be infrequent
   max-concurrent-deletes = 10
 
+  # For applications that are not deleting any events this can be set to 'off', which will optimize
+  # the recovery to not query for highest deleted sequence number from the metadata table.
+  # It must not be off if deletes of events are used or have been used previously.
+  # If this is set to off then delete attempts will fail with an IllegalArgumentException.
+  support-deletes = on
+
   # Cassandra driver connection pool settings
   # Documented at http://docs.datastax.com/en/developer/java-driver/latest/manual/pooling/
   connection-pool {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -54,17 +54,19 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
     config.getLong(CassandraJournalConfig.TargetPartitionProperty)
   val maxResultSize: Int = config.getInt("max-result-size")
   val replayMaxResultSize: Int = config.getInt("max-result-size-replay")
-  val maxMessageBatchSize = config.getInt("max-message-batch-size")
+  val maxMessageBatchSize: Int = config.getInt("max-message-batch-size")
 
   // TODO this is now only used when deciding how to delete, remove this config and just
   // query what version of cassandra we're connected to and do the right thing
   val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
 
-  val maxConcurrentDeletes = config.getInt("max-concurrent-deletes")
+  val maxConcurrentDeletes: Int = config.getInt("max-concurrent-deletes")
 
-  val queryPlugin = config.getString("query-plugin")
+  val supportDeletes: Boolean = config.getBoolean("support-deletes")
 
-  val eventsByTagEnabled = config.getBoolean("events-by-tag.enabled")
+  val queryPlugin: String = config.getString("query-plugin")
+
+  val eventsByTagEnabled: Boolean = config.getBoolean("events-by-tag.enabled")
 
   val bucketSize: BucketSize =
     BucketSize.fromString(config.getString("events-by-tag.bucket-size"))

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -8,9 +8,10 @@ import akka.actor.{ ActorRef, PoisonPill, Props }
 import akka.persistence.{ DeleteMessagesFailure, DeleteMessagesSuccess, PersistentActor, RecoveryCompleted }
 import akka.persistence.cassandra.CassandraSpec
 import akka.testkit.TestProbe
-
 import scala.collection.immutable
 import scala.concurrent.duration._
+
+import akka.testkit.EventFilter
 
 object CassandraJournalDeletionSpec {
   case class PersistMe(msg: Long)
@@ -61,7 +62,9 @@ object CassandraJournalDeletionSpec {
 
 class CassandraJournalDeletionSpec
     extends CassandraSpec("""
-    akka.loglevel = DEBUG
+    akka.loglevel = INFO
+    akka.loggers = ["akka.testkit.TestEventListener"]
+    akka.log-dead-letters = off
     cassandra-journal.max-concurrent-deletes = 100
 
     cassandra-journal-low-concurrent-deletes = ${cassandra-journal}
@@ -83,6 +86,16 @@ class CassandraJournalDeletionSpec
     cassandra-query-journal-small-partition-size = ${cassandra-query-journal}
     cassandra-query-journal-small-partition-size {
       write-plugin = cassandra-journal-small-partition-size
+    }
+    
+    cassandra-journal-no-delete = ${cassandra-journal}
+    cassandra-journal-no-delete {
+      support-deletes = off
+      query-plugin = cassandra-query-journal-no-delete
+    }
+    cassandra-query-journal-no-delete = ${cassandra-query-journal}
+    cassandra-query-journal-no-delete {
+      write-plugin = cassandra-journal-no-delete
     }
   """) {
 
@@ -177,6 +190,42 @@ class CassandraJournalDeletionSpec
       val p1TakeThree = system.actorOf(props)
       p1TakeThree ! GetRecoveredEvents
       expectMsg(RecoveredEvents(List(RecoveryCompleted)))
+    }
+
+    "recover with support-deletes=off" in {
+      val deleteSuccess = TestProbe()
+      val deleteFail = TestProbe()
+      val p1 =
+        system.actorOf(Props(new PAThatDeletes("p3", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
+
+      (1 to 3).foreach { i =>
+        p1 ! PersistMe(i)
+        expectMsg(Ack)
+      }
+
+      p1 ! PoisonPill
+
+      val p1TakeTwo = system.actorOf(Props(new PAThatDeletes("p3", deleteSuccess.ref, deleteFail.ref)))
+      p1TakeTwo ! GetRecoveredEvents
+      expectMsg(RecoveredEvents(List(PersistMe(1), PersistMe(2), PersistMe(3), RecoveryCompleted)))
+    }
+
+    "fail if attempt to delete with support-deletes=off" in {
+      val deleteSuccess = TestProbe()
+      val deleteFail = TestProbe()
+      val p1 =
+        system.actorOf(Props(new PAThatDeletes("p4", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
+
+      (1 to 3).foreach { i =>
+        p1 ! PersistMe(i)
+        expectMsg(Ack)
+      }
+
+      EventFilter.error(start = "Failed to delete to 2", occurrences = 1).intercept {
+        p1 ! DeleteTo(2)
+      }
+
+      deleteFail.expectMsgType[IllegalArgumentException]
     }
 
   }


### PR DESCRIPTION
## Purpose

Optimization

## References

Refs #449

## Changes

* add `support-deletes` config
* don't query metadata if support-deletes=off
* fail delete attempts when  support-deletes=off
* test

## Background Context

Customer request to avoid metadata queries when persistent actors are recovered and event deletion is not used.