### PR TITLE
Replace executeCreateTable with executeDdl in CassandraSession

### DIFF
--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
@@ -72,13 +72,23 @@ final class CassandraSession(delegate: akka.cassandra.session.scaladsl.Cassandra
     delegate.underlying().toJava
 
   /**
+   * Execute <a href=https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlCommandsTOC.html">CQL commands</a>
+   * to manage database resources (create, replace, alter, and drop tables, indexes, user-defined types, etc).
+   *
+   * The returned `CompletionStage` is completed when the command is done, or if the statement fails.
+   */
+  def executeDDL(stmt: String): CompletionStage[Done] =
+    delegate.executeDDL(stmt).toJava
+
+  /**
    * See <a href="http://docs.datastax.com/en/cql/3.3/cql/cql_using/useCreateTableTOC.html">Creating a table</a>.
    *
    * The returned `CompletionStage` is completed when the table has been created,
    * or if the statement fails.
    */
+  @deprecated("Use executeDDL instead.", "0.100")
   def executeCreateTable(stmt: String): CompletionStage[Done] =
-    delegate.executeCreateTable(stmt).toJava
+    delegate.executeDDL(stmt).toJava
 
   /**
    * Create a `PreparedStatement` that can be bound and used in

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
@@ -195,16 +195,25 @@ final class CassandraSession(
     }
 
   /**
+   * Execute <a href=https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlCommandsTOC.html">CQL commands</a>
+   * to manage database resources (create, replace, alter, and drop tables, indexes, user-defined types, etc).
+   *
+   * The returned `Future` is completed when the command is done, or if the statement fails.
+   */
+  def executeDDL(stmt: String): Future[Done] =
+    for {
+      s <- underlying()
+      _ <- s.executeAsync(stmt).asScala
+    } yield Done
+
+  /**
    * See <a href="http://docs.datastax.com/en/cql/3.3/cql/cql_using/useCreateTableTOC.html">Creating a table</a>.
    *
    * The returned `Future` is completed when the table has been created,
    * or if the statement fails.
    */
-  def executeCreateTable(stmt: String): Future[Done] =
-    for {
-      s <- underlying()
-      _ <- s.executeAsync(stmt).asScala
-    } yield Done
+  @deprecated("Use executeDDL instead.", "0.100")
+  def executeCreateTable(stmt: String): Future[Done] = executeDDL(stmt)
 
   /**
    * Create a `PreparedStatement` that can be bound and used in


### PR DESCRIPTION
## Purpose

Make API clearer by adding a new method `executeDdl` and deprecating `executeCreateTable` which can also be used to execute other DDL commands (to create indexes, udt, etc). 

## References

https://github.com/lagom/lagom/issues/647

## Changes

For both Java and Scala APIs:

1. Deprecate `executeCreateTable`
2. Add `executeDdl`
