### PR TITLE
Fix read journal metrics category in multi-plugin scenario - release-0.50

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -42,7 +42,7 @@ import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
 import akka.annotation.InternalApi
 import com.typesafe.config.Config
 
-class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraRecovery with CassandraStatements {
+class CassandraJournal(cfg: Config, cfgPath: String) extends AsyncWriteJournal with CassandraRecovery with CassandraStatements {
 
   import CassandraJournal._
   val config = new CassandraJournalConfig(context.system, cfg)
@@ -82,7 +82,7 @@ class CassandraJournal(cfg: Config) extends AsyncWriteJournal with CassandraReco
     config.sessionSettings,
     context.dispatcher,
     log,
-    metricsCategory = s"${self.path.name}",
+    metricsCategory = cfgPath,
     init = session =>
     executeCreateKeyspaceAndTables(session, config, maxTagId)
       .flatMap(_ => initializePersistentConfig(session).map(_ => Done))

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalProvider.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalProvider.scala
@@ -9,11 +9,15 @@ import com.typesafe.config.Config
 import akka.persistence.query.javadsl.ReadJournal
 import scala.util.control.NonFatal
 
-class CassandraReadJournalProvider(system: ExtendedActorSystem, config: Config) extends ReadJournalProvider {
+class CassandraReadJournalProvider(
+  system:     ExtendedActorSystem,
+  config:     Config,
+  configPath: String
+) extends ReadJournalProvider {
 
   override val scaladslReadJournal: scaladsl.CassandraReadJournal =
     try {
-      new scaladsl.CassandraReadJournal(system, config)
+      new scaladsl.CassandraReadJournal(system, config, configPath)
     } catch {
       case NonFatal(e) =>
         // TODO can be removed when https://github.com/akka/akka/issues/18976 is fixed

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -30,7 +30,10 @@ import java.util.NoSuchElementException
 import scala.util.Success
 import scala.util.Failure
 
-class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraStatements with ActorLogging {
+class CassandraSnapshotStore(
+  cfg:     Config,
+  cfgPath: String
+) extends SnapshotStore with CassandraStatements with ActorLogging {
   import CassandraSnapshotStore._
   val config = new CassandraSnapshotStoreConfig(context.system, cfg)
   val serialization = SerializationExtension(context.system)
@@ -47,7 +50,7 @@ class CassandraSnapshotStore(cfg: Config) extends SnapshotStore with CassandraSt
     config.sessionSettings,
     context.dispatcher,
     log,
-    metricsCategory = s"${self.path.name}",
+    metricsCategory = cfgPath,
     init = session => executeCreateKeyspaceAndTables(session, config)
   )
 


### PR DESCRIPTION
* also uses improvements made in akka/akka#19822 to unify metrics
  category logic for all plugins: write, read and snapshot store

<!--
# Pull Request Checklist

* [ ] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [ ] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [ ] Have you updated the documentation?
* [ ] Have you added tests for any changed functionality?
-->
## Purpose

Fixes read journal Cassandra client metrics category when multiple instances of the plugin used - for MV-based eventsByTag version (`release-0.50`)

## References

<!--
  Are there any relevant issues / PRs / mailing lists discussions?
  Please DON`T use `Fixes` notation.
-->
References #579, #580

## Changes

* read, write and snapshot store plugins now use config path for metrics categories
