### PR TITLE
Remove static column used in reads, #180

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -637,28 +637,27 @@ class CassandraJournal(cfg: Config)
       persistenceId: String,
       fromSequenceNr: Long,
       partitionSize: Long): Future[Long] = {
-    def find(currentPnr: Long, currentSnr: Long): Future[Long] = {
+    def find(currentPnr: Long, currentSnr: Long, foundEmptyPartition: Boolean): Future[Long] = {
       // if every message has been deleted and thus no sequence_nr the driver gives us back 0 for "null" :(
       val boundSelectHighestSequenceNr = preparedSelectHighestSequenceNr.map(_.bind(persistenceId, currentPnr: JLong))
       boundSelectHighestSequenceNr
         .flatMap(session.selectOne)
         .map { rowOption =>
-          rowOption.map { row =>
-            (row.getBool("used"), row.getLong("sequence_nr"))
-          }
+          rowOption.map(_.getLong("sequence_nr"))
         }
         .flatMap {
-          // never been to this partition
-          case None => Future.successful(currentSnr)
-          // don't currently explicitly set false
-          case Some((false, _)) => Future.successful(currentSnr)
-          // everything deleted in this partition, move to the next
-          case Some((true, 0))        => find(currentPnr + 1, currentSnr)
-          case Some((_, nextHighest)) => find(currentPnr + 1, nextHighest)
+          case None | Some(0) =>
+            // never been to this partition, query one more partition because AtomicWrite can span (skip)
+            // one entire partition
+            // Some(0) when old schema with static used column, everything deleted in this partition
+            if (foundEmptyPartition) Future.successful(currentSnr)
+            else find(currentPnr + 1, currentSnr, foundEmptyPartition = true)
+          case Some(nextHighest) =>
+            find(currentPnr + 1, nextHighest, foundEmptyPartition = false)
         }
     }
 
-    find(partitionNr(fromSequenceNr, partitionSize), fromSequenceNr)
+    find(partitionNr(fromSequenceNr, partitionSize), fromSequenceNr, foundEmptyPartition = false)
   }
 
   private def executeBatch(body: BatchStatement ⇒ Unit, retryPolicy: RetryPolicy): Future[Unit] = {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -259,7 +259,7 @@ trait CassandraStatements {
 
   private[akka] def selectHighestSequenceNr =
     s"""
-     SELECT sequence_nr, used FROM ${tableName} WHERE
+     SELECT sequence_nr FROM ${tableName} WHERE
        persistence_id = ? AND
        partition_nr = ?
        ORDER BY sequence_nr

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -104,6 +104,12 @@ import akka.persistence.cassandra.journal.CassandraIntegrationSpec._
 
 class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender with WordSpecLike with Matchers {
 
+  private def stopAndWaitUntilTerminated(ref: ActorRef) = {
+    watch(ref)
+    ref ! PoisonPill
+    expectTerminated(ref)
+  }
+
   def subscribeToRangeDeletion(probe: TestProbe): Unit =
     system.eventStream.subscribe(probe.ref, classOf[JournalProtocol.DeleteMessagesTo])
 
@@ -146,6 +152,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
+      stopAndWaitUntilTerminated(processor1)
+
       val processor2 = system.actorOf(Props(classOf[ProcessorA], persistenceId, self), "p2")
       (1L to 16L).foreach { i =>
         expectMsgAllOf(s"a-${i}", i, true)
@@ -164,10 +172,14 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       val persistenceId = UUID.randomUUID().toString
       val processorAtomic = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
 
+      // more than 2 partitions not supported, will fail the write
+
       processorAtomic ! List("a-1", "a-2", "a-3", "a-4", "a-5", "a-6")
       (1L to 6L).foreach { i =>
         expectMsgAllOf(s"a-${i}", i, false)
       }
+
+      stopAndWaitUntilTerminated(processorAtomic)
 
       val testProbe = TestProbe()
       val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
@@ -191,6 +203,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
         expectMsgAllOf(s"a-${i}", i, false)
       }
 
+      stopAndWaitUntilTerminated(processorAtomic)
+
       val testProbe = TestProbe()
       val processor2 = system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
       (1L to 6L).foreach { i =>
@@ -207,6 +221,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       (1L to 4L).foreach { i =>
         expectMsgAllOf(s"a-${i}", i, false)
       }
+
+      stopAndWaitUntilTerminated(processorAtomic)
 
       system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, self))
       (1L to 4L).foreach { i =>
@@ -227,6 +243,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processorAtomic ! DeleteTo(5L)
       awaitRangeDeletion(deleteProbe)
 
+      stopAndWaitUntilTerminated(processorAtomic)
+
       val testProbe = TestProbe()
       system.actorOf(Props(classOf[ProcessorAtomic], persistenceId, testProbe.ref))
       testProbe.expectMsgAllOf(s"a-6", 6, true)
@@ -244,6 +262,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processor1 ! "b"
       expectMsg("updated-b-2")
 
+      stopAndWaitUntilTerminated(processor1)
+
       system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-1")
       expectMsg("updated-b-2")
@@ -259,6 +279,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
         processor1 ! "a"
         expectMsg(s"updated-a-${i}")
       }
+
+      stopAndWaitUntilTerminated(processor1)
 
       val processor2 =
         system.actorOf(Props(classOf[ProcessorCNoRecover], persistenceId, testActor, Recovery(toSequenceNr = 3L)))
@@ -276,6 +298,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processor1 ! "snap"
       expectMsg("snapped-a-1")
 
+      stopAndWaitUntilTerminated(processor1)
+
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-1")
       processor2 ! "b"
@@ -290,6 +314,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       }
       processor1 ! "snap"
       expectMsg("snapped-a-5")
+
+      stopAndWaitUntilTerminated(processor1)
 
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
@@ -315,6 +341,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
       processor1 ! DeleteTo(6L)
       awaitRangeDeletion(deleteProbe)
 
+      stopAndWaitUntilTerminated(processor1)
+
       val processor2 = system.actorOf(Props(classOf[ProcessorC], persistenceId, testActor))
       expectMsg("offered-a-5")
       processor2 ! "b"
@@ -332,6 +360,8 @@ class CassandraIntegrationSpec extends CassandraSpec(config) with ImplicitSender
 
       p ! DeleteTo(1L)
       awaitRangeDeletion(deleteProbe)
+
+      stopAndWaitUntilTerminated(p)
 
       val r = system.actorOf(Props(classOf[ProcessorA], persistenceId, self))
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -16,7 +16,7 @@ import akka.testkit.EventFilter
 object CassandraJournalDeletionSpec {
   case class PersistMe(msg: Long)
   case class DeleteTo(sequenceNr: Long)
-  case object Ack
+  case class Ack(sequenceNr: Long)
   case object GetRecoveredEvents
 
   case class RecoveredEvents(events: Seq[Any])
@@ -42,7 +42,7 @@ object CassandraJournalDeletionSpec {
     override def receiveCommand: Receive = {
       case p: PersistMe =>
         persist(p) { _ =>
-          sender() ! Ack
+          sender() ! Ack(lastSequenceNr)
         }
       case GetRecoveredEvents =>
         sender() ! RecoveredEvents(recoveredEvents.reverse)
@@ -109,7 +109,7 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val p1 = system.actorOf(Props(new PAThatDeletes("p1", deleteSuccess.ref, deleteFail.ref)))
       (1 to 100).foreach { i =>
         p1 ! PersistMe(i)
-        expectMsg(Ack)
+        expectMsgType[Ack]
       }
 
       (1 to 99).foreach { i =>
@@ -139,7 +139,7 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
 
       (1 to 100).foreach { i =>
         p1 ! PersistMe(i)
-        expectMsg(Ack)
+        expectMsgType[Ack]
       }
 
       (1 to 99).foreach { i =>
@@ -156,15 +156,39 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       successes shouldEqual successes.sorted
     }
 
+    "handle deletes of all events" in {
+      val deleteSuccess = TestProbe()
+      val deleteFail = TestProbe()
+      val props =
+        Props(new PAThatDeletes("p3", deleteSuccess.ref, deleteFail.ref))
+      val p1 = system.actorOf(props)
+      (1 to 17).foreach { i =>
+        p1 ! PersistMe(i)
+        expectMsg(Ack(i))
+      }
+
+      p1 ! DeleteTo(17)
+      deleteSuccess.expectMsg(Deleted(17))
+
+      p1 ! PoisonPill
+
+      // Recovery should not find a deleted sequence nr, and use next sequence nr for persist
+      val p1TakeTwo = system.actorOf(props)
+      p1TakeTwo ! GetRecoveredEvents
+      expectMsg(RecoveredEvents(List(RecoveryCompleted)))
+      p1TakeTwo ! PersistMe(18)
+      expectMsg(Ack(18))
+    }
+
     "handle deletes over many partitions" in {
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val props =
-        Props(new PAThatDeletes("p3", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size"))
+        Props(new PAThatDeletes("p4", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size"))
       val p1 = system.actorOf(props)
       (1 to 100).foreach { i =>
         p1 ! PersistMe(i)
-        expectMsg(Ack)
+        expectMsgType[Ack]
       }
 
       p1 ! DeleteTo(10)
@@ -182,6 +206,8 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val p1TakeTwo = system.actorOf(props)
       p1TakeTwo ! GetRecoveredEvents
       expectMsg(RecoveredEvents(List(PersistMe(99), PersistMe(100), RecoveryCompleted)))
+      p1TakeTwo ! PersistMe(101)
+      expectMsg(Ack(101))
 
       // Delete all with Long.MaxValue
       p1TakeTwo ! DeleteTo(Long.MaxValue)
@@ -192,22 +218,48 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val p1TakeThree = system.actorOf(props)
       p1TakeThree ! GetRecoveredEvents
       expectMsg(RecoveredEvents(List(RecoveryCompleted)))
+      p1TakeThree ! PersistMe(102)
+      expectMsg(Ack(102))
+    }
+
+    "handle deletes of all events over many partitions" in {
+      val deleteSuccess = TestProbe()
+      val deleteFail = TestProbe()
+      val props =
+        Props(new PAThatDeletes("p5", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size"))
+      val p1 = system.actorOf(props)
+      (1 to 100).foreach { i =>
+        p1 ! PersistMe(i)
+        expectMsgType[Ack]
+      }
+
+      p1 ! DeleteTo(100)
+      deleteSuccess.expectMsg(Deleted(100))
+
+      p1 ! PoisonPill
+
+      // Recovery should not find a deleted sequence nr, and use next sequence nr for persist
+      val p1TakeTwo = system.actorOf(props)
+      p1TakeTwo ! GetRecoveredEvents
+      expectMsg(RecoveredEvents(List(RecoveryCompleted)))
+      p1TakeTwo ! PersistMe(101)
+      expectMsg(Ack(101))
     }
 
     "recover with support-deletes=off" in {
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val p1 =
-        system.actorOf(Props(new PAThatDeletes("p3", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
+        system.actorOf(Props(new PAThatDeletes("p6", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
 
       (1 to 3).foreach { i =>
         p1 ! PersistMe(i)
-        expectMsg(Ack)
+        expectMsgType[Ack]
       }
 
       p1 ! PoisonPill
 
-      val p1TakeTwo = system.actorOf(Props(new PAThatDeletes("p3", deleteSuccess.ref, deleteFail.ref)))
+      val p1TakeTwo = system.actorOf(Props(new PAThatDeletes("p6", deleteSuccess.ref, deleteFail.ref)))
       p1TakeTwo ! GetRecoveredEvents
       expectMsg(RecoveredEvents(List(PersistMe(1), PersistMe(2), PersistMe(3), RecoveryCompleted)))
     }
@@ -216,11 +268,11 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val p1 =
-        system.actorOf(Props(new PAThatDeletes("p4", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
+        system.actorOf(Props(new PAThatDeletes("p7", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
 
       (1 to 3).foreach { i =>
         p1 ! PersistMe(i)
-        expectMsg(Ack)
+        expectMsgType[Ack]
       }
 
       EventFilter.error(start = "Failed to delete to 2", occurrences = 1).intercept {


### PR DESCRIPTION
Backport of https://github.com/akka/akka-persistence-cassandra/pull/594

(cherry picked from commit 54a2c58eb58ce1639411d126b281a69f3bf02915)
