### PR TITLE
Remove static column used in writes and table definition, #180

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -29,7 +29,6 @@ trait CassandraStatements {
   private[akka] def createTable =
     s"""
       |CREATE TABLE IF NOT EXISTS ${tableName} (
-      |  used boolean static,
       |  persistence_id text,
       |  partition_nr bigint,
       |  sequence_nr bigint,
@@ -106,8 +105,8 @@ trait CassandraStatements {
     s"""
       INSERT INTO $tableName (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event,
         ${if (withMeta) "meta_ser_id, meta_ser_manifest, meta," else ""}
-        used, tags)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${if (withMeta) "?, ?, ?, " else ""} true, ?)
+        tags)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ${if (withMeta) "?, ?, ?, " else ""} ?)
     """
 
   // could just use the write tags statement if we're going to update all the fields.
@@ -276,12 +275,6 @@ trait CassandraStatements {
       INSERT INTO ${metadataTableName} (persistence_id, deleted_to)
       VALUES ( ?, ? )
     """
-
-  private[akka] def writeInUse =
-    s"""
-       INSERT INTO ${tableName} (persistence_id, partition_nr, used)
-       VALUES(?, ?, true)
-     """
 
   protected def tableName = s"${config.keyspace}.${config.table}"
   private def tagTableName = s"${config.keyspace}.${config.tagTable.name}"

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -35,7 +35,6 @@ CREATE KEYSPACE IF NOT EXISTS akka
 WITH REPLICATION = { 'class' : 'SimpleStrategy','replication_factor':1 };
 
 CREATE TABLE IF NOT EXISTS akka.messages (
-  used boolean static,
   persistence_id text,
   partition_nr bigint,
   sequence_nr bigint,


### PR DESCRIPTION
Second step of removing the static column. Split into two steps to support rolling updates, see migration.md

I will backport this to release-0.x branch

Refs #180