### PR TITLE
[backport] Cleanup persistence id meta data in events by tag queries (#612)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -725,6 +725,17 @@ cassandra-query-journal {
     # Verbose debug logging for offset updates for events by tag queries. Any logging that is per event is
     # affected by this flag. Debug logging that is per query to Cassandra is enabled if DEBUG logging is enabled
     verbose-debug-logging = false
+
+    # Set to a duration to have events by tag queries drop state about persistence ids
+    # this can be set to reduce memory usage of events by tag queries for use cases where there
+    # are many short lived persistence ids
+    # If the metadata for a persistence-id is dropped and the persistence-id is encoutered it will
+    # add a delay of the new-persistence-id-scan-timeout before delivering any new events
+    # This should be set to a large value e.g. 2 x the bucket size. It can be set lower but if the metadata is dropped
+    # for a persistence id and an event is received afterwards then old events in the current and previous bucket may
+    # be redelivered
+    # By default it is set to 2 x the bucket size
+    cleanup-old-persistence-ids = "<default>"
   }
 
   # Deserialization of events is perfomed in an Akka streams mapAsync operator and this is the

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -93,7 +93,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config)
   private val writePluginId = cfg.getString("write-plugin")
   private val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig(writePluginId))
   private val queryPluginConfig =
-    new CassandraReadJournalConfig(cfg, writePluginConfig)
+    new CassandraReadJournalConfig(system, cfg, writePluginConfig)
 
   if (queryPluginConfig.eventsByTagEventualConsistency < 1.seconds) {
     log.warning(

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
@@ -38,7 +38,7 @@ class TagScanningSpec extends CassandraSpec(TagScanningSpec.config) {
           .asScala
           .toList
           .map(row => (row.getString("persistence_id"), row.getLong("sequence_nr")))
-          .filterNot(_._1 == "persistenceInit")
+          .filterNot(_._1.startsWith("persistenceInit"))
           .map { case (pid, seqNr) => (pid.toInt, seqNr) } // sorting by pid makes the failure message easy to interpret
           .sortBy(_._1)
         scanning shouldEqual expected

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -21,6 +21,7 @@ import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
 import EventsByTagSpec._
 import akka.testkit.TestProbe
+import com.datastax.driver.core.utils.UUIDs
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.BeforeAndAfterEach
 
@@ -91,6 +92,16 @@ object EventsByTagSpec {
     cassandra-query-journal.first-time-bucket = "${today.minusDays(1001).format(firstBucketFormatter)}"
     """).withFallback(strictConfig)
 
+  val persistenceIdCleanupConfig =
+    ConfigFactory.parseString("""
+       cassandra-query-journal.events-by-tag {
+          eventual-consistency-delay = 0s
+          # will test by requiring a new persistence-id search every 2s
+          new-persistence-id-scan-timeout = 500ms
+          cleanup-old-persistence-ids = 1s
+       }
+      """).withFallback(config)
+
   val disabledConfig = ConfigFactory.parseString("""
       akka.loglevel = INFO
       cassandra-journal {
@@ -110,7 +121,7 @@ class EventWithMetaDataTagger extends WriteEventAdapter {
 }
 
 class ColorFruitTagger extends WriteEventAdapter {
-  val colors = Set("green", "black", "blue", "yellow")
+  val colors = Set("green", "black", "blue", "yellow", "orange")
   val fruits = Set("apple", "banana")
   override def toJournal(event: Any): Any = event match {
     case s: String =>
@@ -551,7 +562,7 @@ class EventsByTagFindDelayedEventsSpec
       ConfigFactory
         .parseString(
           """
-akka.loglevel = INFO 
+akka.loglevel = INFO
 # find delayed events from offset relies on this as it puts an event before the offset that will not
 # be found and one after that will be found for a new persistence id
 # have it at least 2x the interval so searching for missing tries trice
@@ -1053,6 +1064,37 @@ object EventsByTagDisabledSpec {
   }
 
   def props(pid: String): Props = Props(new CounterActor(pid))
+}
+
+class EventsByTagPersistenceIfCleanupSpec
+    extends AbstractEventsByTagSpec(EventsByTagSpec.persistenceIdCleanupConfig, false) {
+
+  val newPersistenceIdScan: FiniteDuration = 500.millis
+  val cleanupPeriod: FiniteDuration = 1.second
+
+  "PersistenceId cleanup" must {
+    "drop state and trigger new persistence id lookup peridodically" in {
+      val t1: LocalDateTime = LocalDateTime.now(ZoneOffset.UTC).minusDays(2)
+      val event1 = PersistentRepr(s"cleanup-1", 1, "cleanup")
+      writeTaggedEvent(t1, event1, Set("cleanup-tag"), 1, bucketSize)
+
+      val query =
+        queries.eventsByTag("cleanup-tag", TimeBasedUUID(UUIDs.startOf(t1.toInstant(ZoneOffset.UTC).toEpochMilli - 1L)))
+      val probe = query.runWith(TestSink.probe[Any])
+      probe.request(10)
+      probe.expectNextPF { case e @ EventEnvelope(_, "cleanup", 1L, "cleanup-1") => e }
+      probe.expectNoMessage(cleanupPeriod + 250.millis)
+
+      // the metadata for pid cleanup should have been removed meaning the next event will be delayed
+      val event2 = PersistentRepr(s"cleanup-2", 2, "cleanup")
+      writeTaggedEvent(event2, Set("cleanup-tag"), 2, bucketSize)
+
+      probe.expectNoMessage(newPersistenceIdScan - 50.millis)
+      probe.expectNextPF { case e @ EventEnvelope(_, "cleanup", 2L, "cleanup-2") => e }
+
+    }
+  }
+
 }
 
 class EventsByTagDisabledSpec extends AbstractEventsByTagSpec(EventsByTagSpec.disabledConfig) {


### PR DESCRIPTION
Backport of #612 