### PR TITLE
EventsByPersistenceIdStage: Previous query was not exhausted (release-0.50)

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -378,6 +378,9 @@ import com.datastax.driver.core.utils.Bytes
                     lookingForMissingSeqNr = Some(
                       MissingSeqNr(Deadline.now + config.eventsByPersistenceIdEventTimeout, event.sequenceNr)
                     )
+                    // Forget about any other rows in this result set until we find
+                    // the missing sequence nrs
+                    queryState = QueryIdle
                     query(false)
                 }
               } else {

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
@@ -25,7 +25,7 @@ object EventsByPersistenceIdFastForwardSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
     cassandra-journal.keyspace=EventsByPersistenceIdFastForwardSpec
-    cassandra-query-journal.refresh-interval = 0.5s
+    cassandra-query-journal.refresh-interval = 250ms
     cassandra-query-journal.max-result-size-query = 2
     cassandra-journal.target-partition-size = 15
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -177,7 +177,7 @@ class EventsByPersistenceIdSpec
     "(eventually) produce correct sequence of sequence numbers when events appear out of order in cassandra" in {
 
       writeTestEvent(PersistentRepr("jo-1", 1L, "jo"))
-      writeTestEvent(PersistentRepr("jo-1", 2L, "jo"))
+      writeTestEvent(PersistentRepr("jo-2", 2L, "jo"))
 
       val (killKill, probe) = queries.eventsByPersistenceId("jo", 0L, Long.MaxValue)
         .viaMat(KillSwitches.single)(Keep.right)
@@ -185,7 +185,7 @@ class EventsByPersistenceIdSpec
         .toMat(TestSink.probe[Any])(Keep.both)
         .run()
 
-      probe.request(4)
+      probe.request(5)
 
       probe.expectNext(
         ("jo", 1, Offset.sequence(1)),
@@ -195,7 +195,9 @@ class EventsByPersistenceIdSpec
 
       // 4 arrived out of order
       writeTestEvent(PersistentRepr("jo-4", 4L, "jo"))
-      system.log.debug("Wrote evt 4, sleeping")
+      system.log.debug("Wrote evt 4")
+      writeTestEvent(PersistentRepr("jo-5", 5L, "jo"))
+      system.log.debug("Wrote evt 5, sleeping")
 
       // give the source some time to see it, but less than
       // the configured events-by-persistence-id-gap-timeout
@@ -207,7 +209,8 @@ class EventsByPersistenceIdSpec
 
       probe.expectNext(
         ("jo", 3, Offset.sequence(3)),
-        ("jo", 4, Offset.sequence(4))
+        ("jo", 4, Offset.sequence(4)),
+        ("jo", 5, Offset.sequence(5))
       )
 
       killKill.shutdown()


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
Allows the successful recovery of persistent actors where there is an out-of-order event in the journal.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
Issues #295 and #532 report the issue on various versions including 0.59, 0.80 pre-release. Change #297 fixes this for 0.80. 

## Changes

* Modifies existing test to catch the fault.
* Sets query state to idle when a missing sequence number is observed.

## Background Context

This is a backport of the good work done in #297
<!-- Why did you take this approach? -->
