### PR TITLE
Fix missing FlushComplete message

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -155,8 +155,8 @@ class EventsByTagMigration(
    * @param pids PersistenceIds to migrate
    * @return A Future that completes when the migration is complete
    */
-  def migratePidsToTagViews(pids: Seq[PersistenceId], periodicFlush: Int = 1000): Future[Done] = {
-    migrateToTagViewsInternal(Source.fromIterator(() => pids.iterator), periodicFlush)
+  def migratePidsToTagViews(pids: Seq[PersistenceId], periodicFlush: Int = 1000, flushTimeout: Timeout = Timeout(30.seconds)): Future[Done] = {
+    migrateToTagViewsInternal(Source.fromIterator(() => pids.iterator), periodicFlush, flushTimeout)
   }
 
   /**
@@ -171,11 +171,11 @@ class EventsByTagMigration(
    *
    * @return A Future that completes when the migration is complete.
    */
-  def migrateToTagViews(periodicFlush: Int = 1000, filter: String => Boolean = _ => true): Future[Done] = {
-    migrateToTagViewsInternal(queries.currentPersistenceIds().filter(filter), periodicFlush)
+  def migrateToTagViews(periodicFlush: Int = 1000, filter: String => Boolean = _ => true, flushTimeout: Timeout = Timeout(30.seconds)): Future[Done] = {
+    migrateToTagViewsInternal(queries.currentPersistenceIds().filter(filter), periodicFlush, flushTimeout)
   }
 
-  private def migrateToTagViewsInternal(src: Source[PersistenceId, NotUsed], periodicFlush: Int): Future[Done] = {
+  private def migrateToTagViewsInternal(src: Source[PersistenceId, NotUsed], periodicFlush: Int, flushTimeout: Timeout): Future[Done] = {
     log.info("Beginning migration of data to tag_views table in keyspace {}", config.keyspace)
     val tagWriterSession = TagWritersSession(
       () => preparedWriteToTagViewWithoutMeta,
@@ -189,8 +189,8 @@ class EventsByTagMigration(
     val eventDeserializer: CassandraJournal.EventDeserializer =
       new CassandraJournal.EventDeserializer(system)
 
-    // A bit arbitrary, but we could be waiting on many Cassandra writes during the flush
-    implicit val timeout = Timeout(30.seconds)
+    implicit val timeout: Timeout  = flushTimeout
+
     val allPids = src
       .map { pids =>
         log.info("Migrating the following persistence ids {}", pids)
@@ -229,7 +229,7 @@ class EventsByTagMigration(
                     EventsByTagMigration.rawPayloadOldTagSchemaExtractor(config.bucketSize, eventDeserializer, system))
                 .map(sendMissingTagWriteRaw(tp, tagWriters))
                 .buffer(periodicFlush, OverflowStrategy.backpressure)
-                .mapAsync(1)(_ => (tagWriters ? FlushAllTagWriters).mapTo[AllFlushed.type])
+                .mapAsync(1)(_ => (tagWriters ? FlushAllTagWriters(timeout)).mapTo[AllFlushed.type])
             }
           }
         }
@@ -237,7 +237,7 @@ class EventsByTagMigration(
 
     for {
       _ <- allPids.runWith(Sink.ignore)
-      _ <- (tagWriters ? FlushAllTagWriters).mapTo[AllFlushed.type]
+      _ <- (tagWriters ? FlushAllTagWriters(timeout)).mapTo[AllFlushed.type]
     } yield Done
   }
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -147,7 +147,8 @@ import akka.util.ByteString
   def receive: Receive = {
     case FlushAllTagWriters(t) =>
       implicit val timeout: Timeout = t
-      log.debug("Flushing all tag writers {}", tagActors.keySet)
+      if (log.isDebugEnabled)
+        log.debug("Flushing all tag writers [{}]", tagActors.keySet.mkString(", "))
       val replyTo = sender()
       val flushes = tagActors.map {
         case (tag, ref) =>

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -105,7 +105,7 @@ import akka.util.ByteString
     Props(new TagWriters(settings, tagWriterSession))
 
   final case class TagFlush(tag: String)
-  case object FlushAllTagWriters
+  final case class FlushAllTagWriters(timeout: Timeout)
   case object AllFlushed
 
   final case class SetTagProgress(pid: String, tagProgresses: Map[Tag, TagProgress])
@@ -145,13 +145,18 @@ import akka.util.ByteString
   timers.startPeriodicTimer(WriteTagScanningTick, WriteTagScanningTick, settings.scanningFlushInterval)
 
   def receive: Receive = {
-    case FlushAllTagWriters =>
-      log.debug("Flushing all tag writers")
-      // will include a C* write so be patient
-      implicit val timeout = Timeout(10.seconds)
+    case FlushAllTagWriters(t) =>
+      implicit val timeout: Timeout = t
+      log.debug("Flushing all tag writers {}", tagActors.keySet)
       val replyTo = sender()
       val flushes = tagActors.map {
-        case (_, ref) => (ref ? Flush).mapTo[FlushComplete.type]
+        case (tag, ref) =>
+          (ref ? Flush)
+            .mapTo[FlushComplete.type]
+            .map(fc => {
+              log.debug("Flush complete for tag {}", tag)
+              fc
+            })
       }
       Future.sequence(flushes).map(_ => AllFlushed).pipeTo(replyTo)
     case TagFlush(tag) =>

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -8,12 +8,19 @@ import akka.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props }
 import akka.persistence.cassandra.journal.TagWriter._
 import akka.persistence.cassandra.journal.TagWriters._
 import akka.testkit.{ ImplicitSender, TestKit, TestProbe }
+import akka.util.Timeout
+import com.typesafe.config.ConfigFactory
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
 import scala.concurrent.duration._
 
 class TagWritersSpec
-    extends TestKit(ActorSystem("TagWriterSpec"))
+    extends TestKit(
+      ActorSystem(
+        "TagWriterSpec",
+        ConfigFactory.parseString("""
+        akka.loglevel = INFO
+      """)))
     with WordSpecLike
     with BeforeAndAfterAll
     with ImplicitSender
@@ -60,7 +67,7 @@ class TagWritersSpec
       tagWriters ! redTagWrite
       redProbe.expectMsg(redTagWrite)
 
-      tagWriters ! FlushAllTagWriters
+      tagWriters ! FlushAllTagWriters(Timeout(1.second))
       blueProbe.expectMsg(Flush)
       blueProbe.reply(FlushComplete)
       redProbe.expectMsg(Flush)


### PR DESCRIPTION
The requestor of the flush was lost in two cases. When another tag write
is received while a write to cassandra was in progress and when a reset
persistence id was received while a write was in progress.


