### PR TITLE
`CassandraSession` and `ReadJournal` don't use fetch size/max-result-size

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -52,7 +52,6 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
     with NoSerializationVerificationNeeded {
   val targetPartitionSize: Long =
     config.getLong(CassandraJournalConfig.TargetPartitionProperty)
-  val maxResultSize: Int = config.getInt("max-result-size")
   val replayMaxResultSize: Int = config.getInt("max-result-size-replay")
   val maxMessageBatchSize: Int = config.getInt("max-message-batch-size")
 

--- a/session/src/main/scala/akka/cassandra/session/CassandraSessionSettings.scala
+++ b/session/src/main/scala/akka/cassandra/session/CassandraSessionSettings.scala
@@ -18,7 +18,6 @@ object CassandraSessionSettings {
 }
 
 class CassandraSessionSettings(val config: Config) {
-  val fetchSize = config.getInt("max-result-size")
   val readConsistency: ConsistencyLevel =
     ConsistencyLevel.valueOf(config.getString("read-consistency"))
   val writeConsistency: ConsistencyLevel =


### PR DESCRIPTION
## Purpose

Drop the setting `fetchSize`.

## Background Context

The `fetchSize` or `max-result-size` is not used by `CassandraSession` nor  and  `CassandraReadJournalConfig` (but by `ConfigSessionProvider`).
