### PR TITLE
 Write to tag scanning table as async writes rather than batch (#481)

### DIFF
--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -93,6 +93,9 @@ abstract class CassandraSpec(
 
   lazy val queryJournal = PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
 
+  // cluster is shutdown by cassandra lifecycle
+  lazy val journalSession = cluster.connect(journalName)
+
   override def port(): Int = CassandraLifecycle.mode match {
     case External => 9042
     case Embedded => randomPort

--- a/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
@@ -15,13 +15,11 @@ import scala.concurrent.duration._
 object RecoveryLoadSpec {
   val config = ConfigFactory.parseString(s"""
       akka.loglevel = INFO
-      cassandra-journal.keyspace=RecoveryLoadSpec
       cassandra-journal.events-by-tag.enabled = on
       cassandra-journal.events-by-tag.scanning-flush-interval = 2s
       cassandra-journal.replay-filter.mode = off
       cassandra-journal.log-queries = off
-      cassandra-snapshot-store.keyspace=RecoveryLoadSpecSnapshot
-      cassandra-snapshot-store.log-queries = on
+      cassandra-snapshot-store.log-queries = off
     """).withFallback(CassandraLifecycle.config)
 
   final case class Init(numberOfEvents: Int)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import akka.actor._
+import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, TestTaggingActor }
+import com.typesafe.config.ConfigFactory
+
+object TagScanningSpec {
+  val config = ConfigFactory.parseString(s"""
+      akka.loglevel = INFO
+      cassandra-journal.events-by-tag.enabled = on
+      cassandra-journal.events-by-tag.scanning-flush-interval = 2s
+      cassandra-journal.replay-filter.mode = off
+      cassandra-journal.log-queries = off
+      cassandra-snapshot-store.log-queries = off
+    """).withFallback(CassandraLifecycle.config)
+}
+
+class TagScanningSpec extends CassandraSpec(TagScanningSpec.config) {
+
+  "Tag writing" must {
+    "complete writes to tag scanning for many persistent actors" in {
+      val nrActors = 25
+      (0 until nrActors).foreach { i =>
+        val ref = system.actorOf(TestTaggingActor.props(s"$i"))
+        ref ! "msg"
+      }
+
+      awaitAssert {
+        import scala.collection.JavaConverters._
+        val expected = (0 until nrActors).map(n => (s"$n".toInt, 1L)).toList
+        val scanning = journalSession
+          .execute("select * from tag_scanning")
+          .all()
+          .asScala
+          .toList
+          .map(row => (row.getString("persistence_id"), row.getLong("sequence_nr")))
+          .filterNot(_._1 == "persistenceInit")
+          .map { case (pid, seqNr) => (pid.toInt, seqNr) } // sorting by pid makes the failure message easy to interpret
+          .sortBy(_._1)
+        scanning shouldEqual expected
+      }
+    }
+  }
+}


### PR DESCRIPTION
Backport of https://github.com/akka/akka-persistence-cassandra/pull/481

* Write to tag scanning table as async writes rather than batch

Run 10 at a time, only schedule next tick once all have completed

Refs #442

(cherry picked from commit 81f00662253201eb57e9418a9cd2587b32789469)
