### PR TITLE
Rollback change of organisation id back to com.typesafe.akka

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Replicated [Akka Persistence](https://doc.akka.io/docs/akka/current/scala/persis
 
 [![Build Status](https://travis-ci.org/akka/akka-persistence-cassandra.svg?branch=master)](https://travis-ci.org/akka/akka-persistence-cassandra)
 
-Implementation in the `master` branch is currently work-in-progress for the upcoming `1.0` release. [Snapshot documentation](https://doc.akka.io/docs/akka-persistence-cassandra/snapshot/) and [snapshot artifacts](https://oss.sonatype.org/content/repositories/snapshots/com/lightbend/akka/akka-persistence-cassandra_2.12/) are published for every successful `master` branch build.
+Implementation in the `master` branch is currently work-in-progress for the upcoming `1.0` release. [Snapshot documentation](https://doc.akka.io/docs/akka-persistence-cassandra/snapshot/) and [snapshot artifacts](https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-persistence-cassandra_2.12/) are published for every successful `master` branch build.
 
 Documentation for the `0.x` versions is available on the [`release-0.x` branch](https://github.com/akka/akka-persistence-cassandra/tree/release-0.x).
 
@@ -17,4 +17,4 @@ Documentation for the `0.x` versions is available on the [`release-0.x` branch](
 
 This [Apache Cassandra](https://cassandra.apache.org/) plugin to Akka Persistence was initiated [originally](https://github.com/krasserm/akka-persistence-cassandra) by Martin Krasser, [@krasserm](https://github.com/krasserm) in 2014.
 
-It moved to the [Akka](https://github.com/akka/) organisation in 2017 and the first release after that move was 0.80 in January 2018.
+It moved to the [Akka](https://github.com/akka/) organisation in 2016 and the first release after that move was 0.7 in January 2016.

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -9,7 +9,7 @@ The Akka Persistence Cassandra plugin allows for using [Apache Cassandra](https:
 ## Dependencies
 
 @@dependency [Maven,sbt,Gradle] {
-  group=com.lightbend.akka
+  group=com.typesafe.akka
   artifact=akka-persistence-cassandra_$scala.binary.version$
   version=$project.version$
 }
@@ -22,8 +22,8 @@ The table below shows Akka Persistence Cassandra’s direct dependencies and the
 
 ## Snapshots
 
-[sonatype-badge]: https://img.shields.io/nexus/s/https/oss.sonatype.org/com.lightbend.akka/akka-persistence-cassandra_2.12.svg?label=latest%20snapshot
-[sonatype]:       https://oss.sonatype.org/content/repositories/snapshots/com/lightbend/akka/akka-persistence-cassandra_2.12/
+[sonatype-badge]: https://img.shields.io/nexus/s/https/oss.sonatype.org/com.typesafe.akka/akka-persistence-cassandra_2.12.svg?label=latest%20snapshot
+[sonatype]:       https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-persistence-cassandra_2.12/
 
 Snapshots are published to a snapshot repository in Sonatype after every successful build on master. Add the following to your project build definition to resolve snapshots:
 
@@ -64,7 +64,7 @@ The [snapshot documentation](https://doc.akka.io/docs/akka-persistence-cassandra
 
 This [Apache Cassandra](https://cassandra.apache.org/) plugin to Akka Persistence was initiated [originally](https://github.com/krasserm/akka-persistence-cassandra) by Martin Krasser, [@krasserm](https://github.com/krasserm) in 2014.
 
-It moved to the [Akka](https://github.com/akka/) organisation in 2017 and the first release after that move was 0.80 in January 2018.
+It moved to the [Akka](https://github.com/akka/) organisation in 2016 and the first release after that move was 0.7 in January 2016.
 
 ## Contributing
 

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -16,7 +16,7 @@ object Common extends AutoPlugin {
 
   override def globalSettings =
     Seq(
-      organization := "com.lightbend.akka",
+      organization := "com.typesafe.akka",
       organizationName := "Lightbend Inc.",
       organizationHomepage := Some(url("https://www.lightbend.com/")),
       startYear := Some(2016),


### PR DESCRIPTION
## Purpose

The organisation id changed by mistake to `com.lightbend.akka`, this rolls it back to `com.typesafe.akka`.
Furthermore, it applies the changes suggested in #497.

