### PR TITLE
test with Akka 2.6.0-RC1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ jobs:
       name: Run all tests with Jdk 8
     - script: jabba use adopt@~1.11-0 && java -version && docker-compose up -d cassandra && sbt +test
       name: Run all tests with Jdk 11
-    - script: jabba use adopt@~1.11-0 && java -version && docker-compose up -d cassandra && sbt -Doverride.akka.version="2.6.0-M4" +test
+    - script: jabba use adopt@~1.11-0 && java -version && docker-compose up -d cassandra && sbt -Doverride.akka.version="2.6.0-RC1" +test
       name: Run all the tests with Akka 2.6
 
     - stage: whitesource

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -44,6 +44,9 @@ object CassandraLifecycle {
     akka.test.single-expect-default = 20s
     akka.test.filter-leeway = 20s
     akka.actor.serialize-messages=on
+    # needed when testing with Akka 2.6
+    akka.actor.allow-java-serialization = on
+    akka.actor.warn-about-java-serializer-usage = off
     """).resolve()
 
     // this isn't used if extending CassandraSpec

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
@@ -2,6 +2,7 @@
  * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
  */
 
+/* FIXME enable again when branch for Akka 2.6.x
 package akka.persistence.cassandra.journal
 
 import akka.actor.testkit.typed.scaladsl.ActorTestKit
@@ -177,7 +178,8 @@ class CassandraLoadTypedSpec extends CassandraSpec(CassandraLoadTypedSpec.config
     "have some reasonable write throughput" in {
       val probe = testKit.createTestProbe[String]
       val processor =
-        system.spawnAnonymous(Processor.behavior(PersistenceId("p1"), probe.ref, notifyProbeInEventHandler = false))
+        system.spawnAnonymous(
+          Processor.behavior(PersistenceId.ofUniqueId("p1"), probe.ref, notifyProbeInEventHandler = false))
       (1 to iterations).foreach { _ =>
         testThroughput(processor, probe)
       }
@@ -186,10 +188,12 @@ class CassandraLoadTypedSpec extends CassandraSpec(CassandraLoadTypedSpec.config
     "work properly under load" in {
       val probe = testKit.createTestProbe[String]
       def spawnProcessor() =
-        system.spawnAnonymous(Processor.behavior(PersistenceId("p2"), probe.ref, notifyProbeInEventHandler = true))
+        system.spawnAnonymous(
+          Processor.behavior(PersistenceId.ofUniqueId("p2"), probe.ref, notifyProbeInEventHandler = true))
       val processor = spawnProcessor()
       testLoad(processor, () => spawnProcessor(), probe)
     }
 
   }
 }
+ */

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -44,6 +44,12 @@ object Common extends AutoPlugin {
       // define scalac options that are only valid or desirable for 2.12
       if (scalaVersion.value.startsWith("2.13"))
         Seq()
+      else if (Dependencies.AkkaVersion.startsWith("2.6"))
+        Seq(
+          // -deprecation causes some warnings with Akka 2.6 because of deprecation of ActorMaterializer
+          // We only enable `fatal-warnings` on Akka 2.5 and accept the warning on 2.6
+          "-Xfuture" // invalid in 2.13
+        )
       else
         Seq(
           // -deprecation causes some warnings on 2.13 because of collection converters.


### PR DESCRIPTION
* comment out CassandraLoadTypedSpec because of API change of PersistenceId
  between 2.5.x and 2.6.x
* no fatal warning for 2.6, because of deprecation of ActorMaterializer

Refs #555