### PR TITLE
Replace executeCreateTable with executeDdl in CassandraSession (backport)

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/session/javadsl/CassandraSession.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/session/javadsl/CassandraSession.scala
@@ -73,13 +73,23 @@ final class CassandraSession(delegate: akka.persistence.cassandra.session.scalad
     delegate.underlying().toJava
 
   /**
+   * Execute <a href=https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlCommandsTOC.html">CQL commands</a>
+   * to manage database resources (create, replace, alter, and drop tables, indexes, user-defined types, etc).
+   *
+   * The returned `CompletionStage` is completed when the command is done, or if the statement fails.
+   */
+  def executeDDL(stmt: String): CompletionStage[Done] =
+    delegate.executeDDL(stmt).toJava
+
+  /**
    * See <a href="http://docs.datastax.com/en/cql/3.3/cql/cql_using/useCreateTableTOC.html">Creating a table</a>.
    *
    * The returned `CompletionStage` is completed when the table has been created,
    * or if the statement fails.
    */
+  @deprecated("Use executeDDL instead.", "0.100")
   def executeCreateTable(stmt: String): CompletionStage[Done] =
-    delegate.executeCreateTable(stmt).toJava
+    delegate.executeDDL(stmt).toJava
 
   /**
    * Create a `PreparedStatement` that can be bound and used in

--- a/core/src/main/scala/akka/persistence/cassandra/session/scaladsl/CassandraSession.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/session/scaladsl/CassandraSession.scala
@@ -199,16 +199,25 @@ final class CassandraSession(
     }
 
   /**
+   * Execute <a href=https://docs.datastax.com/en/archived/cql/3.3/cql/cql_reference/cqlCommandsTOC.html">CQL commands</a>
+   * to manage database resources (create, replace, alter, and drop tables, indexes, user-defined types, etc).
+   *
+   * The returned `Future` is completed when the command is done, or if the statement fails.
+   */
+  def executeDDL(stmt: String): Future[Done] =
+    for {
+      s <- underlying()
+      _ <- s.executeAsync(stmt).asScala
+    } yield Done
+
+  /**
    * See <a href="http://docs.datastax.com/en/cql/3.3/cql/cql_using/useCreateTableTOC.html">Creating a table</a>.
    *
    * The returned `Future` is completed when the table has been created,
    * or if the statement fails.
    */
-  def executeCreateTable(stmt: String): Future[Done] =
-    for {
-      s <- underlying()
-      _ <- s.executeAsync(stmt).asScala
-    } yield Done
+  @deprecated("Use executeDDL instead.", "0.100")
+  def executeCreateTable(stmt: String): Future[Done] = executeDDL(stmt)
 
   /**
    * Create a `PreparedStatement` that can be bound and used in

--- a/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
@@ -18,6 +18,7 @@ import com.typesafe.config.ConfigFactory
 
 import scala.collection.JavaConverters._
 import scala.compat.java8.FutureConverters._
+import scala.compat.java8.OptionConverters._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
@@ -64,7 +65,7 @@ class CassandraSessionSpec extends CassandraSpec(CassandraSessionSpec.config) {
 
   def createTable(): Unit =
     Await.ready(
-      session.executeCreateTable(s"""
+      session.executeDDL(s"""
       CREATE TABLE IF NOT EXISTS testcounts (
         partition text,
         key text,
@@ -130,6 +131,18 @@ class CassandraSessionSpec extends CassandraSpec(CassandraSessionSpec.config) {
       row should be(Optional.empty())
     }
 
+    "create indexes" in {
+      Await.result(session.executeDDL("CREATE INDEX IF NOT EXISTS count_idx ON testcounts(count)").toScala, 5.seconds)
+      val row = Await
+        .result(
+          session
+            .selectOne("SELECT * FROM system_schema.indexes WHERE table_name = ? ALLOW FILTERING", "testcounts")
+            .toScala,
+          5.seconds)
+        .asScala
+      row.map(index => index.getString("table_name") -> index.getString("index_name")) should be(
+        Some("testcounts" -> "count_idx"))
+    }
   }
 
 }


### PR DESCRIPTION
Backport of https://github.com/akka/akka-persistence-cassandra/pull/539

(cherry picked from commit 467f80ebacc48b4eae085f4ecc5e451c70edd527)
