### PR TITLE
Fix change in jabba java 8 version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,8 @@ before_install:
   - git fetch --unshallow
   # using jabba for custom jdk management
   - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.1/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install adopt@~1.8.202-08
-  - jabba install adopt@~1.11.0-1
+  - jabba install adopt@~1.8.0-222
+  - jabba install adopt@~1.11.0-4
 
 before_script:
   - unset _JAVA_OPTIONS


### PR DESCRIPTION
The format of the 1.8 jabba names has had a 0 added so all the release-0.x builds are failing