### PR TITLE
Update snapshot deletion to use range query #450

### DIFF
--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -411,6 +411,16 @@ cassandra-snapshot-store {
   # If the table doesn't exist it is automatically created.
   config-table = "config"
 
+  # Set this to on to only use Cassandra 2.x compatible features,
+  # i.e. if you are using a Cassandra 2.x server.
+  # To run tests with Cassandra 2.x server you have to do the following:
+  # - start Cassandra 2.x server on default port 9042, with empty data directory
+  # - change CassandraLauncher.randomPort to 9042
+  # - change CassandraLauncher.start to do nothing
+  # - set this cassandra-2x-compat = on
+  # - note that you must delete all data between each test run
+  cassandra-2x-compat = off
+
   # Name of the table to be created/used for storing metadata.
   # If the table doesn't exist it is automatically created.
   metadata-table = "metadata"

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -3,13 +3,11 @@
  */
 package akka.persistence.cassandra.snapshot
 
-import java.lang.{ Long => JLong }
+import java.lang.{Long => JLong}
 import java.nio.ByteBuffer
 
 import scala.collection.immutable
-import scala.concurrent.Await
 import scala.concurrent.Future
-
 import akka.actor._
 import akka.persistence._
 import akka.persistence.cassandra._
@@ -184,14 +182,25 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
     boundDeleteSnapshot.flatMap(session.executeWrite(_)).map(_ => ())
   }
 
+  /** Plugin API: deletes all snapshots matching `criteria`. This call is protected with a circuit-breaker.
+    * @param persistenceId id of the persistent actor.
+    * @param criteria selection criteria for deleting. If no timestamp constraints are specified this routine
+    * @note Due to the limitations of Cassandra deletion requests, this routine makes an initial query in order to obtain the
+    * records matching the criteria which are then deleted in a batch deletion. Improvements in Cassandra v3.0+ mean a single
+    * range deletion on the sequence number is used instead, except if timestamp constraints are specified, which still
+    * requires the original two step routine.*/
   override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = {
     if (config.cassandra2xCompat || 0L < criteria.minTimestamp || criteria.maxTimestamp < SnapshotSelectionCriteria.latest().maxTimestamp) {
       preparedSelectSnapshotMetadata.flatMap { prepStmt =>
         metadata(prepStmt, persistenceId, criteria, limit = None).flatMap { mds =>
-          val boundStatements = mds.map(md => preparedDeleteSnapshot.map(_.bind(md.persistenceId, md.sequenceNr: JLong)))
-          Future.sequence(boundStatements).flatMap { stmts =>
-            executeBatch(batch => stmts.foreach(batch.add))
-          }
+          val boundStatementBatches = mds.map(
+            md => preparedDeleteSnapshot.map(_.bind(md.persistenceId, md.sequenceNr: JLong))
+          ).grouped(0xFFFF-1)
+          Future.sequence(
+            boundStatementBatches.map(
+              boundStatements => Future.sequence(boundStatements).flatMap(stmts => executeBatch(batch => stmts.foreach(batch.add)))
+            )
+          ).map(_ => ())
         }
       }
     } else {

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -9,4 +9,5 @@ import akka.actor.ActorSystem
 
 class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) {
   val maxLoadAttempts = config.getInt("max-load-attempts")
+  val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
 }

--- a/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -42,6 +42,8 @@ trait CassandraStatements {
         sequence_nr = ?
     """
 
+  def deleteSnapshots = s"""DELETE FROM $tableName WHERE persistence_id = ? AND sequence_nr >= ? AND sequence_nr <= ?"""
+
   def selectSnapshot = s"""
       SELECT * FROM ${tableName} WHERE
         persistence_id = ? AND


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose
Range deletions are more performant than a compound query which was only previously used due to the restrictions in Cassandra versions before 3.0.

## References
References #450

## Changes
* Snapshot deleteAsync now uses a range in the CQL deletion query. 

## Background Context
Support for range deletions in Cassandra was added in version 3.0 and
the previous operation was implemented with that limitation and is kept
to be used if the cassandra-2x-compat flag is enabled in the config.
Otherwise this new change means the default query is a more performant
single range deletion as opposed to the compound delete query used before.
