### PR TITLE
End new persistence id search without relying on refresh interval (#577)

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -26,7 +26,6 @@ import akka.stream.scaladsl.Flow
 import akka.stream.scaladsl.Source
 import akka.stream.{ ActorAttributes, ActorMaterializer }
 import akka.util.ByteString
-import com.datastax.driver.core._
 import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
 import com.datastax.driver.core.utils.UUIDs
 import com.typesafe.config.Config
@@ -37,6 +36,7 @@ import scala.concurrent.duration._
 import scala.util.{ Failure, Success }
 import scala.util.control.NonFatal
 import akka.serialization.SerializationExtension
+import com.datastax.driver.core.{ ConsistencyLevel, PreparedStatement, Session }
 
 object CassandraReadJournal {
 
@@ -342,7 +342,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
     val currentBucket =
       TimeBucket(System.currentTimeMillis(), writePluginConfig.bucketSize)
     val initialTagPidSequenceNrs =
-      if (usingOffset && currentBucket.within(fromOffset))
+      if (usingOffset && currentBucket.within(fromOffset) && queryPluginConfig.eventsByTagOffsetScanning > Duration.Zero)
         scanTagSequenceNrs(tag, fromOffset)
       else
         Future.successful(Map.empty[Tag, (TagPidSequenceNr, UUID)])

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -62,6 +62,7 @@ object EventsByTagStageSpec {
 
 }
 
+// Writes events directly to the tables rather than via the persistence API
 class EventsByTagStageSpec
     extends CassandraSpec(EventsByTagStageSpec.config)
     with BeforeAndAfterAll
@@ -547,7 +548,7 @@ class EventsByTagStageSpec
       sub.expectNoMessage(100.millis)
       writeTaggedEvent(nowTime, PersistentRepr("p1e11", 11, "p-1"), Set(tag), 11, bucketSize)
       // wait more than the new persistence id timeout but less than the gap-timeout
-      sub.expectNextWithTimeoutPF(2.seconds, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
+      sub.expectNextWithTimeoutPF(newPersistenceIdTimeout * 1.1, { case EventEnvelope(_, "p-1", 11, "p1e11") => })
       sub.cancel()
     }
   }


### PR DESCRIPTION
Port of https://github.com/akka/akka-persistence-cassandra/pull/577 to master