### PR TITLE
Exclude spotbugs from cassandra driver from pom

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ object Dependencies {
   val DriverVersion = "4.3.0"
 
   val akkaCassandraSessionDependencies = Seq(
-    "com.datastax.oss" % "java-driver-core" % DriverVersion,
+    ("com.datastax.oss" % "java-driver-core" % DriverVersion).exclude("com.github.spotbugs", "spotbugs-annotations"),
     "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test)
 
@@ -28,7 +28,7 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-cluster-sharding")
 
   val akkaPersistenceCassandraDependencies = Seq(
-      "com.datastax.oss" % "java-driver-core" % DriverVersion,
+      ("com.datastax.oss" % "java-driver-core" % DriverVersion).exclude("com.github.spotbugs", "spotbugs-annotations"),
       // Specifying guava dependency because older transitive dependency has security vulnerability
       "com.google.guava" % "guava" % "27.0.1-jre",
       "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,


### PR DESCRIPTION
These have a GPL license and aren't needed on user's runtime classpath