### PR TITLE
Cleanup persistence id meta data in events by tag queries

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -437,7 +437,9 @@ cassandra-query-journal {
     # If the metadata for a persistence-id is dropped and the persistence-id is encoutered it will
     # add a delay of the new-persistence-id-scan-timeout before delivering any new events
     # If the query is started with NoOffset then the the stream will fail
-    # This should be a large value, e.g. at least an hour, unless
+    # This should be set to a large value e.g. 2 x the bucket size. It can be set lower but if the metadata is dropped
+    # for a persistence id and an event is received afterward then old events in the current and previous bucket may
+    # be redelivered
     cleanup-old-persistence-ids = "off"
   }
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -353,7 +353,7 @@ cassandra-query-journal {
   # Absolute path to the write journal plugin configuration section
   write-plugin = "cassandra-journal"
 
-  read-profile = "cassandra-journal"
+  ead-profile = "cassandra-journal"
 
 
   # New events are retrieved (polled) with this interval.
@@ -430,6 +430,15 @@ cassandra-query-journal {
     # Verbose debug logging for offset updates for events by tag queries. Any logging that is per event is
     # affected by this flag. Debug logging that is per query to Cassandra is enabled if DEBUG logging is enabled
     verbose-debug-logging = false
+
+    # Set to a duration to have events by tag queries drop state about persistence ids
+    # this can be set to reduce memory usage of events by tag queries for use cases where there
+    # are many short lived persistence ids
+    # If the metadata for a persistence-id is dropped and the persistence-id is encoutered it will
+    # add a delay of the new-persistence-id-scan-timeout before delivering any new events
+    # If the query is started with NoOffset then the the stream will fail
+    # This should be a large value, e.g. at least an hour, unless
+    cleanup-old-persistence-ids = "off"
   }
 
   # Deserialization of events is perfomed in an Akka streams mapAsync operator and this is the

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -353,7 +353,7 @@ cassandra-query-journal {
   # Absolute path to the write journal plugin configuration section
   write-plugin = "cassandra-journal"
 
-  ead-profile = "cassandra-journal"
+  read-profile = "cassandra-journal"
 
 
   # New events are retrieved (polled) with this interval.

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -436,11 +436,11 @@ cassandra-query-journal {
     # are many short lived persistence ids
     # If the metadata for a persistence-id is dropped and the persistence-id is encoutered it will
     # add a delay of the new-persistence-id-scan-timeout before delivering any new events
-    # If the query is started with NoOffset then the the stream will fail
     # This should be set to a large value e.g. 2 x the bucket size. It can be set lower but if the metadata is dropped
-    # for a persistence id and an event is received afterward then old events in the current and previous bucket may
+    # for a persistence id and an event is received afterwards then old events in the current and previous bucket may
     # be redelivered
-    cleanup-old-persistence-ids = "off"
+    # By default it is set to 2 x the bucket size
+    cleanup-old-persistence-ids = "<default>"
   }
 
   # Deserialization of events is perfomed in an Akka streams mapAsync operator and this is the

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -76,11 +76,12 @@ import scala.concurrent.duration._
     config.getDuration("events-by-tag.new-persistence-id-scan-timeout", MILLISECONDS).millis
   val eventsByTagOffsetScanning: FiniteDuration =
     config.getDuration("events-by-tag.offset-scanning-period", MILLISECONDS).millis
-  val eventsByTagCleanUpPersistenceIds: Duration = config.getString("events-by-tag.cleanup-old-persistence-ids") match {
-    case "off"       => Duration.Inf
-    case "<default>" => (writePluginConfig.bucketSize.durationMillis * 2).millis
-    case _           => config.getDuration("events-by-tag.cleanup-old-persistence-ids", MILLISECONDS).millis
-  }
+  val eventsByTagCleanUpPersistenceIds: Duration =
+    config.getString("events-by-tag.cleanup-old-persistence-ids").toLowerCase match {
+      case "off" | "false" => Duration.Inf
+      case "<default>"     => (writePluginConfig.bucketSize.durationMillis * 2).millis
+      case _               => config.getDuration("events-by-tag.cleanup-old-persistence-ids", MILLISECONDS).millis
+    }
 
   if (eventsByTagCleanUpPersistenceIds != Duration.Inf && eventsByTagCleanUpPersistenceIds.toMillis < (writePluginConfig.bucketSize.durationMillis * 2)) {
     log.warning(

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -73,5 +73,8 @@ import scala.concurrent.duration._
     config.getDuration("events-by-tag.new-persistence-id-scan-timeout", MILLISECONDS).millis
   val eventsByTagOffsetScanning: FiniteDuration =
     config.getDuration("events-by-tag.offset-scanning-period", MILLISECONDS).millis
-
+  val eventsByTagCleanUpPersistenceIds: Duration = config.getString("cleanup-old-persistence-ids") match {
+    case "off" => Duration.Inf
+    case _     => config.getDuration("cleanup-old-persistence-ids", MILLISECONDS).millis
+  }
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -77,8 +77,9 @@ import scala.concurrent.duration._
   val eventsByTagOffsetScanning: FiniteDuration =
     config.getDuration("events-by-tag.offset-scanning-period", MILLISECONDS).millis
   val eventsByTagCleanUpPersistenceIds: Duration = config.getString("events-by-tag.cleanup-old-persistence-ids") match {
-    case "off" => Duration.Inf
-    case _     => config.getDuration("events-by-tag.cleanup-old-persistence-ids", MILLISECONDS).millis
+    case "off"       => Duration.Inf
+    case "<default>" => (writePluginConfig.bucketSize.durationMillis * 2).millis
+    case _           => config.getDuration("events-by-tag.cleanup-old-persistence-ids", MILLISECONDS).millis
   }
 
   if (eventsByTagCleanUpPersistenceIds != Duration.Inf && eventsByTagCleanUpPersistenceIds.toMillis < (writePluginConfig.bucketSize.durationMillis * 2)) {

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -81,7 +81,7 @@ import scala.concurrent.duration._
     case _     => config.getDuration("events-by-tag.cleanup-old-persistence-ids", MILLISECONDS).millis
   }
 
-  if (eventsByTagCleanUpPersistenceIds.toMillis < (writePluginConfig.bucketSize.durationMillis * 2)) {
+  if (eventsByTagCleanUpPersistenceIds != Duration.Inf && eventsByTagCleanUpPersistenceIds.toMillis < (writePluginConfig.bucketSize.durationMillis * 2)) {
     log.warning(
       "cleanup-old-persistence-ids has been set to less than 2 x the bucket size. If a tagged event for a persistence id " +
       "is not received for the cleanup period but then received before 2 x the bucket size then old events could re-delivered.")

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -9,6 +9,7 @@ import java.time.{ LocalDateTime, ZoneOffset }
 import akka.actor.{ ActorSystem, ExtendedActorSystem, NoSerializationVerificationNeeded }
 import akka.annotation.InternalApi
 import akka.cassandra.session.CqlSessionProvider
+import akka.event.Logging
 import akka.persistence.cassandra.CassandraPluginConfig
 import akka.persistence.cassandra.journal.{ CassandraJournalConfig, Day, Hour, TimeBucket }
 import com.typesafe.config.Config
@@ -23,6 +24,8 @@ import scala.concurrent.duration._
     config: Config,
     writePluginConfig: CassandraJournalConfig)
     extends NoSerializationVerificationNeeded {
+
+  val log = Logging(system, classOf[CassandraReadJournalConfig])
 
   val readProfile = config.getString("read-profile")
   CassandraPluginConfig.checkProfile(system, readProfile)
@@ -73,8 +76,14 @@ import scala.concurrent.duration._
     config.getDuration("events-by-tag.new-persistence-id-scan-timeout", MILLISECONDS).millis
   val eventsByTagOffsetScanning: FiniteDuration =
     config.getDuration("events-by-tag.offset-scanning-period", MILLISECONDS).millis
-  val eventsByTagCleanUpPersistenceIds: Duration = config.getString("cleanup-old-persistence-ids") match {
+  val eventsByTagCleanUpPersistenceIds: Duration = config.getString("events-by-tag.cleanup-old-persistence-ids") match {
     case "off" => Duration.Inf
-    case _     => config.getDuration("cleanup-old-persistence-ids", MILLISECONDS).millis
+    case _     => config.getDuration("events-by-tag.cleanup-old-persistence-ids", MILLISECONDS).millis
+  }
+
+  if (eventsByTagCleanUpPersistenceIds.toMillis < (writePluginConfig.bucketSize.durationMillis * 2)) {
+    log.warning(
+      "cleanup-old-persistence-ids has been set to less than 2 x the bucket size. If a tagged event for a persistence id " +
+      "is not received for the cleanup period but then received before 2 x the bucket size then old events could re-delivered.")
   }
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -253,7 +253,7 @@ import scala.compat.java8.FutureConverters._
       override def preStart(): Unit = {
         stageState = StageState(QueryIdle, fromOffset, calculateToOffset(), initialTagPidSequenceNrs.mapValues {
           case (tagPidSequenceNr, offset) => (tagPidSequenceNr, offset, System.currentTimeMillis())
-        }, None, bucketSize)
+        }.toMap, None, bucketSize)
         if (log.isInfoEnabled) {
           log.info(
             s"[{}]: EventsByTag query [${session.tag}] starting with EC delay {}ms: fromOffset [{}] toOffset [{}]",

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -322,9 +322,10 @@ import scala.compat.java8.FutureConverters._
       }
 
       private def cleanup(): Unit = {
+        val now = System.currentTimeMillis()
         val garbageCollected = stageState.tagPidSequenceNrs.filterNot {
           case (_, (_, _, lastUpdated)) =>
-            (System.currentTimeMillis() - lastUpdated) > settings.eventsByTagNewPersistenceIdScanTimeout.toMillis
+            (now - lastUpdated) > settings.eventsByTagNewPersistenceIdScanTimeout.toMillis
         }
         updateStageState(_.copy(tagPidSequenceNrs = garbageCollected))
       }
@@ -468,7 +469,9 @@ import scala.compat.java8.FutureConverters._
         } else {
           if (log.isDebugEnabled) {
             log.debug(
-              s"[${stageUuid}] " + " [{}]: New persistence id: [{}] does not start at tag pid sequence nr 1. This could either be that the events are before the offset or that they are missing. Tag pid sequence nr found: [{}]. Looking for lower tag pid sequence nrs for [{}]",
+              s"[${stageUuid}] " + " [{}]: Persistence Id not in metadata: [{}] does not start at tag pid sequence nr 1. " +
+              "This could either be that the events are before the offset, that the metadata has been dropped or that they are delayed. " +
+              "Tag pid sequence nr found: [{}]. Looking for lower tag pid sequence nrs for [{}] in the current and previous buckets.",
               session.tag,
               repr.persistenceId,
               repr.tagPidSequenceNr,

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -327,7 +327,7 @@ import scala.compat.java8.FutureConverters._
         val now = System.currentTimeMillis()
         val remaining = stageState.tagPidSequenceNrs.filterNot {
           case (_, (_, _, lastUpdated)) =>
-            (now - lastUpdated) > settings.eventsByTagNewPersistenceIdScanTimeout.toMillis
+            (now - lastUpdated) > settings.eventsByTagCleanUpPersistenceIds.toMillis
         }
         updateStageState(_.copy(tagPidSequenceNrs = remaining))
       }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraReadJournalConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraReadJournalConfigSpec.scala
@@ -20,6 +20,19 @@ class CassandraReadJournalConfigSpec
   override protected def afterAll(): Unit = shutdown()
 
   "Cassandra read journal config" must {
+
+    "default persistence id cleanup to 2x bucket" in {
+      import scala.concurrent.duration._
+      val config = ConfigFactory.parseString("""
+         cassandra-journal.events-by-tag.bucket-size = Hour
+        """).withFallback(system.settings.config)
+
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
+      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+
+      readConfig.eventsByTagCleanUpPersistenceIds shouldEqual 2.hours
+    }
+
     "support Day with just day format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Day

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -94,11 +94,12 @@ object EventsByTagSpec {
   val persistenceIdCleanupConfig =
     ConfigFactory.parseString("""
        cassandra-query-journal.events-by-tag {
+          eventual-consistency-delay = 0s
           # will test by requiring a new persistence-id search every 2s
           new-persistence-id-scan-timeout = 500ms
           cleanup-old-persistence-ids = 1s
        }
-      """)
+      """).withFallback(config)
 
   val disabledConfig = ConfigFactory.parseString("""
       cassandra-journal {
@@ -1048,17 +1049,31 @@ object EventsByTagDisabledSpec {
   def props(pid: String): Props = Props(new CounterActor(pid))
 }
 
-class EventsByTagPersistenceIfCleanupSpec extends AbstractEventsByTagSpec(EventsByTagSpec.persistenceIdCleanupConfig) {
+class EventsByTagPersistenceIfCleanupSpec
+    extends AbstractEventsByTagSpec(EventsByTagSpec.persistenceIdCleanupConfig, false) {
+
+  val newPersistenceIdScan: FiniteDuration = 500.millis
+  val cleanupPeriod: FiniteDuration = 1.second
 
   "PersistenceId cleanup" must {
     "drop state and trigger new persistence id lookup peridodically" in {
-      val a = system.actorOf(TestActor.props("cleanup"))
-      val query = queries.eventsByTag("orange", TimeBasedUUID.apply(Uuids.timeBased()))
+      val t1: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).minusDays(2)
+      val event1 = PersistentRepr(s"cleanup-1", 1, "cleanup")
+      writeTaggedEvent(t1, event1, Set("cleanup-tag"), 1, bucketSize)
+
+      val query =
+        queries.eventsByTag("cleanup-tag", TimeBasedUUID(Uuids.startOf(t1.toInstant(ZoneOffset.UTC).toEpochMilli - 1L)))
       val probe = query.runWith(TestSink.probe[Any])
       probe.request(10)
-      a ! "orange chair"
-      expectMsg(s"orange chair-done")
-      probe.expectNext("orange chair")
+      probe.expectNextPF { case e @ EventEnvelope(_, "cleanup", 1L, "cleanup-1") => e }
+      probe.expectNoMessage(cleanupPeriod + 250.millis)
+
+      // the metadata for pid cleanup should have been removed meaning the next event will be delayed
+      val event2 = PersistentRepr(s"cleanup-2", 2, "cleanup")
+      writeTaggedEvent(event2, Set("cleanup-tag"), 2, bucketSize)
+
+      probe.expectNoMessage(newPersistenceIdScan - 50.millis)
+      probe.expectNextPF { case e @ EventEnvelope(_, "cleanup", 2L, "cleanup-2") => e }
 
     }
   }


### PR DESCRIPTION
This is disabled by default as dropping the metadata for a persistence id has the issue of what happens if an event for that persistence id is then received, so it is opt in.

For short lived persistence ids it can be set to any value, but still ideally not too small.

For long lived persistence ids it must be set to at least 2 x the bucket size. Otherwise the search triggered when a new event comes in after the metadata has been dropped will find an old event.

Another option would be to have an option to publish info to pub sub to drop metadata that users could use directly. 

Refs #605