### PR TITLE
mark internal API #65

### DIFF
--- a/core/project/build.properties
+++ b/core/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -4,18 +4,22 @@
 
 package akka.persistence.cassandra.journal
 
+import java.lang.{ Long => JLong }
+
+import scala.collection.JavaConverters._
+import scala.concurrent.{ ExecutionContext, Future }
+
+import akka.annotation.InternalApi
 import akka.Done
 import akka.event.LoggingAdapter
 import akka.persistence.cassandra.journal.CassandraJournal.{ Serialized, TagPidSequenceNr }
 import akka.cassandra.session.scaladsl.CassandraSession
 import com.datastax.driver.core.{ PreparedStatement, Row, Statement }
 
-import scala.collection.JavaConverters._
-import scala.concurrent.{ ExecutionContext, Future }
-
-import java.lang.{ Long => JLong }
-
-private[akka] trait CassandraEventUpdate extends CassandraStatements {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] trait CassandraEventUpdate extends CassandraStatements {
 
   private[akka] val session: CassandraSession
   private[akka] def config: CassandraJournalConfig

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -605,7 +605,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
             .getOrElse(PartitionInfo(partitionNr, minSequenceNr(partitionNr), -1)))
   }
 
-  private[akka] def asyncHighestDeletedSequenceNumber(persistenceId: String): Future[Long] = {
+  @InternalApi private[akka] def asyncHighestDeletedSequenceNumber(persistenceId: String): Future[Long] = {
     preparedSelectDeletedTo match {
       case Some(pstmt) =>
         val boundSelectDeletedTo = pstmt.map(_.bind(persistenceId))
@@ -617,7 +617,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
     }
   }
 
-  private[akka] def asyncReadLowestSequenceNr(
+  @InternalApi private[akka] def asyncReadLowestSequenceNr(
       persistenceId: String,
       fromSequenceNr: Long,
       highestDeletedSequenceNumber: Long,
@@ -643,7 +643,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
       }
   }
 
-  private[akka] def asyncFindHighestSequenceNr(
+  @InternalApi private[akka] def asyncFindHighestSequenceNr(
       persistenceId: String,
       fromSequenceNr: Long,
       partitionSize: Long): Future[Long] = {
@@ -713,6 +713,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
 
   private case class SerializedAtomicWrite(persistenceId: String, payload: Seq[Serialized])
 
+  @InternalApi
   private[akka] case class Serialized(
       persistenceId: String,
       sequenceNr: Long,
@@ -726,6 +727,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
       timeUuid: UUID,
       timeBucket: TimeBucket)
 
+  @InternalApi
   private[akka] case class SerializedMeta(serialized: ByteBuffer, serManifest: String, serId: Int)
 
   private case class PartitionInfo(partitionNr: Long, minSequenceNr: Long, maxSequenceNr: Long)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -22,40 +22,21 @@ import scala.concurrent.duration._
   val durationMillis: Long
 }
 
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] case object Day extends BucketSize {
+private[akka] case object Day extends BucketSize {
   override val durationMillis: Long = 1.day.toMillis
 }
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] case object Hour extends BucketSize {
+private[akka] case object Hour extends BucketSize {
   override val durationMillis: Long = 1.hour.toMillis
 }
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] case object Minute extends BucketSize {
+private[akka] case object Minute extends BucketSize {
   override val durationMillis: Long = 1.minute.toMillis
 }
 
-/**
- * INTERNAL API
- */
-@InternalApi
 // Not to be used for real production apps. Just to make testing bucket transitions easier.
 private[akka] case object Second extends BucketSize {
   override val durationMillis: Long = 1.second.toMillis
 }
 
-/**
- * INTERNAL API
- */
-@InternalApi
 private[akka] object BucketSize {
   def fromString(value: String): BucketSize =
     Vector(Day, Hour, Minute, Second)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -15,25 +15,47 @@ import akka.persistence.cassandra.journal.TagWriter.TagWriterSettings
 import com.typesafe.config.Config
 import scala.concurrent.duration._
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] sealed trait BucketSize {
   val durationMillis: Long
 }
 
-private[akka] case object Day extends BucketSize {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object Day extends BucketSize {
   override val durationMillis: Long = 1.day.toMillis
 }
-private[akka] case object Hour extends BucketSize {
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object Hour extends BucketSize {
   override val durationMillis: Long = 1.hour.toMillis
 }
-private[akka] case object Minute extends BucketSize {
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] case object Minute extends BucketSize {
   override val durationMillis: Long = 1.minute.toMillis
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 // Not to be used for real production apps. Just to make testing bucket transitions easier.
 private[akka] case object Second extends BucketSize {
   override val durationMillis: Long = 1.second.toMillis
 }
 
+/**
+ * INTERNAL API
+ */
+@InternalApi
 private[akka] object BucketSize {
   def fromString(value: String): BucketSize =
     Vector(Day, Hour, Minute, Second)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -4,8 +4,11 @@
 
 package akka.persistence.cassandra.journal
 
+import scala.concurrent._
+
 import akka.Done
 import akka.actor.ActorRef
+import akka.annotation.InternalApi
 import akka.persistence.PersistentRepr
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.CassandraJournal.Tag
@@ -14,7 +17,6 @@ import akka.persistence.cassandra.journal.TagWriters.TagWrite
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.{ Extractors, TaggedPersistentRepr }
 import akka.stream.scaladsl.{ Sink, Source }
 import akka.util.OptionVal
-import scala.concurrent._
 import akka.cassandra.session._
 
 trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatements {
@@ -27,7 +29,9 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
   private[akka] val eventDeserializer: CassandraJournal.EventDeserializer =
     new CassandraJournal.EventDeserializer(context.system)
 
-  private[akka] def asyncReadHighestSequenceNrInternal(persistenceId: String, fromSequenceNr: Long): Future[Long] = {
+  @InternalApi private[akka] def asyncReadHighestSequenceNrInternal(
+      persistenceId: String,
+      fromSequenceNr: Long): Future[Long] = {
     asyncHighestDeletedSequenceNumber(persistenceId).flatMap { h =>
       asyncFindHighestSequenceNr(persistenceId, math.max(fromSequenceNr, h), targetPartitionSize)
     }
@@ -95,7 +99,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
     }
   }
 
-  private[akka] def sendPreSnapshotTagWrites(
+  @InternalApi private[akka] def sendPreSnapshotTagWrites(
       minProgressNr: Long,
       fromSequenceNr: Long,
       pid: String,

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraTagRecovery.scala
@@ -6,6 +6,7 @@ package akka.persistence.cassandra.journal
 
 import akka.Done
 import akka.actor.ActorRef
+import akka.annotation.InternalApi
 import akka.pattern.ask
 import akka.event.LoggingAdapter
 import akka.persistence.cassandra.journal.CassandraJournal.{ SequenceNr, Tag }
@@ -34,7 +35,7 @@ trait CassandraTagRecovery {
   // No other writes for this pid should be taking place during recovery
   // The result set size will be the number of distinct tags that this pid has used, expecting
   // that to be small (<10) so call to all should be safe
-  private[akka] def lookupTagProgress(persistenceId: String)(
+  @InternalApi private[akka] def lookupTagProgress(persistenceId: String)(
       implicit ec: ExecutionContext): Future[Map[Tag, TagProgress]] =
     preparedSelectTagProgressForPersistenceId
       .map(_.bind(persistenceId))
@@ -50,14 +51,16 @@ trait CassandraTagRecovery {
   // Before starting the actual recovery first go from the oldest tag progress -> fromSequenceNr
   // or min tag scanning sequence number, and fix any tags. This recovers any tag writes that
   // happened before the latest snapshot
-  private[akka] def tagScanningStartingSequenceNr(persistenceId: String): Future[SequenceNr] =
+  @InternalApi private[akka] def tagScanningStartingSequenceNr(persistenceId: String): Future[SequenceNr] =
     preparedSelectTagScanningForPersistenceId.map(_.bind(persistenceId)).flatMap(session.selectOne).map {
       case Some(row) => row.getLong("sequence_nr")
       case None      => 1L
     }
 
-  private[akka] def sendMissingTagWriteRaw(tp: Map[Tag, TagProgress], to: ActorRef, actorRunning: Boolean = true)(
-      rawEvent: RawEvent): RawEvent = {
+  @InternalApi private[akka] def sendMissingTagWriteRaw(
+      tp: Map[Tag, TagProgress],
+      to: ActorRef,
+      actorRunning: Boolean = true)(rawEvent: RawEvent): RawEvent = {
     // FIXME logging once stable
     log.debug("Processing tag write for event {} tags {}", rawEvent.sequenceNr, rawEvent.serialized.tags)
     rawEvent.serialized.tags.foreach(tag => {
@@ -87,7 +90,7 @@ trait CassandraTagRecovery {
    * Before starting to process tagged messages then a [SetTagProgress] is sent to the
    * [TagWriters] to initialise the sequence numbers for each tag.
    */
-  private[akka] def setTagProgress(
+  @InternalApi private[akka] def setTagProgress(
       pid: String,
       tagProgress: Map[Tag, TagProgress],
       tagWriters: ActorRef): Future[Done] = {
@@ -95,7 +98,7 @@ trait CassandraTagRecovery {
     (tagWriters ? SetTagProgress(pid, tagProgress)).mapTo[TagProcessAck.type].map(_ => Done)
   }
 
-  private[akka] def sendPersistentActorStarting(
+  @InternalApi private[akka] def sendPersistentActorStarting(
       pid: String,
       persistentActor: ActorRef,
       tagWriters: ActorRef): Future[Done] = {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -36,16 +36,16 @@ import scala.concurrent.duration._
  */
 @InternalApi private[akka] object TagWriter {
 
-  @InternalApi private[akka] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag): Props =
+  private[akka] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag): Props =
     Props(new TagWriter(settings, session, tag))
 
-  @InternalApi private[akka] case class TagWriterSettings(
+  private[akka] case class TagWriterSettings(
       maxBatchSize: Int,
       flushInterval: FiniteDuration,
       scanningFlushInterval: FiniteDuration,
       pubsubNotification: Boolean)
 
-  @InternalApi private[akka] case class TagProgress(
+  private[akka] case class TagProgress(
       persistenceId: PersistenceId,
       sequenceNr: SequenceNr,
       pidTagSequenceNr: TagPidSequenceNr)
@@ -54,18 +54,17 @@ import scala.concurrent.duration._
    * INTERNAL API
    * Reset pid tag sequence numbers to the given [[TagProgress]] and discard any messages for the given persistenceId.
    */
-  @InternalApi private[akka] case class ResetPersistenceId(tag: Tag, progress: TagProgress)
-      extends NoSerializationVerificationNeeded
+  private[akka] case class ResetPersistenceId(tag: Tag, progress: TagProgress) extends NoSerializationVerificationNeeded
 
   /**
-   * INTERNAL APIa
+   * INTERNAL API
    * Sent in response to a [[ResetPersistenceId]].
    */
-  @InternalApi private[akka] case object ResetPersistenceIdComplete
+  private[akka] case object ResetPersistenceIdComplete
 
   // Flush buffer regardless of size
-  @InternalApi private[akka] case object Flush
-  @InternalApi private[akka] case object FlushComplete
+  private[akka] case object Flush
+  private[akka] case object FlushComplete
 
   type TagWriteSummary = Map[PersistenceId, PidProgress]
   case class PidProgress(seqNrFrom: SequenceNr, seqNrTo: SequenceNr, tagPidSequenceNr: TagPidSequenceNr, offset: UUID)
@@ -76,7 +75,7 @@ import scala.concurrent.duration._
   private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[(Serialized, TagPidSequenceNr)])
       extends TagWriteFinished
 
-  @InternalApi private[akka] case class DropState(pid: PersistenceId)
+  private[akka] case class DropState(pid: PersistenceId)
 
   val timeUuidOrdering = new Ordering[UUID] {
     override def compare(x: UUID, y: UUID) =
@@ -84,9 +83,7 @@ import scala.concurrent.duration._
   }
 }
 
-/**
- * INTERNAL API
- */
+/** INTERNAL API */
 @InternalApi private[akka] class TagWriter(settings: TagWriterSettings, session: TagWritersSession, tag: String)
     extends Actor
     with Timers

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -21,7 +21,8 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.concurrent.duration._
 
-/*
+/**
+ * INTERNAL API
  * Groups writes into un-logged batches for the same partition.
  *
  * For the read stage to work correctly events must be written in order for a given
@@ -35,33 +36,36 @@ import scala.concurrent.duration._
  */
 @InternalApi private[akka] object TagWriter {
 
-  private[akka] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag): Props =
+  @InternalApi private[akka] def props(settings: TagWriterSettings, session: TagWritersSession, tag: Tag): Props =
     Props(new TagWriter(settings, session, tag))
 
-  private[akka] case class TagWriterSettings(
+  @InternalApi private[akka] case class TagWriterSettings(
       maxBatchSize: Int,
       flushInterval: FiniteDuration,
       scanningFlushInterval: FiniteDuration,
       pubsubNotification: Boolean)
 
-  private[akka] case class TagProgress(
+  @InternalApi private[akka] case class TagProgress(
       persistenceId: PersistenceId,
       sequenceNr: SequenceNr,
       pidTagSequenceNr: TagPidSequenceNr)
 
-  /*
-   * Reset pid tag sequence numbers to the given [[TagProgress]] and discard any messages for the given persistenceId
+  /**
+   * INTERNAL API
+   * Reset pid tag sequence numbers to the given [[TagProgress]] and discard any messages for the given persistenceId.
    */
-  private[akka] case class ResetPersistenceId(tag: Tag, progress: TagProgress) extends NoSerializationVerificationNeeded
+  @InternalApi private[akka] case class ResetPersistenceId(tag: Tag, progress: TagProgress)
+      extends NoSerializationVerificationNeeded
 
-  /*
-   * Sent in response to a [[ResetPersistenceId]]
+  /**
+   * INTERNAL APIa
+   * Sent in response to a [[ResetPersistenceId]].
    */
-  private[akka] case object ResetPersistenceIdComplete
+  @InternalApi private[akka] case object ResetPersistenceIdComplete
 
   // Flush buffer regardless of size
-  private[akka] case object Flush
-  private[akka] case object FlushComplete
+  @InternalApi private[akka] case object Flush
+  @InternalApi private[akka] case object FlushComplete
 
   type TagWriteSummary = Map[PersistenceId, PidProgress]
   case class PidProgress(seqNrFrom: SequenceNr, seqNrTo: SequenceNr, tagPidSequenceNr: TagPidSequenceNr, offset: UUID)
@@ -72,7 +76,7 @@ import scala.concurrent.duration._
   private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[(Serialized, TagPidSequenceNr)])
       extends TagWriteFinished
 
-  private[akka] case class DropState(pid: PersistenceId)
+  @InternalApi private[akka] case class DropState(pid: PersistenceId)
 
   val timeUuidOrdering = new Ordering[UUID] {
     override def compare(x: UUID, y: UUID) =
@@ -80,6 +84,9 @@ import scala.concurrent.duration._
   }
 }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] class TagWriter(settings: TagWriterSettings, session: TagWritersSession, tag: String)
     extends Actor
     with Timers

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -35,9 +35,12 @@ import scala.util.Try
 
 import akka.util.ByteString
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] object TagWriters {
 
-  private[akka] case class TagWritersSession(
+  @InternalApi private[akka] case class TagWritersSession(
       tagWritePs: () => Future[PreparedStatement],
       tagWriteWithMetaPs: () => Future[PreparedStatement],
       executeStatement: Statement => Future[Done],
@@ -92,23 +95,33 @@ import akka.util.ByteString
 
   }
 
-  private[akka] object BulkTagWrite {
+  /**
+   * INTERNAL API
+   */
+  @InternalApi private[akka] object BulkTagWrite {
     def apply(tw: TagWrite, owner: ActorRef): BulkTagWrite =
       BulkTagWrite(tw :: Nil, Nil)
   }
 
   /**
+   * INTERNAL API
    * All tag writes should be for the same persistenceId
    */
-  private[akka] case class BulkTagWrite(tagWrites: immutable.Seq[TagWrite], withoutTags: immutable.Seq[Serialized])
+  @InternalApi private[akka] case class BulkTagWrite(
+      tagWrites: immutable.Seq[TagWrite],
+      withoutTags: immutable.Seq[Serialized])
       extends NoSerializationVerificationNeeded
 
   /**
+   * INTERNAL API
    * All serialised should be for the same persistenceId
    * @param actorRunning migration sends these messages without the actor running so TagWriters should not
    *                     validate that the pid is running
    */
-  private[akka] case class TagWrite(tag: Tag, serialised: immutable.Seq[Serialized], actorRunning: Boolean = true)
+  @InternalApi private[akka] case class TagWrite(
+      tag: Tag,
+      serialised: immutable.Seq[Serialized],
+      actorRunning: Boolean = true)
       extends NoSerializationVerificationNeeded
 
   def props(settings: TagWriterSettings, tagWriterSession: TagWritersSession): Props =

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -40,7 +40,7 @@ import akka.util.ByteString
  */
 @InternalApi private[akka] object TagWriters {
 
-  @InternalApi private[akka] case class TagWritersSession(
+  private[akka] case class TagWritersSession(
       tagWritePs: () => Future[PreparedStatement],
       tagWriteWithMetaPs: () => Future[PreparedStatement],
       executeStatement: Statement => Future[Done],
@@ -95,10 +95,7 @@ import akka.util.ByteString
 
   }
 
-  /**
-   * INTERNAL API
-   */
-  @InternalApi private[akka] object BulkTagWrite {
+  private[akka] object BulkTagWrite {
     def apply(tw: TagWrite, owner: ActorRef): BulkTagWrite =
       BulkTagWrite(tw :: Nil, Nil)
   }
@@ -107,9 +104,7 @@ import akka.util.ByteString
    * INTERNAL API
    * All tag writes should be for the same persistenceId
    */
-  @InternalApi private[akka] case class BulkTagWrite(
-      tagWrites: immutable.Seq[TagWrite],
-      withoutTags: immutable.Seq[Serialized])
+  private[akka] case class BulkTagWrite(tagWrites: immutable.Seq[TagWrite], withoutTags: immutable.Seq[Serialized])
       extends NoSerializationVerificationNeeded
 
   /**
@@ -118,10 +113,7 @@ import akka.util.ByteString
    * @param actorRunning migration sends these messages without the actor running so TagWriters should not
    *                     validate that the pid is running
    */
-  @InternalApi private[akka] case class TagWrite(
-      tag: Tag,
-      serialised: immutable.Seq[Serialized],
-      actorRunning: Boolean = true)
+  private[akka] case class TagWrite(tag: Tag, serialised: immutable.Seq[Serialized], actorRunning: Boolean = true)
       extends NoSerializationVerificationNeeded
 
   def props(settings: TagWriterSettings, tagWriterSession: TagWritersSession): Props =
@@ -145,6 +137,7 @@ import akka.util.ByteString
 }
 
 /**
+ * INTERNAL API
  * Manages all the tag writers.
  */
 @InternalApi private[akka] class TagWriters(settings: TagWriterSettings, tagWriterSession: TagWritersSession)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TimeBucket.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TimeBucket.scala
@@ -10,6 +10,9 @@ import akka.annotation.InternalApi
 import akka.util.HashCode
 import com.datastax.driver.core.utils.UUIDs
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] object TimeBucket {
 
   def apply(timeuuid: UUID, bucketSize: BucketSize): TimeBucket =
@@ -25,6 +28,9 @@ import com.datastax.driver.core.utils.UUIDs
   }
 }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] final class TimeBucket private (val key: Long, val bucketSize: BucketSize) {
   def inPast: Boolean =
     key < TimeBucket.roundDownBucketSize(System.currentTimeMillis(), bucketSize)

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -34,13 +34,13 @@ import com.github.ghik.silencer.silent
  */
 @InternalApi private[akka] object EventsByPersistenceIdStage {
 
-  @InternalApi private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) {
+  private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) {
     def sequenceNr: Long = pr.sequenceNr
   }
 
-  @InternalApi private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr])
+  private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr])
 
-  @InternalApi private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized)
+  private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized)
 
   // materialized value
   trait Control {

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -9,6 +9,12 @@ import java.nio.ByteBuffer
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
 
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+import scala.concurrent.{ ExecutionContext, Future, Promise }
+import scala.concurrent.duration.{ FiniteDuration, _ }
+import scala.util.{ Failure, Success, Try }
+
 import akka.Done
 import akka.annotation.InternalApi
 import akka.persistence.PersistentRepr
@@ -20,12 +26,6 @@ import akka.stream.stage._
 import com.datastax.driver.core._
 import com.datastax.driver.core.policies.RetryPolicy
 import com.datastax.driver.core.utils.Bytes
-
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
-import scala.concurrent.{ ExecutionContext, Future, Promise }
-import scala.concurrent.duration.{ FiniteDuration, _ }
-import scala.util.{ Failure, Success, Try }
 import akka.util.OptionVal
 import com.github.ghik.silencer.silent
 
@@ -34,13 +34,13 @@ import com.github.ghik.silencer.silent
  */
 @InternalApi private[akka] object EventsByPersistenceIdStage {
 
-  private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) {
+  @InternalApi private[akka] case class TaggedPersistentRepr(pr: PersistentRepr, tags: Set[String], offset: UUID) {
     def sequenceNr: Long = pr.sequenceNr
   }
 
-  private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr])
+  @InternalApi private[akka] case class OptionalTagged(sequenceNr: Long, tagged: OptionVal[TaggedPersistentRepr])
 
-  private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized)
+  @InternalApi private[akka] case class RawEvent(sequenceNr: Long, serialized: Serialized)
 
   // materialized value
   trait Control {

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -86,7 +86,7 @@ import com.github.ghik.silencer.silent
       usingOffset,
       initialTagPidSequenceNrs)
 
-  @InternalApi private[akka] class TagStageSession(
+  private[akka] class TagStageSession(
       val tag: String,
       session: Session,
       statements: EventByTagStatements,
@@ -100,7 +100,7 @@ import com.github.ghik.silencer.silent
     }
   }
 
-  @InternalApi private[akka] object TagStageSession {
+  private[akka] object TagStageSession {
     def apply(tag: String, session: Session, statements: EventByTagStatements, fetchSize: Int): TagStageSession =
       new TagStageSession(tag, session, statements, fetchSize)
   }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -4,8 +4,15 @@
 
 package akka.persistence.cassandra.query
 
+import java.lang.{ Long => JLong }
 import java.util.UUID
 import java.util.concurrent.ThreadLocalRandom
+
+import scala.annotation.tailrec
+import scala.concurrent.duration.Duration
+import scala.concurrent.duration._
+import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
+import scala.util.{ Failure, Success, Try }
 
 import akka.annotation.InternalApi
 import akka.persistence.cassandra._
@@ -15,14 +22,6 @@ import akka.stream.stage.{ GraphStage, _ }
 import akka.stream.{ ActorMaterializer, Attributes, Outlet, SourceShape }
 import akka.cassandra.session._
 import akka.util.PrettyDuration._
-
-import scala.annotation.tailrec
-import scala.concurrent.duration.Duration
-import scala.concurrent.duration._
-import scala.concurrent.{ ExecutionContext, ExecutionContextExecutor, Future }
-import scala.util.{ Failure, Success, Try }
-import java.lang.{ Long => JLong }
-
 import akka.cluster.pubsub.{ DistributedPubSub, DistributedPubSubMediator }
 import akka.persistence.cassandra.journal.CassandraJournal._
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal.EventByTagStatements
@@ -32,6 +31,7 @@ import com.datastax.driver.core.utils.UUIDs
 import com.github.ghik.silencer.silent
 
 /**
+ * INTERNAL API
  * Walks the tag_views table.
  *
  * For current queries:
@@ -86,7 +86,7 @@ import com.github.ghik.silencer.silent
       usingOffset,
       initialTagPidSequenceNrs)
 
-  private[akka] class TagStageSession(
+  @InternalApi private[akka] class TagStageSession(
       val tag: String,
       session: Session,
       statements: EventByTagStatements,
@@ -100,7 +100,7 @@ import com.github.ghik.silencer.silent
     }
   }
 
-  private[akka] object TagStageSession {
+  @InternalApi private[akka] object TagStageSession {
     def apply(tag: String, session: Session, statements: EventByTagStatements, fetchSize: Int): TagStageSession =
       new TagStageSession(tag, session, statements, fetchSize)
   }
@@ -173,6 +173,9 @@ import com.github.ghik.silencer.silent
   }
 }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi private[akka] class EventsByTagStage(
     session: TagStageSession,
     fromOffset: UUID,

--- a/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
@@ -30,11 +30,10 @@ private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: 
   private val log = Logging(materializer.system, getClass)
 
   /**
-   * INTERNAL API
    * This could be its own stage and return half way through a query to better meet the deadline
    * but this is a quick and simple way to do it given we're scanning a small segment
    */
-  @InternalApi private[akka] def scan(
+  private[akka] def scan(
       tag: String,
       offset: UUID,
       bucket: TimeBucket,

--- a/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
@@ -20,6 +20,9 @@ import com.datastax.driver.core.utils.UUIDs
 import scala.concurrent.duration.{ Deadline, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future }
 
+/**
+ * INTERNAL API
+ */
 @InternalApi
 private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: Future[PreparedStatement])(
     implicit materializer: ActorMaterializer,
@@ -27,10 +30,11 @@ private[akka] class TagViewSequenceNumberScanner(session: CassandraSession, ps: 
   private val log = Logging(materializer.system, getClass)
 
   /**
+   * INTERNAL API
    * This could be its own stage and return half way through a query to better meet the deadline
    * but this is a quick and simple way to do it given we're scanning a small segment
    */
-  private[akka] def scan(
+  @InternalApi private[akka] def scan(
       tag: String,
       offset: UUID,
       bucket: TimeBucket,

--- a/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -8,12 +8,10 @@ import java.util.UUID
 import java.util.concurrent.CompletionStage
 
 import akka.cassandra.session.javadsl.CassandraSession
-import akka.{ Done, NotUsed }
-import akka.persistence.query.EventEnvelope
-import akka.persistence.query.Offset
-import akka.persistence.query.TimeBasedUUID
+import akka.persistence.query.{ EventEnvelope, Offset, TimeBasedUUID }
 import akka.persistence.query.javadsl._
 import akka.stream.javadsl.Source
+import akka.{ Done, NotUsed }
 
 import scala.compat.java8.FutureConverters
 

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -195,6 +195,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       ps3 <- preparedSelectDeletedTo
     } yield CombinedEventsByPersistenceIdStmts(ps1, ps2, ps3)
 
+  /**
+   * INTERNAL API
+   */
   @InternalApi private[akka] def combinedEventsByTagStmts: Future[EventByTagStatements] =
     for {
       byTagWithUpper <- preparedSelectFromTagViewWithUpperBound
@@ -288,6 +291,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       .mapMaterializedValue(_ => NotUsed)
       .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
 
+  /**
+   * INTERNAL API
+   */
   @InternalApi private[akka] def eventsByTagInternal(tag: String, offset: Offset): Source[UUIDPersistentRepr, NotUsed] =
     if (!config.eventsByTagEnabled)
       Source.failed(new IllegalStateException("Events by tag queries are disabled"))
@@ -356,6 +362,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
     } yield (statements, tagSequenceNrs)
   }
 
+  /**
+   * INTERNAL API
+   */
   @InternalApi private[akka] def scanTagSequenceNrs(
       tag: String,
       fromOffset: UUID): Future[Map[PersistenceId, (TagPidSequenceNr, UUID)]] = {
@@ -428,6 +437,9 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       .mapConcat(r => toEventEnvelope(r.persistentRepr, TimeBasedUUID(r.offset)))
       .named("eventsByTag-" + URLEncoder.encode(tag, ByteString.UTF_8))
 
+  /**
+   * INTERNAL API
+   */
   @InternalApi private[akka] def currentEventsByTagInternal(
       tag: String,
       offset: Offset): Source[UUIDPersistentRepr, NotUsed] =

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -16,6 +16,7 @@ import scala.util.Success
 import scala.util.control.NonFatal
 
 import akka.actor._
+import akka.annotation.InternalApi
 import akka.persistence._
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.FixedRetryPolicy
@@ -313,7 +314,10 @@ class CassandraSnapshotStore(cfg: Config, cfgPath: String)
 
 }
 
-private[snapshot] object CassandraSnapshotStore {
+/**
+ * INTERNAL API
+ */
+@InternalApi private[snapshot] object CassandraSnapshotStore {
   private case object Init
 
   private case class Serialized(serialized: ByteBuffer, serManifest: String, serId: Int, meta: Option[SerializedMeta])

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -8,26 +8,15 @@ import java.lang.{ Long => JLong }
 import java.nio.ByteBuffer
 import java.util.NoSuchElementException
 
-import scala.collection.immutable
-import scala.concurrent.ExecutionContext
-import scala.concurrent.Future
-import scala.util.Failure
-import scala.util.Success
-import scala.util.control.NonFatal
-
 import akka.actor._
-import akka.annotation.InternalApi
+import akka.cassandra.session._
+import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence._
 import akka.persistence.cassandra._
 import akka.persistence.cassandra.journal.FixedRetryPolicy
-import akka.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.serialization.Snapshot
 import akka.persistence.snapshot.SnapshotStore
-import akka.cassandra.session._
-import akka.serialization.AsyncSerializer
-import akka.serialization.Serialization
-import akka.serialization.SerializationExtension
-import akka.serialization.Serializers
+import akka.serialization.{ AsyncSerializer, Serialization, SerializationExtension, Serializers }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import akka.util.OptionVal
@@ -35,6 +24,11 @@ import com.datastax.driver.core._
 import com.datastax.driver.core.policies.LoggingRetryPolicy
 import com.datastax.driver.core.utils.Bytes
 import com.typesafe.config.Config
+
+import scala.collection.immutable
+import scala.concurrent.{ ExecutionContext, Future }
+import scala.util.{ Failure, Success }
+import scala.util.control.NonFatal
 
 class CassandraSnapshotStore(cfg: Config, cfgPath: String)
     extends SnapshotStore
@@ -314,10 +308,7 @@ class CassandraSnapshotStore(cfg: Config, cfgPath: String)
 
 }
 
-/**
- * INTERNAL API
- */
-@InternalApi private[snapshot] object CassandraSnapshotStore {
+private[snapshot] object CassandraSnapshotStore {
   private case object Init
 
   private case class Serialized(serialized: ByteBuffer, serManifest: String, serId: Int, meta: Option[SerializedMeta])


### PR DESCRIPTION
https://github.com/akka/akka-persistence-cassandra/issues/65

Based on the existing patterns in the repo, the rules I went with were:
* Annotated if a private[akka] top level type, object member case etc, or a def.
* Not annotated if `val`.
* If already having scaladoc or a top-level, added doc comment `INTERNAL API`.