### PR TITLE
Cleanup (incuding reference.conf) after config-table is removed

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -161,10 +161,6 @@ cassandra-journal {
   # If the table doesn't exist it is automatically created.
   metadata-table = "metadata"
 
-  # Name of the table to be created/used for journal config.
-  # If the table doesn't exist it is automatically created.
-  config-table = "config"
-
   # TODO remove this and just query cassandra to see what version it is
   # Set this to on to only use Cassandra 2.x compatible features,
   # i.e. if you are using a Cassandra 2.x server.

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -27,7 +27,6 @@ class CassandraPluginConfig(system: ActorSystem, config: Config) {
   val keyspace: String = config.getString("keyspace")
   val table: String = config.getString("table")
   val metadataTable: String = config.getString("metadata-table")
-  val configTable: String = validateTableName(config.getString("config-table"))
 
   val tableCompactionStrategy: CassandraCompactionStrategy =
     CassandraCompactionStrategy(config.getConfig("table-compaction-strategy"))


### PR DESCRIPTION
Lightbend CLA signed 

## Purpose

(Issue #544) which is cleanup #311 which has had some leftovers `reference.conf` and `CassandraPluginConfig`.

## Changes

Removed unused table name from `reference.conf`
Removed obsolete validation of unused table name in `CassandraPluginConfig`

