### PR TITLE
Remove static column used in reads, #180

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -258,7 +258,7 @@ trait CassandraStatements {
 
   private[akka] def selectHighestSequenceNr =
     s"""
-     SELECT sequence_nr, used FROM ${tableName} WHERE
+     SELECT sequence_nr FROM ${tableName} WHERE
        persistence_id = ? AND
        partition_nr = ?
        ORDER BY sequence_nr

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -451,7 +451,7 @@ import com.github.ghik.silencer.silent
                     persistenceId,
                     expectedNextSeqNr,
                     partition)
-                  checkForGaps()
+                  checkForGaps(foundEmptyPartitionCount = 0)
                 } else if (refreshInterval.isEmpty) {
                   completeStage()
                 } else {
@@ -550,22 +550,26 @@ import com.github.ghik.silencer.silent
         }
       }
 
-      // The strategy is simple, if full partition was cleaned up we will find null-row
-      // i.e row: <persistence_id>, <partition_nr>, null, ...
-      // If such row exists, we have to switch partition and continue to fetching
-      def checkForGaps(): Unit = {
+      // See PR #509 for background
+      // Only used when gapFreeSequenceNumbers==false
+      // if full partition was cleaned up we look for two empty partitions before completing
+      def checkForGaps(foundEmptyPartitionCount: Int): Unit = {
         session.selectSingleRow(persistenceId, partition).onComplete {
           getAsyncCallback[Try[Option[Row]]] {
             case Success(mbRow) =>
-              val r = mbRow.map(row => (row.getBool("used"), row.getLong("sequence_nr")))
-              r match {
-                case Some((true, _)) =>
-                  //We increment partition nr manually, otherwise we will break `lookingForMissingSeqNr` logic
-                  partition = partition + 1
+              mbRow.map(_.getLong("sequence_nr")) match {
+                case None | Some(0) =>
+                  // Some(0) when old schema with static used column, everything deleted in this partition
+                  if (foundEmptyPartitionCount == 5)
+                    completeStage()
+                  else {
+                    partition = partition + 1
+                    checkForGaps(foundEmptyPartitionCount + 1)
+                  }
+                case Some(_) =>
+                  if (foundEmptyPartitionCount == 0)
+                    partition = partition + 1
                   query(switchPartition = false)
-                case _ =>
-                  //No data found, but at least we tried
-                  completeStage()
               }
             case Failure(exception) =>
               throw new IllegalStateException("Should not be able to get here")

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -104,6 +104,12 @@ import akka.persistence.cassandra.journal.CassandraIntegrationSpec._
 
 class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender with WordSpecLike with Matchers {
 
+  private def stopAndWaitUntilTerminated(ref: ActorRef) = {
+    watch(ref)
+    ref ! PoisonPill
+    expectTerminated(ref)
+  }
+
   def subscribeToRangeDeletion(probe: TestProbe): Unit =
     system.eventStream.subscribe(probe.ref, classOf[JournalProtocol.DeleteMessagesTo])
 
@@ -146,6 +152,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
+      stopAndWaitUntilTerminated(processor1)
+
       val processor2 = system.actorOf(Props(classOf[ProcessorA], persistenceId, self), "p2")
       (1L to 16L).foreach { i =>
         expectMsgAllOf(s"a-${i}", i, true)
@@ -164,10 +172,14 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       val persistenceId = UUID.randomUUID().toString
       val processorAtomic = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
 
+      // more than 2 partitions not supported, will fail the write
+
       processorAtomic ! List("a-1", "a-2", "a-3", "a-4", "a-5", "a-6")
       (1L to 6L).foreach { i =>
         expectMsgAllOf(s"a-${i}", i, false)
       }
+
+      stopAndWaitUntilTerminated(processorAtomic)
 
       val testProbe = TestProbe()
       val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
@@ -191,6 +203,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
+      stopAndWaitUntilTerminated(processorAtomic)
+
       val testProbe = TestProbe()
       val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
       (1L to 6L).foreach { i =>
@@ -207,6 +221,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       (1L to 4L).foreach { i =>
         expectMsgAllOf(s"a-${i}", i, false)
       }
+
+      stopAndWaitUntilTerminated(processorAtomic)
 
       system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
       (1L to 4L).foreach { i =>
@@ -227,6 +243,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processorAtomic ! DeleteTo(5L)
       awaitRangeDeletion(deleteProbe)
 
+      stopAndWaitUntilTerminated(processorAtomic)
+
       val testProbe = TestProbe()
       system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
       testProbe.expectMsgAllOf(s"a-6", 6, true)
@@ -244,6 +262,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processor1 ! "b"
       expectMsg("updated-b-2")
 
+      stopAndWaitUntilTerminated(processor1)
+
       system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-1")
       expectMsg("updated-b-2")
@@ -259,6 +279,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
         processor1 ! "a"
         expectMsg(s"updated-a-${i}")
       }
+
+      stopAndWaitUntilTerminated(processor1)
 
       val processor2 =
         system.actorOf(Props(classOf[ProcessorCNoRecover], persistenceId, testActor, Recovery(toSequenceNr = 3L)))
@@ -276,6 +298,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processor1 ! "snap"
       expectMsg("snapped-a-1")
 
+      stopAndWaitUntilTerminated(processor1)
+
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-1")
       processor2 ! "b"
@@ -290,6 +314,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       }
       processor1 ! "snap"
       expectMsg("snapped-a-5")
+
+      stopAndWaitUntilTerminated(processor1)
 
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
@@ -315,6 +341,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processor1 ! DeleteTo(6L)
       awaitRangeDeletion(deleteProbe)
 
+      stopAndWaitUntilTerminated(processor1)
+
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
       processor2 ! "b"
@@ -332,6 +360,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
 
       p ! DeleteTo(1L)
       awaitRangeDeletion(deleteProbe)
+
+      stopAndWaitUntilTerminated(p)
 
       val r = system.actorOf(Props(classOf[ProcessorA], persistenceId, self))
 

--- a/docs/src/main/paradox/migrations.md
+++ b/docs/src/main/paradox/migrations.md
@@ -4,6 +4,25 @@
 
 * After being deprecated, the DateTieredCompactionStrategy has been removed.
 
+## Migrations to 0.101 and 0.102
+
+Version 0.101 and 0.102 removes the static column `used`. It is released in two versions to be able to
+support rolling update where an Akka Cluster is running a mix of versions 0.100 and 0.101 in the first update
+and then a mix of 0.101 and 0.102 in the second update.
+
+If you can accept a full cluster shutdown you can update to 0.102 directly.
+
+0.101 is not using the static column `used` in the reads but still populates it in the writes so that earlier
+versions can read it.
+
+0.102 is not using the static column `used` at all, but it can run with an old schema where the column exists. 
+
+After completed update to version 0.102 the column can be dropped with:
+
+```
+alter table akka.messages drop used;
+```  
+
 ### Migrations to 0.80 and later
 
 0.80 introduces a completely different way to manage tags for events. You can skip right ahead to 0.98 without going to


### PR DESCRIPTION
First step of removing the static column. Split into two steps to support rolling updates, see migration.md

Second part is in https://github.com/akka/akka-persistence-cassandra/pull/594

I will backport this to release-0.x branch

Refs #180