### PR TITLE
Fix the scope of the launcher dependency

### DIFF
--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -15,7 +15,7 @@ The Akka Persistence Cassandra plugin allows for using [Apache Cassandra](https:
   group2=com.typesafe.akka
   artifact2=akka-persistence-cassandra-launcher_$scala.binary.version$
   version2=$project.version$
-  scope2=Test
+  scope2=test
 }
 
 The launcher artifact is a utility for starting an embedded Cassandra, useful for running tests. It can be removed if not needed.


### PR DESCRIPTION
Paradox expects this to be specified in lowercase, and automatically transforms it as appropriate for the selected build tool.