### PR TITLE
Upgrade C* driver + reduce verbose warn logging

### DIFF
--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -14,8 +14,9 @@
          cassandra-snapshot-store.log-queries = on
      -->
     <logger name="com.datastax.driver.core.QueryLogger.NORMAL" level="DEBUG" />
-    <logger name="com.datastax.driver.core" level="WARN" />
     <logger name="com.codahale.metrics.JmxReporter" level="INFO" />
+    <!-- Driver gets very spammy at WARN after dropping keyspaces with the latest C* -->
+    <logger name="com.datastax.driver.core" level="ERROR" />
 
     <root level="INFO">
         <appender-ref ref="CONSOLE"/>

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraCorruptJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraCorruptJournalSpec.scala
@@ -57,7 +57,7 @@ object CassandraCorruptJournalSpec {
 
 class CassandraCorruptJournalSpec extends CassandraSpec(s"""
     akka {
-      loglevel = debug
+      loglevel = INFO
       loggers = ["akka.testkit.TestEventListener"]
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,7 @@ object Dependencies {
   val silencerVersion = "1.4.1"
 
   val akkaPersistenceCassandraDependencies = Seq(
-    "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.1",
+    "com.datastax.cassandra" % "cassandra-driver-core" % "3.7.2",
     // Specifying guava dependency because older transitive dependency has security vulnerability
     "com.google.guava" % "guava" % "27.0.1-jre",
     // Specifying jnr-posix version for licensing reasons: cassandra-driver-core


### PR DESCRIPTION
The 0.x release branch fails right now as its logs are too large. The logs are full of:

```
07/11 16:26:19 WARN [cluster12-nio-worker-0] c.d.d.c.Cluster - Received a DROPPED notification for TABLE cassandrajournalcompat2spec.messages, but this keyspace is unknown in our metadata
```