### PR TITLE
Snapshots deletion optimisation #450

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -168,12 +168,6 @@ cassandra-journal {
   # TODO remove this and just query cassandra to see what version it is
   # Set this to on to only use Cassandra 2.x compatible features,
   # i.e. if you are using a Cassandra 2.x server.
-  # To run tests with Cassandra 2.x server you have to do the following:
-  # - start Cassandra 2.x server on default port 9042, with empty data directory
-  # - change CassandraLauncher.randomPort to 9042
-  # - change CassandraLauncher.start to do nothing
-  # - set this cassandra-2x-compat = on
-  # - note that you must delete all data between each test run
   cassandra-2x-compat = off
 
   events-by-tag {
@@ -500,6 +494,10 @@ cassandra-snapshot-store {
   # Name of the table to be created/used for journal config.
   # If the table doesn't exist it is automatically created.
   config-table = "config"
+
+  # Set this to on to only use Cassandra 2.x compatible features,
+  # i.e. if you are using a Cassandra 2.x server.
+  cassandra-2x-compat = off
 
   # Name of the table to be created/used for storing metadata.
   # If the table doesn't exist it is automatically created.

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
@@ -32,6 +32,11 @@ trait CassandraSnapshotCleanup extends CassandraStatements {
       .prepare(deleteAllSnapshotForPersistenceId)
       .map(_.setConsistencyLevel(snapshotConfig.writeConsistency).setIdempotent(true).setRetryPolicy(deleteRetryPolicy))
 
+  def preparedDeleteAllSnapshotsForPidAndSequenceNrBetween =
+    session
+      .prepare(deleteAllSnapshotForPersistenceIdAndSequenceNrBetween)
+      .map(_.setConsistencyLevel(snapshotConfig.writeConsistency).setIdempotent(true).setRetryPolicy(deleteRetryPolicy))
+
   def deleteAsync(metadata: SnapshotMetadata): Future[Unit] = {
     val boundDeleteSnapshot = preparedDeleteSnapshot.map(_.bind(metadata.persistenceId, metadata.sequenceNr: JLong))
     boundDeleteSnapshot.flatMap(session.executeWrite(_)).map(_ => ())

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -12,6 +12,7 @@ import akka.actor.ActorSystem
 
 class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) {
   val maxLoadAttempts = config.getInt("max-load-attempts")
+  val cassandra2xCompat = config.getBoolean("cassandra-2x-compat")
 
   /**
    * The Cassandra statement that can be used to create the configured keyspace.

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraStatements.scala
@@ -59,6 +59,13 @@ trait CassandraStatements {
         persistence_id = ?
     """
 
+  def deleteAllSnapshotForPersistenceIdAndSequenceNrBetween = s"""
+    DELETE FROM ${tableName}
+    WHERE persistence_id = ?
+    AND sequence_nr >= ?
+    AND sequence_nr <= ?
+  """
+
   def selectSnapshot = s"""
       SELECT * FROM ${tableName} WHERE
         persistence_id = ? AND


### PR DESCRIPTION
## Purpose
Improved the performance of deletions of snapshots in the database. 

## References
References #450

## Changes
* Snapshot deletions are performed in batches of 65535 to avoid batch query limit.
* Snapshot deleteAsync now uses a range in the CQL deletion query.

## Background Context
Support for range deletions in Cassandra was added in version 3.0 and
the previous operation was implemented within that limitation and is kept
to be used if the cassandra-2x-compat flag is enabled in the config.
Otherwise this new change means the default query is a more performant
single range deletion as opposed to the compound delete query used before.
