### PR TITLE
Fix read journal metrics category in multi-plugin scenario

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -53,7 +53,7 @@ import scala.util.{ Failure, Success, Try }
  * Inheritance is possible but without any guarantees for future source compatibility.
  */
 @DoNotInherit
-class CassandraJournal(cfg: Config)
+class CassandraJournal(cfg: Config, cfgPath: String)
     extends AsyncWriteJournal
     with CassandraRecovery
     with CassandraStatements
@@ -99,7 +99,7 @@ class CassandraJournal(cfg: Config)
     config.sessionSettings,
     context.dispatcher,
     log,
-    metricsCategory = s"${self.path.name}",
+    metricsCategory = cfgPath,
     init = (session: Session) => executeCreateKeyspaceAndTables(session, config))
 
   private val tagWriterSession = TagWritersSession(

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalProvider.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalProvider.scala
@@ -9,11 +9,12 @@ import akka.persistence.query.ReadJournalProvider
 import com.typesafe.config.Config
 import scala.util.control.NonFatal
 
-class CassandraReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
+class CassandraReadJournalProvider(system: ExtendedActorSystem, config: Config, configPath: String)
+    extends ReadJournalProvider {
 
   override val scaladslReadJournal: scaladsl.CassandraReadJournal =
     try {
-      new scaladsl.CassandraReadJournal(system, config)
+      new scaladsl.CassandraReadJournal(system, config, configPath)
     } catch {
       case NonFatal(e) =>
         // TODO can be removed when https://github.com/akka/akka/issues/18976 is fixed

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -35,7 +35,7 @@ import com.datastax.driver.core.policies.LoggingRetryPolicy
 import com.datastax.driver.core.utils.Bytes
 import com.typesafe.config.Config
 
-class CassandraSnapshotStore(cfg: Config)
+class CassandraSnapshotStore(cfg: Config, cfgPath: String)
     extends SnapshotStore
     with CassandraStatements
     with ActorLogging
@@ -58,7 +58,7 @@ class CassandraSnapshotStore(cfg: Config)
     snapshotConfig.sessionSettings,
     context.dispatcher,
     log,
-    metricsCategory = s"${self.path.name}",
+    metricsCategory = cfgPath,
     init = session => executeCreateKeyspaceAndTables(session, snapshotConfig))
 
   private val writeRetryPolicy = new LoggingRetryPolicy(new FixedRetryPolicy(snapshotConfig.writeRetries))

--- a/core/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalOverrideSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalOverrideSpec.scala
@@ -16,13 +16,14 @@ import com.typesafe.config.{ Config, ConfigFactory }
 
 import scala.concurrent.duration._
 
-class JournalOverride(as: ExtendedActorSystem, config: Config) extends CassandraReadJournal(as, config) {
+class JournalOverride(as: ExtendedActorSystem, config: Config, configPath: String)
+    extends CassandraReadJournal(as, config, configPath) {
   override private[akka] def mapEvent(pr: PersistentRepr) =
     PersistentRepr("cat", pr.sequenceNr, pr.persistenceId, pr.manifest, pr.deleted, pr.sender, pr.writerUuid)
 }
 
-class JournalOverrideProvider(as: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
-  override def scaladslReadJournal() = new JournalOverride(as, config)
+class JournalOverrideProvider(as: ExtendedActorSystem, config: Config, configPath: String) extends ReadJournalProvider {
+  override def scaladslReadJournal() = new JournalOverride(as, config, configPath)
   override def javadslReadJournal() = null
 }
 


### PR DESCRIPTION
* also uses improvements made in akka/akka#19822 to unify metrics
  category logic for all plugins: write, read and snapshot store

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Fixes read journal Cassandra client metrics category when multiple instances of the plugin used.

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #579

## Changes

* read, write and snapshot store plugins now use config path for metrics categories