### PR TITLE
[backport] Detach the batching of the pub-sub notifications from the write-flush…

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -184,8 +184,8 @@ cassandra-journal {
     # Max time to buffer events for before writing.
     # Larger valeues will increase cassandra write efficiency but increase the delay before
     # seeing events in EventsByTag queries.
-    # Setting this to 0 means that tag writes will get written immediately but will still be asynchronous
-    # with respect to the PersistentActor's persist call. However, this will be very bad for throughput.
+    # Setting this to 0 means that tag writes will be written immediately but will still be asynchronous
+    # with respect to the PersistentActor's persist call.
     flush-interval = 250ms
 
     # Update the tag_scanning table with this interval. Shouldn't be done too often to
@@ -312,6 +312,9 @@ cassandra-journal {
   #    - cassandra-journal.pubsub-notification=on              (send real-time announcements at most every sec)
   #
   # Setting pubsub-notification to "off" will disable the journal sending these announcements.
+  # When enabled with `on` it will throttle the number of notfication messages per tag to at most 10 per second.
+  # Alternatively a duration can be defined, such as pubsub-notification=300ms, which will be throttling interval
+  # for sending the notifications.
   pubsub-notification = off
 
   # Set the protocol version explicitly, should only be used for compatibility testing.

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -85,11 +85,17 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
       Some(config.getDuration("events-by-tag.time-to-live", TimeUnit.MILLISECONDS).millis)
     else None)
 
+  private val pubsubNotificationInterval: Duration = config.getString("pubsub-notification").toLowerCase match {
+    case "on" | "true"   => 100.millis
+    case "off" | "false" => Duration.Undefined
+    case _               => config.getDuration("pubsub-notification", TimeUnit.MILLISECONDS).millis
+  }
+
   val tagWriterSettings = TagWriterSettings(
     config.getInt("events-by-tag.max-message-batch-size"),
     config.getDuration("events-by-tag.flush-interval", TimeUnit.MILLISECONDS).millis,
     config.getDuration("events-by-tag.scanning-flush-interval", TimeUnit.MILLISECONDS).millis,
-    config.getBoolean("pubsub-notification"))
+    pubsubNotificationInterval)
 
   val coordinatedShutdownOnError: Boolean = config.getBoolean("coordinated-shutdown-on-error")
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import scala.concurrent.duration.FiniteDuration
+import akka.actor.{ Actor, ActorRef }
+import akka.actor.Props
+import akka.annotation.InternalApi
+
+/**
+ * INTERNAL API: Proxies messages to another actor, only allowing identical messages through once every [interval].
+ */
+@InternalApi private[akka] class PubSubThrottler(delegate: ActorRef, interval: FiniteDuration) extends Actor {
+  import PubSubThrottler._
+  import context.dispatcher
+
+  /** The messages we've already seen during this interval */
+  val seen = collection.mutable.Set.empty[Any]
+
+  /** The messages we've seen more than once during this interval, and their sender(s). */
+  val repeated = collection.mutable.Map.empty[Any, Set[ActorRef]].withDefaultValue(Set.empty)
+
+  val timer = context.system.scheduler.schedule(interval, interval, self, Tick)
+
+  def receive = {
+    case Tick =>
+      for ((msg, clients) <- repeated;
+           client <- clients) {
+        delegate.tell(msg, client)
+      }
+      seen.clear()
+      repeated.clear()
+
+    case msg =>
+      if (seen.contains(msg)) {
+        repeated += (msg -> (repeated(msg) + sender))
+      } else {
+        delegate.forward(msg)
+        seen += msg
+      }
+
+  }
+
+  override def postStop() = {
+    timer.cancel()
+    super.postStop()
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi private[akka] object PubSubThrottler {
+
+  def props(delegate: ActorRef, interval: FiniteDuration): Props =
+    Props(new PubSubThrottler(delegate, interval))
+
+  private case object Tick
+
+}

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -58,7 +58,7 @@ import scala.concurrent.duration._
   val keyspace: String = writePluginConfig.keyspace
   val targetPartitionSize: Long = writePluginConfig.targetPartitionSize
   val table: String = writePluginConfig.table
-  val pubsubNotification: Boolean =
+  val pubsubNotification: Duration =
     writePluginConfig.tagWriterSettings.pubsubNotification
   val eventsByPersistenceIdEventTimeout: FiniteDuration =
     config.getDuration("events-by-persistence-id-gap-timeout", MILLISECONDS).millis

--- a/core/src/test/scala/akka/persistence/cassandra/journal/PubSubThrottlerSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/PubSubThrottlerSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import scala.concurrent.duration.DurationInt
+
+import org.scalatest.{ MustMatchers, WordSpecLike }
+
+import akka.actor.{ ActorSystem, Props }
+import akka.testkit.{ TestKit, TestProbe }
+
+class PubSubThrottlerSpec
+    extends TestKit(ActorSystem("CassandraConfigCheckerSpec"))
+    with WordSpecLike
+    with MustMatchers {
+  "PubSubThrottler" should {
+    "eat up duplicate messages that arrive within the same [interval] window" in {
+      val delegate = TestProbe()
+      val throttler = system.actorOf(Props(new PubSubThrottler(delegate.ref, 5.seconds)))
+
+      throttler ! "hello"
+      throttler ! "hello"
+      throttler ! "hello"
+      delegate.within(2.seconds) {
+        delegate.expectMsg("hello")
+      }
+      // Only first "hello" makes it through during the first interval.
+      delegate.expectNoMessage(2.seconds)
+
+      // Eventually, the interval will roll over and forward ONE further hello.
+      delegate.expectMsg(10.seconds, "hello")
+      delegate.expectNoMessage(2.seconds)
+
+      throttler ! "hello"
+      delegate.within(2.seconds) {
+        delegate.expectMsg("hello")
+      }
+    }
+
+    "allow differing messages to pass through within the same [interval] window" in {
+      val delegate = TestProbe()
+      val throttler = system.actorOf(Props(new PubSubThrottler(delegate.ref, 5.seconds)))
+      throttler ! "hello"
+      throttler ! "world"
+      delegate.within(2.seconds) {
+        delegate.expectMsg("hello")
+        delegate.expectMsg("world")
+      }
+    }
+  }
+}

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
@@ -70,7 +70,7 @@ class TagWriterSpec
     maxBatchSize = 10,
     flushInterval = 10.seconds,
     scanningFlushInterval = 20.seconds,
-    pubsubNotification = false)
+    pubsubNotification = Duration.Undefined)
   val waitDuration = 100.millis
   val shortDuration = 50.millis
   val tagName = "tag-1"

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -32,7 +32,7 @@ class TagWritersSpec
     maxBatchSize = 10,
     flushInterval = 10.seconds,
     scanningFlushInterval = 20.seconds,
-    pubsubNotification = false)
+    pubsubNotification = Duration.Undefined)
 
   private def testProps(settings: TagWriterSettings, tagWriterCreator: String => ActorRef): Props =
     Props(new TagWriters(settings, tagWriterSession = null) {


### PR DESCRIPTION
…ing, #623 (#624)

* Detach the batching of the pub-sub notifications from the write-flushing, #623

* main reason is to be able to reduce the tag write flush-interval but still
  not publish too many notifications
* note that the PubSubThrottler will send immediately for the first
  message in the interval so it will not add additional latency
  for low frequency

* Don't reset the scheduled TagNotification for each message

Co-authored-by: Christopher Batey <christopher.batey@gmail.com>
