### PR TITLE
mark internal API #65

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -15,7 +15,10 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 import java.lang.{ Long => JLong }
 
-private[akka] trait CassandraEventUpdate extends CassandraStatements {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] trait CassandraEventUpdate extends CassandraStatements {
 
   private[akka] val session: CassandraSession
   private[akka] def config: CassandraJournalConfig

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -605,7 +605,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
             .getOrElse(PartitionInfo(partitionNr, minSequenceNr(partitionNr), -1)))
   }
 
-  private[akka] def asyncHighestDeletedSequenceNumber(persistenceId: String): Future[Long] = {
+  @InternalApi private[akka] def asyncHighestDeletedSequenceNumber(persistenceId: String): Future[Long] = {
     preparedSelectDeletedTo match {
       case Some(pstmt) =>
         val boundSelectDeletedTo = pstmt.map(_.bind(persistenceId))
@@ -617,7 +617,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
     }
   }
 
-  private[akka] def asyncReadLowestSequenceNr(
+  @InternalApi private[akka] def asyncReadLowestSequenceNr(
       persistenceId: String,
       fromSequenceNr: Long,
       highestDeletedSequenceNumber: Long,
@@ -643,7 +643,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
       }
   }
 
-  private[akka] def asyncFindHighestSequenceNr(
+  @InternalApi private[akka] def asyncFindHighestSequenceNr(
       persistenceId: String,
       fromSequenceNr: Long,
       partitionSize: Long): Future[Long] = {
@@ -713,6 +713,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
 
   private case class SerializedAtomicWrite(persistenceId: String, payload: Seq[Serialized])
 
+  @InternalApi
   private[akka] case class Serialized(
       persistenceId: String,
       sequenceNr: Long,
@@ -726,6 +727,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
       timeUuid: UUID,
       timeBucket: TimeBucket)
 
+  @InternalApi
   private[akka] case class SerializedMeta(serialized: ByteBuffer, serManifest: String, serId: Int)
 
   private case class PartitionInfo(partitionNr: Long, minSequenceNr: Long, maxSequenceNr: Long)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -15,25 +15,47 @@ import akka.persistence.cassandra.journal.TagWriter.TagWriterSettings
 import com.typesafe.config.Config
 import scala.concurrent.duration._
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] sealed trait BucketSize {
   val durationMillis: Long
 }
 
-private[akka] case object Day extends BucketSize {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object Day extends BucketSize {
   override val durationMillis: Long = 1.day.toMillis
 }
-private[akka] case object Hour extends BucketSize {
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object Hour extends BucketSize {
   override val durationMillis: Long = 1.hour.toMillis
 }
-private[akka] case object Minute extends BucketSize {
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object Minute extends BucketSize {
   override val durationMillis: Long = 1.minute.toMillis
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 // Not to be used for real production apps. Just to make testing bucket transitions easier.
 private[akka] case object Second extends BucketSize {
   override val durationMillis: Long = 1.second.toMillis
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] object BucketSize {
   def fromString(value: String): BucketSize =
     Vector(Day, Hour, Minute, Second)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -27,7 +27,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
   private[akka] val eventDeserializer: CassandraJournal.EventDeserializer =
     new CassandraJournal.EventDeserializer(context.system)
 
-  private[akka] def asyncReadHighestSequenceNrInternal(persistenceId: String, fromSequenceNr: Long): Future[Long] = {
+  @InternalApi private[akka] def asyncReadHighestSequenceNrInternal(persistenceId: String, fromSequenceNr: Long): Future[Long] = {
     asyncHighestDeletedSequenceNumber(persistenceId).flatMap { h =>
       asyncFindHighestSequenceNr(persistenceId, math.max(fromSequenceNr, h), targetPartitionSize)
     }
@@ -95,7 +95,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
     }
   }
 
-  private[akka] def sendPreSnapshotTagWrites(
+  @InternalApi private[akka] def sendPreSnapshotTagWrites(
       minProgressNr: Long,
       fromSequenceNr: Long,
       pid: String,

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -12,9 +12,10 @@ import scala.concurrent.{ ExecutionContext, Future }
 import akka.persistence.cassandra.indent
 
 trait CassandraStatements {
-  private[akka] def config: CassandraJournalConfig
 
-  private[akka] def createKeyspace =
+  @InternalApi private[akka] def config: CassandraJournalConfig
+
+  @InternalApi private[akka] def createKeyspace =
     s"""
      |CREATE KEYSPACE IF NOT EXISTS ${config.keyspace}
      |WITH REPLICATION = { 'class' : ${config.replicationStrategy} }
@@ -26,7 +27,7 @@ trait CassandraStatements {
   // PersistentRepr.manifest is stored in event_manifest (sorry for naming confusion).
   // PersistentRepr.manifest is used by the event adapters (in akka-persistence).
   // ser_manifest together with ser_id is used for the serialization of the event (payload).
-  private[akka] def createTable =
+  @InternalApi private[akka] def createTable =
     s"""
       |CREATE TABLE IF NOT EXISTS ${tableName} (
       |  used boolean static,
@@ -50,7 +51,7 @@ trait CassandraStatements {
       |  AND compaction = ${indent(config.tableCompactionStrategy.asCQL, "    ")}
     """.stripMargin.trim
 
-  private[akka] def createTagsTable =
+  @InternalApi private[akka] def createTagsTable =
     s"""
       |CREATE TABLE IF NOT EXISTS ${tagTableName} (
       |  tag_name text,
@@ -94,7 +95,7 @@ trait CassandraStatements {
      |  PRIMARY KEY (persistence_id))
      """.stripMargin.trim
 
-  private[akka] def createMetadataTable =
+  @InternalApi private[akka] def createMetadataTable =
     s"""
      |CREATE TABLE IF NOT EXISTS $metadataTableName(
      |  persistence_id text PRIMARY KEY,
@@ -102,7 +103,7 @@ trait CassandraStatements {
      |  properties map<text,text>)
     """.stripMargin.trim
 
-  private[akka] def writeMessage(withMeta: Boolean) =
+  @InternalApi private[akka] def writeMessage(withMeta: Boolean) =
     s"""
       INSERT INTO $tableName (persistence_id, partition_nr, sequence_nr, timestamp, timebucket, writer_uuid, ser_id, ser_manifest, event_manifest, event,
         ${if (withMeta) "meta_ser_id, meta_ser_manifest, meta," else ""}
@@ -112,7 +113,7 @@ trait CassandraStatements {
 
   // could just use the write tags statement if we're going to update all the fields.
   // Fields that are not updated atm: writer_uuid and metadata fields
-  private[akka] def updateMessagePayloadAndTags =
+  @InternalApi private[akka] def updateMessagePayloadAndTags =
     s"""
        UPDATE $tableName
        SET
@@ -129,7 +130,7 @@ trait CassandraStatements {
         timebucket = ?
      """
 
-  private[akka] def addTagsToMessagesTable =
+  @InternalApi private[akka] def addTagsToMessagesTable =
     s"""
        UPDATE $tableName
        SET tags = tags + ?
@@ -141,7 +142,7 @@ trait CassandraStatements {
         timebucket = ?
      """
 
-  private[akka] def writeTags(withMeta: Boolean) =
+  @InternalApi private[akka] def writeTags(withMeta: Boolean) =
     s"""
        INSERT INTO $tagTableName(
         tag_name,
@@ -161,7 +162,7 @@ trait CassandraStatements {
         ?)
      """
 
-  private[akka] def updateMessagePayloadInTagView =
+  @InternalApi private[akka] def updateMessagePayloadInTagView =
     s"""
        UPDATE $tagTableName
        SET
@@ -177,7 +178,7 @@ trait CassandraStatements {
         tag_pid_sequence_nr = ?
      """
 
-  private[akka] def selectTagPidSequenceNr =
+  @InternalApi private[akka] def selectTagPidSequenceNr =
     s"""
        SELECT tag_pid_sequence_nr
        FROM $tagTableName WHERE
@@ -187,7 +188,7 @@ trait CassandraStatements {
        persistence_id = ?
      """.stripMargin
 
-  private[akka] def writeTagProgress =
+  @InternalApi private[akka] def writeTagProgress =
     s"""
        INSERT INTO $tagProgressTableName(
         persistence_id,
@@ -197,32 +198,32 @@ trait CassandraStatements {
         offset) VALUES (?, ?, ?, ?, ?)
      """
 
-  private[akka] def selectTagProgress =
+  @InternalApi private[akka] def selectTagProgress =
     s"""
        SELECT * from $tagProgressTableName WHERE
        persistence_id = ? AND
        tag = ?
      """
 
-  private[akka] def selectTagProgressForPersistenceId =
+  @InternalApi private[akka] def selectTagProgressForPersistenceId =
     s"""
        SELECT * from $tagProgressTableName WHERE
        persistence_id = ?
      """
 
-  private[akka] def writeTagScanning =
+  @InternalApi private[akka] def writeTagScanning =
     s"""
        INSERT INTO $tagScanningTableName(
          persistence_id, sequence_nr) VALUES (?, ?)
      """
 
-  private[akka] def selectTagScanningForPersistenceId =
+  @InternalApi private[akka] def selectTagScanningForPersistenceId =
     s"""
        SELECT sequence_nr from $tagScanningTableName WHERE
        persistence_id = ?
      """
 
-  private[akka] def deleteMessage =
+  @InternalApi private[akka] def deleteMessage =
     s"""
       DELETE FROM ${tableName} WHERE
         persistence_id = ? AND
@@ -230,7 +231,7 @@ trait CassandraStatements {
         sequence_nr = ?
     """
 
-  private[akka] def deleteMessages =
+  @InternalApi private[akka] def deleteMessages =
     if (config.cassandra2xCompat)
       s"""
       DELETE FROM ${tableName} WHERE
@@ -247,7 +248,7 @@ trait CassandraStatements {
         sequence_nr <= ?
     """
 
-  private[akka] def selectMessages =
+  @InternalApi private[akka] def selectMessages =
     s"""
       SELECT * FROM ${tableName} WHERE
         persistence_id = ? AND
@@ -256,7 +257,7 @@ trait CassandraStatements {
         sequence_nr <= ?
     """
 
-  private[akka] def selectHighestSequenceNr =
+  @InternalApi private[akka] def selectHighestSequenceNr =
     s"""
      SELECT sequence_nr, used FROM ${tableName} WHERE
        persistence_id = ? AND
@@ -265,19 +266,19 @@ trait CassandraStatements {
        DESC LIMIT 1
    """
 
-  private[akka] def selectDeletedTo =
+  @InternalApi private[akka] def selectDeletedTo =
     s"""
       SELECT deleted_to FROM ${metadataTableName} WHERE
         persistence_id = ?
     """
 
-  private[akka] def insertDeletedTo =
+  @InternalApi private[akka] def insertDeletedTo =
     s"""
       INSERT INTO ${metadataTableName} (persistence_id, deleted_to)
       VALUES ( ?, ? )
     """
 
-  private[akka] def writeInUse =
+  @InternalApi private[akka] def writeInUse =
     s"""
        INSERT INTO ${tableName} (persistence_id, partition_nr, used)
        VALUES(?, ?, true)
@@ -296,7 +297,7 @@ trait CassandraStatements {
    * Those statements are retried, because that could happen across different
    * nodes also but serializing those statements gives a better "experience".
    */
-  private[akka] def executeCreateKeyspaceAndTables(session: Session, config: CassandraJournalConfig)(
+  @InternalApi private[akka] def executeCreateKeyspaceAndTables(session: Session, config: CassandraJournalConfig)(
       implicit ec: ExecutionContext): Future[Done] = {
     import akka.cassandra.session._
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -21,7 +21,8 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.concurrent.duration._
 
-/*
+/**
+ * INTERNAL API
  * Groups writes into un-logged batches for the same partition.
  *
  * For the read stage to work correctly events must be written in order for a given
@@ -35,33 +36,35 @@ import scala.concurrent.duration._
  */
 @InternalApi private[akka] object TagWriter {
 
-  private[akka] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag): Props =
+  @InternalApi private[akka] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag): Props =
     Props(new TagWriter(settings, session, tag))
 
-  private[akka] case class TagWriterSettings(
+  @InternalApi private[akka] case class TagWriterSettings(
       maxBatchSize: Int,
       flushInterval: FiniteDuration,
       scanningFlushInterval: FiniteDuration,
       pubsubNotification: Boolean)
 
-  private[akka] case class TagProgress(
+  @InternalApi private[akka] case class TagProgress(
       persistenceId: PersistenceId,
       sequenceNr: SequenceNr,
       pidTagSequenceNr: TagPidSequenceNr)
 
-  /*
-   * Reset pid tag sequence numbers to the given [[TagProgress]] and discard any messages for the given persistenceId
+  /**
+   * INTERNAL API
+   * Reset pid tag sequence numbers to the given [[TagProgress]] and discard any messages for the given persistenceId.
    */
-  private[akka] case class ResetPersistenceId(tag: Tag, progress: TagProgress) extends NoSerializationVerificationNeeded
+  @InternalApi private[akka] case class ResetPersistenceId(tag: Tag, progress: TagProgress) extends NoSerializationVerificationNeeded
 
-  /*
-   * Sent in response to a [[ResetPersistenceId]]
+  /**
+   * INTERNAL APIa
+   * Sent in response to a [[ResetPersistenceId]].
    */
-  private[akka] case object ResetPersistenceIdComplete
+  @InternalApi private[akka] case object ResetPersistenceIdComplete
 
   // Flush buffer regardless of size
-  private[akka] case object Flush
-  private[akka] case object FlushComplete
+  @InternalApi private[akka] case object Flush
+  @InternalApi private[akka] case object FlushComplete
 
   type TagWriteSummary = Map[PersistenceId, PidProgress]
   case class PidProgress(seqNrFrom: SequenceNr, seqNrTo: SequenceNr, tagPidSequenceNr: TagPidSequenceNr, offset: UUID)
@@ -72,7 +75,7 @@ import scala.concurrent.duration._
   private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[(Serialized, TagPidSequenceNr)])
       extends TagWriteFinished
 
-  private[akka] case class DropState(pid: PersistenceId)
+  @InternalApi private[akka] case class DropState(pid: PersistenceId)
 
   val timeUuidOrdering = new Ordering[UUID] {
     override def compare(x: UUID, y: UUID) =
@@ -80,6 +83,9 @@ import scala.concurrent.duration._
   }
 }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] class TagWriter(settings: TagWriterSettings, session: TagWritersSession, tag: String)
     extends Actor
     with Timers

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -35,9 +35,12 @@ import scala.util.Try
 
 import akka.util.ByteString
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] object TagWriters {
 
-  private[akka] case class TagWritersSession(
+  @InternalApi private[akka] case class TagWritersSession(
       tagWritePs: () => Future[PreparedStatement],
       tagWriteWithMetaPs: () => Future[PreparedStatement],
       executeStatement: Statement => Future[Done],
@@ -92,7 +95,7 @@ import akka.util.ByteString
 
   }
 
-  private[akka] object BulkTagWrite {
+  @InternalApi private[akka] object BulkTagWrite {
     def apply(tw: TagWrite, owner: ActorRef): BulkTagWrite =
       BulkTagWrite(tw :: Nil, Nil)
   }
@@ -100,15 +103,16 @@ import akka.util.ByteString
   /**
    * All tag writes should be for the same persistenceId
    */
-  private[akka] case class BulkTagWrite(tagWrites: immutable.Seq[TagWrite], withoutTags: immutable.Seq[Serialized])
+  @InternalApi private[akka] case class BulkTagWrite(tagWrites: immutable.Seq[TagWrite], withoutTags: immutable.Seq[Serialized])
       extends NoSerializationVerificationNeeded
 
   /**
+   * INTERNAL API
    * All serialised should be for the same persistenceId
    * @param actorRunning migration sends these messages without the actor running so TagWriters should not
    *                     validate that the pid is running
    */
-  private[akka] case class TagWrite(tag: Tag, serialised: immutable.Seq[Serialized], actorRunning: Boolean = true)
+  @InternalApi private[akka] case class TagWrite(tag: Tag, serialised: immutable.Seq[Serialized], actorRunning: Boolean = true)
       extends NoSerializationVerificationNeeded
 
   def props(settings: TagWriterSettings, tagWriterSession: TagWritersSession): Props =

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TimeBucket.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TimeBucket.scala
@@ -10,6 +10,9 @@ import akka.annotation.InternalApi
 import akka.util.HashCode
 import com.datastax.driver.core.utils.UUIDs
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] object TimeBucket {
 
   def apply(timeuuid: UUID, bucketSize: BucketSize): TimeBucket =
@@ -25,6 +28,9 @@ import com.datastax.driver.core.utils.UUIDs
   }
 }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] final class TimeBucket private (val key: Long, val bucketSize: BucketSize) {
   def inPast: Boolean =
     key < TimeBucket.roundDownBucketSize(System.currentTimeMillis(), bucketSize)

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -34,13 +34,13 @@ import com.github.ghik.silencer.silent
  */
 @InternalApi private[akka] object EventsByPersistenceIdStage {
 
-  private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) {
+  @InternalApi private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) {
     def sequenceNr: Long = pr.sequenceNr
   }
 
-  private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr])
+  @InternalApi private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr])
 
-  private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized)
+  @InternalApi private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized)
 
   // materialized value
   trait Control {

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -32,6 +32,7 @@ import com.datastax.driver.core.utils.UUIDs
 import com.github.ghik.silencer.silent
 
 /**
+ * INTERNAL API
  * Walks the tag_views table.
  *
  * For current queries:
@@ -86,7 +87,7 @@ import com.github.ghik.silencer.silent
       usingOffset,
       initialTagPidSequenceNrs)
 
-  private[akka] class TagStageSession(
+  @InternalApi private[akka] class TagStageSession(
       val tag: String,
       session: Session,
       statements: EventByTagStatements,
@@ -100,7 +101,7 @@ import com.github.ghik.silencer.silent
     }
   }
 
-  private[akka] object TagStageSession {
+  @InternalApi private[akka] object TagStageSession {
     def apply(tag: String, session: Session, statements: EventByTagStatements, fetchSize: Int): TagStageSession =
       new TagStageSession(tag, session, statements, fetchSize)
   }
@@ -173,6 +174,9 @@ import com.github.ghik.silencer.silent
   }
 }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] class EventsByTagStage(
     session: TagStageSession,
     fromOffset: UUID,

--- a/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
@@ -20,6 +20,9 @@ import com.datastax.driver.core.utils.UUIDs
 import scala.concurrent.duration.{ Deadline, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi
 private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: Future[PreparedStatement])(
     implicit materializer: ActorMaterializer,
@@ -27,10 +30,11 @@ private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: 
   private val log = Logging(materializer.system, getClass)
 
   /**
+   * INTERNAL API
    * This could be its own stage and return half way through a query to better meet the deadline
    * but this is a quick and simple way to do it given we're scanning a small segment
    */
-  private[akka] def scan(
+  @InternalApi private[akka] def scan(
       tag: String,
       offset: UUID,
       bucket: TimeBucket,

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -57,6 +57,9 @@ object CassandraReadJournal {
       prepareSelectHighestNr: PreparedStatement,
       preparedSelectDeletedTo: PreparedStatement)
 
+  /**
+   * INTERNAL API
+   */
   @InternalApi private[akka] case class EventByTagStatements(byTagWithUpperLimit: PreparedStatement)
 }
 
@@ -285,7 +288,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       .mapMaterializedValue(_ => NotUsed)
       .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
 
-  private[akka] def eventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] =
+  @InternalApi private[akka] def eventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] =
     if (!config.eventsByTagEnabled)
       Source.failed(new IllegalStateException("Events by tag queries are disabled"))
     else {
@@ -353,7 +356,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
     } yield (statements, tagSequenceNrs)
   }
 
-  private[akka] def scanTagSequenceNrs(
+  @InternalApi private[akka] def scanTagSequenceNrs(
       tag: String,
       fromOffset: UUID): Future[Map[PersistenceId, (TagPidSequenceNr, UUID)]] = {
     val scanner =
@@ -425,7 +428,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       .mapConcat(r => toEventEnvelope(r.persistentRepr, TimeBasedUUID(r.offset)))
       .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
 
-  private[akka] def currentEventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] =
+  @InternalApi private[akka] def currentEventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] =
     if (!config.eventsByTagEnabled)
       Source.failed(new IllegalStateException("Events by tag queries are disabled"))
     else {

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -313,7 +313,10 @@ class CassandraSnapshotStore(cfg: Config, cfgPath: String)
 
 }
 
-private[snapshot] object CassandraSnapshotStore {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[snapshot] object CassandraSnapshotStore {
   private case object Init
 
   private case class Serialized(serialized: ByteBuffer, serManifest: String, serId: Int, meta: Option[SerializedMeta])


### PR DESCRIPTION
https://github.com/akka/akka-persistence-cassandra/issues/65

Based on the existing patterns I found, the rules I went with were:
* Annotated if a private[akka] top level type, object member case etc, or a def.
* Not annotated if `val`.
* If already having scaladoc or a top-level, added doc comment `INTERNAL API`.

Please update this if incorrect and I'll make the changes.