### PR TITLE
EventsByTag current queries, use toOffset at end of current millisecond

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -441,7 +441,8 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
       try {
         val (fromOffset, usingOffset) = offsetToInternalOffset(offset)
         val prereqs = eventsByTagPrereqs(tag, usingOffset, fromOffset)
-        val toOffset = Some(offsetUuid(System.currentTimeMillis()))
+        // pick up all the events written this millisecond
+        val toOffset = Some(UUIDs.endOf(System.currentTimeMillis()))
 
         createFutureSource(prereqs) { (s, prereqs) =>
           val session =


### PR DESCRIPTION
It used to use the beginning meaning that any event written in the
current millisecond won't be picked up. This doesn't seem right
as an event that has just been written may not be picked up for a query
started after (but in the same ms).

This causes a few tests to fail infrequently. WDYT @patriknw ?
