### PR TITLE
Fix eventual-consistency-delay log alert logic(akka#547)

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -96,12 +96,12 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
   private val queryPluginConfig =
     new CassandraReadJournalConfig(cfg, writePluginConfig)
 
-  if (queryPluginConfig.eventsByTagEventualConsistency < 2.seconds) {
-    log.info(
-      "EventsByTag eventual consistency set below 2 seconds. This can result in missed events. See reference.conf for details.")
-  } else if (queryPluginConfig.eventsByTagEventualConsistency < 1.seconds) {
+  if (queryPluginConfig.eventsByTagEventualConsistency < 1.seconds) {
     log.warning(
       "EventsByTag eventual consistency set below 1 second. This is likely to result in missed events. See reference.conf for details.")
+  } else if (queryPluginConfig.eventsByTagEventualConsistency < 2.seconds) {
+    log.info(
+      "EventsByTag eventual consistency set below 2 seconds. This can result in missed events. See reference.conf for details.")
   }
   private val eventAdapters = Persistence(system).adaptersFor(writePluginId)
 


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
fix the print log logic about checking the eventual consistency delay is been set lower than 2s


## Changes
Changed `CassandraReadJournal.scala` 
<!-- Bullets for important changes in this PR -->

## Background Context

<!-- Why did you take this approach? -->
