### PR TITLE
End new persistence id search without relying on refresh interval

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -333,8 +333,8 @@ import com.datastax.driver.core.utils.UUIDs
           updateQueryState(QueryInProgress())
           if (log.isDebugEnabled) {
             log.debug(
-              s"[${stageUuid}] " + "{}: Executing query to look for missing. Timebucket: {}. From: {}. To: {}",
-              session.tag,
+              s"[${stageUuid}] " + s"${session.tag}: Executing query to look for {}. Timebucket: {}. From: {}. To: {}",
+              if (missing.gapDetected) "missing" else "previous events",
               missing.bucket,
               formatOffset(missing.previousOffset),
               formatOffset(missing.maxOffset))
@@ -592,9 +592,9 @@ import com.datastax.driver.core.utils.UUIDs
               abortMissingSearch(missing)
             } else {
               log.debug(
-                "[{}] [{}]: Still looking for missing. {}. Duration left for search: {}",
-                stageUuid,
+                s"[${stageUuid}] [{}]: Still looking for {}. {}. Duration left for search: {}",
                 session.tag,
+                if (missing.gapDetected) "missing" else "previous events",
                 stageState,
                 timeLeft.pretty)
               updateStageState(_.copy(missingLookup = stageState.missingLookup.map(m => {

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -27,7 +27,6 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.{ ActorAttributes, ActorMaterializer }
 import akka.util.ByteString
-import com.datastax.driver.core._
 import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
 import com.datastax.driver.core.utils.UUIDs
 import com.typesafe.config.Config
@@ -38,6 +37,7 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 import akka.serialization.SerializationExtension
+import com.datastax.driver.core.{ ConsistencyLevel, PreparedStatement, Session }
 
 object CassandraReadJournal {
   //temporary counter for keeping Read Journal metrics unique
@@ -349,7 +349,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
     val currentBucket =
       TimeBucket(System.currentTimeMillis(), writePluginConfig.bucketSize)
     val initialTagPidSequenceNrs =
-      if (usingOffset && currentBucket.within(fromOffset))
+      if (usingOffset && currentBucket.within(fromOffset) && queryPluginConfig.eventsByTagOffsetScanning > Duration.Zero)
         scanTagSequenceNrs(tag, fromOffset)
       else
         Future.successful(Map.empty[Tag, (TagPidSequenceNr, UUID)])

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -798,7 +798,7 @@ class EventsByTagLongRefreshIntervalSpec
       ConfigFactory
         .parseString(
           """
-     akka.loglevel = DEBUG
+     akka.loglevel = INFO 
      cassandra-query-journal {
       refresh-interval = 10s # set large enough so that it will fail the test if a refresh is required to continue the stream
       events-by-tag {
@@ -831,6 +831,8 @@ class EventsByTagLongRefreshIntervalSpec
 
     pa.tell(Tagged("cat2", Set("animal")), sender.ref)
     sender.expectMsg("cat2-done")
+    // flush interval for tag writes is 0ms but still give some time for the tag write to complete
+    sender.expectNoMessage(250.millis)
 
     withProbe(queries.eventsByTag(tag = "animal", offset = offset).runWith(TestSink.probe[Any]), probe => {
       probe.request(2)

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -803,7 +803,7 @@ class EventsByTagLongRefreshIntervalSpec
       refresh-interval = 10s # set large enough so that it will fail the test if a refresh is required to continue the stream
       events-by-tag {
         gap-timeout = 30s
-        offset-scanning-period = 0ms # do no scanning so each new persistence id triggers the serach
+        offset-scanning-period = 0ms # do no scanning so each new persistence id triggers the search
         eventual-consistency-delay = 0ms  # speed up the test
       }
     } 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -548,7 +548,7 @@ class EventsByTagStageSpec
       sub.expectNoMessage(100.millis)
       writeTaggedEvent(nowTime, PersistentRepr("p1e11", 11, "p-1"), Set(tag), 11, bucketSize)
       // wait more than the new persistence id timeout but less than the gap-timeout
-      sub.expectNextWithTimeoutPF(2.seconds, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
+      sub.expectNextWithTimeoutPF(newPersistenceIdTimeout * 1.1, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
       sub.cancel()
     }
   }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -62,6 +62,7 @@ object EventsByTagStageSpec {
 
 }
 
+// Writes events directly to the tables rather than via the persistence API
 class EventsByTagStageSpec
     extends CassandraSpec(EventsByTagStageSpec.config)
     with BeforeAndAfterAll


### PR DESCRIPTION
To be ported to the master branch

Two improvements;
* Check if the deadline for a new persistence id search has elapsed when a query is exhausted, not on the next refresh interval
* Schedule an extra refresh based on the new persistence id deadline if it is smaller than the refresh interval

Refs https://github.com/akka/akka-persistence-cassandra/issues/570