### PR TITLE
Don't reset flush timer for each event

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -139,7 +139,7 @@ import scala.concurrent.duration._
       // reached to force a flush or that the batch size is met
       val (newTagPidSequenceNrs, events) =
         assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
-      log.debug("Assigned tag pid sequence nrs: {}", events)
+      log.debug("Assigned tag pid sequence nrs: {}", newTagPidSequenceNrs)
       val newBuffer = (buffer ++ events).sortBy(_._1.timeUuid)(timeUuidOrdering)
       flushIfRequired(newBuffer, newTagPidSequenceNrs)
     case twd: TagWriteDone =>
@@ -260,11 +260,11 @@ import scala.concurrent.duration._
       log.debug("Batch size reached. Writing to Cassandra.")
       write(buffer.take(settings.maxBatchSize), buffer.drop(settings.maxBatchSize), tagSequenceNrs, None)
     } else if (settings.flushInterval == Duration.Zero) {
-      log.debug("Flushing right away as interval is zero")
       // Should always be a buffer of 1
       write(buffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagSequenceNrs, None)
     } else {
-      timers.startSingleTimer(FlushKey, InternalFlush, settings.flushInterval)
+      if (!timers.isTimerActive(FlushKey))
+        timers.startSingleTimer(FlushKey, InternalFlush, settings.flushInterval)
       context.become(idle(buffer, tagSequenceNrs))
     }
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
@@ -224,6 +224,38 @@ class TagWriterSpec
       probe.expectMsg(ProgressWrite("p1", 2, 2, e2.timeUuid))
     }
 
+    "flush after interval when new events are written" in {
+      val (probe, ref) = setup(settings = defaultSettings.copy(maxBatchSize = 100, flushInterval = 500.millis))
+      val bucket = nowBucket()
+
+      val allEvents =
+        (1 to 6).foldLeft(Vector.empty[Serialized]) {
+          case (acc, n) =>
+            val evt = event("p1", n, s"e-$n", bucket)
+            val events = acc :+ evt
+            ref ! TagWrite(tagName, Vector(evt))
+            Thread.sleep(200)
+            if (n == 3) {
+              probe.within(200.millis) {
+                probe.expectMsg(events.map(evt => toEw(evt, evt.sequenceNr)).toVector)
+                probe.expectMsg(
+                  ProgressWrite("p1", events.last.sequenceNr, events.last.sequenceNr, events.last.timeUuid))
+              }
+            }
+            events
+        }
+
+      val remainingFlushedEvents = allEvents.drop(3)
+      probe.expectMsg(remainingFlushedEvents.map(evt => toEw(evt, evt.sequenceNr)).toVector)
+      probe.expectMsg(
+        ProgressWrite(
+          "p1",
+          remainingFlushedEvents.last.sequenceNr,
+          remainingFlushedEvents.last.sequenceNr,
+          remainingFlushedEvents.last.timeUuid))
+
+    }
+
     "flush when time bucket changes" in {
       val (probe, ref) = setup(settings = defaultSettings.copy(maxBatchSize = 3))
       val bucket = nowBucket()


### PR DESCRIPTION
`startSingleTimer` was re-scheduled for each event which could result in long delays if events are written at a lower frequency than the `flush-interval`.

Example, `flush-interval=250ms` and if one event is written every 200ms it would not flush until reaching the `max-message-batch-size`.