### PR TITLE
Add a release step: update Lightbend Platform docs

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -16,3 +16,4 @@ From a direct clone (rather than a fork). You will need permission in sonatype t
   * update the 'akka-persistence-cassandra-xx-stable' project name in [WhiteSource](https://saas.whitesourcesoftware.com)
   * checkout the released version, e.g. v0.80
   * `sbt whitesourceUpdate`
+* Ask someone in the Akka team to update the [Lightbend Platform supported modules list](https://developer.lightbend.com/docs/lightbend-platform/2.0/supported-modules/) (requires Lightbend private GitHub permission). Only for stable releases, not milestones/RCs.


### PR DESCRIPTION
## Purpose

When releasing final versions, we need to update the [Lightbend Platform supported modules list](https://developer.lightbend.com/docs/lightbend-platform/2.0/supported-modules/#other-akka-modules).

## References

Copied from https://github.com/akka/akka-persistence-couchbase/pull/212