### PR TITLE
Stop journal if tag writers/tag writer throw an exception

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -120,6 +120,7 @@ lazy val cassandraBundle = (project in file("cassandra-bundle"))
     autoScalaLibrary := false,
     libraryDependencies += ("org.apache.cassandra" % "cassandra-all" % "3.11.3")
         .exclude("commons-logging", "commons-logging"),
+    dependencyOverrides += "com.github.jbellis" % "jamm" % "0.3.3", // See jamm comment in https://issues.apache.org/jira/browse/CASSANDRA-9608
     target in assembly := target.value / "bundle" / "akka" / "persistence" / "cassandra" / "launcher",
     assemblyJarName in assembly := "cassandra-bundle.jar")
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -352,12 +352,12 @@ cassandra-journal {
   # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
   jmx-reporting-enabled = on
 
-  # If there is an unexpected error in the Cassandra Journal the journal shutsdown
+  # If there is an unexpected error in the Cassandra Journal the journal shuts down
   # to prevent any data corruption. Set to true to also run coordinated shutdown so
-  # that the application shuts down. Useful in environemtns where applicatons are
+  # that the application shuts down. Useful in environments where applicatons are
   # automatically shutdown or if the Cassandra Journal not working means the application
-  # won't function
-  coordinated-shutdown-on-error = false
+  # won't function.
+  coordinated-shutdown-on-error = off
 }
 
 # This configures the default settings for all Cassandra Snapshot plugin

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -351,6 +351,13 @@ cassandra-journal {
   # Enable JMX reporter for Dropwizard Metrics.
   # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
   jmx-reporting-enabled = on
+
+  # If there is an unexpected error in the Cassandra Journal the journal shutsdown
+  # to prevent any data corruption. Set to true to also run coordinated shutdown so
+  # that the application shuts down. Useful in environemtns where applicatons are
+  # automatically shutdown or if the Cassandra Journal not working means the application
+  # won't function
+  coordinated-shutdown-on-error = false
 }
 
 # This configures the default settings for all Cassandra Snapshot plugin

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -155,7 +155,10 @@ class EventsByTagMigration(
    * @param pids PersistenceIds to migrate
    * @return A Future that completes when the migration is complete
    */
-  def migratePidsToTagViews(pids: Seq[PersistenceId], periodicFlush: Int = 1000, flushTimeout: Timeout = Timeout(30.seconds)): Future[Done] = {
+  def migratePidsToTagViews(
+      pids: Seq[PersistenceId],
+      periodicFlush: Int = 1000,
+      flushTimeout: Timeout = Timeout(30.seconds)): Future[Done] = {
     migrateToTagViewsInternal(Source.fromIterator(() => pids.iterator), periodicFlush, flushTimeout)
   }
 
@@ -171,11 +174,17 @@ class EventsByTagMigration(
    *
    * @return A Future that completes when the migration is complete.
    */
-  def migrateToTagViews(periodicFlush: Int = 1000, filter: String => Boolean = _ => true, flushTimeout: Timeout = Timeout(30.seconds)): Future[Done] = {
+  def migrateToTagViews(
+      periodicFlush: Int = 1000,
+      filter: String => Boolean = _ => true,
+      flushTimeout: Timeout = Timeout(30.seconds)): Future[Done] = {
     migrateToTagViewsInternal(queries.currentPersistenceIds().filter(filter), periodicFlush, flushTimeout)
   }
 
-  private def migrateToTagViewsInternal(src: Source[PersistenceId, NotUsed], periodicFlush: Int, flushTimeout: Timeout): Future[Done] = {
+  private def migrateToTagViewsInternal(
+      src: Source[PersistenceId, NotUsed],
+      periodicFlush: Int,
+      flushTimeout: Timeout): Future[Done] = {
     log.info("Beginning migration of data to tag_views table in keyspace {}", config.keyspace)
     val tagWriterSession = TagWritersSession(
       () => preparedWriteToTagViewWithoutMeta,
@@ -189,7 +198,7 @@ class EventsByTagMigration(
     val eventDeserializer: CassandraJournal.EventDeserializer =
       new CassandraJournal.EventDeserializer(system)
 
-    implicit val timeout: Timeout  = flushTimeout
+    implicit val timeout: Timeout = flushTimeout
 
     val allPids = src
       .map { pids =>

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -89,6 +89,8 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
     config.getDuration("events-by-tag.scanning-flush-interval", TimeUnit.MILLISECONDS).millis,
     config.getBoolean("pubsub-notification"))
 
+  val coordinatedShutdownOnError: Boolean = config.getBoolean("coordinated-shutdown-on-error")
+
   /**
    * The Cassandra statement that can be used to create the configured keyspace.
    *

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalUnexpectedError.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalUnexpectedError.scala
@@ -1,0 +1,8 @@
+package akka.persistence.cassandra.journal
+
+import akka.actor.CoordinatedShutdown.Reason
+
+/**
+ * Cassandra Journal unexpected error with cassandra-journal.coordinated-shutdown-on-error set to true
+ */
+object CassandraJournalUnexpectedError extends Reason

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalUnexpectedError.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalUnexpectedError.scala
@@ -5,4 +5,4 @@ import akka.actor.CoordinatedShutdown.Reason
 /**
  * Cassandra Journal unexpected error with cassandra-journal.coordinated-shutdown-on-error set to true
  */
-object CassandraJournalUnexpectedError extends Reason
+case object CassandraJournalUnexpectedError extends Reason

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -158,7 +158,7 @@ import scala.concurrent.duration._
       log.debug("Dropping state for pid: [{}]", pid)
       become(writeInProgress(buffer, tagPidSequenceNrs - pid, awaitingFlush))
     case InternalFlush =>
-      // Ignore, we will check when the write is done
+    // Ignore, we will check when the write is done
     case Flush =>
       log.debug("External flush while write in progress. Will flush after write complete")
       become(writeInProgress(buffer, tagPidSequenceNrs, Some(sender())))
@@ -229,7 +229,11 @@ import scala.concurrent.duration._
 
     case ResetPersistenceId(_, tp @ TagProgress(pid, _, _)) =>
       log.debug("Resetting persistence id {}. TagProgress {}", pid, tp)
-      become(writeInProgress(buffer.filterNot(_._1.persistenceId == pid), tagPidSequenceNrs + (pid -> tp.pidTagSequenceNr), awaitingFlush))
+      become(
+        writeInProgress(
+          buffer.filterNot(_._1.persistenceId == pid),
+          tagPidSequenceNrs + (pid -> tp.pidTagSequenceNr),
+          awaitingFlush))
       sender() ! ResetPersistenceIdComplete
   }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -52,7 +52,7 @@ object EventsByTagSpec {
         time-to-live = 1d
       }
 
-      # coordinated-shutdown-on-error = true
+      # coordinated-shutdown-on-error = on
     }
 
     cassandra-query-journal {

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -51,6 +51,8 @@ object EventsByTagSpec {
         bucket-size = Day
         time-to-live = 1d
       }
+
+      # coordinated-shutdown-on-error = true
     }
 
     cassandra-query-journal {


### PR DESCRIPTION
* The state for tag sequence numbers will be unknown for an unexpected
exception, safest thing to do it to shut down the journal as not to mess
up sequence numbers
* Option to run Coordination shutdown if the application needs to
restart

I couldn't think of a way to test this but tried it out manually by inserting in throws into the TagWriter and TagWriters actors

Fixes #461