### PR TITLE
New configuration structure, #81

### DIFF
--- a/akka-26-tests/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
+++ b/akka-26-tests/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
@@ -10,12 +10,10 @@ import akka.actor.typed.ActorRef
 import akka.actor.typed.Behavior
 import akka.actor.typed.scaladsl.Behaviors
 import akka.actor.typed.scaladsl.adapter._
-import akka.persistence.cassandra.CassandraLifecycle
 import akka.persistence.cassandra.CassandraSpec
 import akka.persistence.typed.PersistenceId
 import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
-import com.typesafe.config.ConfigFactory
 import org.scalatest._
 
 object CassandraLoadTypedSpec {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -60,9 +60,6 @@ cassandra-journal {
   # meta data columns in the materialized view by setting this property to off.
   meta-in-events-by-tag-view = on
 
-  # Dispatcher for the plugin actor.
-  plugin-dispatcher = "cassandra-plugin-default-dispatcher"
-
   # Enable DistributedPubSub to announce events for a specific tag have
   # been written. These announcements cause any ongoing getEventsByTag to immediately re-poll, rather than
   # wait. In order enable this feature, make the following settings:
@@ -99,6 +96,9 @@ cassandra-journal {
 
     # FQCN of the cassandra journal plugin
     class = "akka.persistence.cassandra.journal.CassandraJournal"
+
+    # Dispatcher for the plugin actor
+    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
     # Name of the table to be created/used by the journal.
     # If the table doesn't exist it is automatically created.
@@ -174,6 +174,9 @@ cassandra-journal {
     # Implementation class of the Cassandra ReadJournalProvider
     class = "akka.persistence.cassandra.query.CassandraReadJournalProvider"
 
+    # Dispatcher for the plugin actors.
+    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
+
     # FIXME #81 is this needed in read section?
     read-profile = "cassandra-journal"
 
@@ -207,9 +210,6 @@ cassandra-journal {
     # of higher CPU saturation and more competing tasks when there are many concurrent queries or
     # replays.
     deserialization-parallelism = 1
-
-    # Dispatcher for the plugin actors.
-    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
     # Enable Dropwizard Metrics for Cluster.
     # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
@@ -378,6 +378,9 @@ cassandra-journal {
     # FQCN of the cassandra snapshot store plugin
     class = "akka.persistence.cassandra.snapshot.CassandraSnapshotStore"
 
+    # Dispatcher for the plugin actor
+    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
+
     write-profile = "cassandra-journal"
     read-profile = "cassandra-journal"
 
@@ -404,9 +407,6 @@ cassandra-journal {
 
     # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
     data-center-replication-factors = []
-
-    # Dispatcher for the plugin actor and task.
-    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
     # The time to wait before cassandra will remove the tombstones created for deleted entries.
     # cfr. gc_grace_seconds table property documentation on

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -31,21 +31,6 @@ cassandra-journal {
   read-profile = "cassandra-journal"
   write-profile = "cassandra-journal"
 
-  # Name of the keyspace to be created/used by the journal
-  keyspace = "akka"
-
-  # Parameter indicating whether the journal keyspace should be auto created.
-  # Not all Cassandra settings are configurable when using autocreate and for
-  # full control of the keyspace and table definitions you should create them 
-  # manually (with a script).
-  keyspace-autocreate = true
-
-  # Parameter indicating whether the journal tables should be auto created
-  # Not all Cassandra settings are configurable when using autocreate and for
-  # full control of the keyspace and table definitions you should create them 
-  # manually (with a script).
-  tables-autocreate = true
-
     # TODO remove this and just query cassandra to see what version it is
   # Set this to on to only use Cassandra 2.x compatible features,
   # i.e. if you are using a Cassandra 2.x server.
@@ -91,6 +76,21 @@ cassandra-journal {
 
     # Dispatcher for the plugin actor
     plugin-dispatcher = "cassandra-plugin-default-dispatcher"
+
+    # Parameter indicating whether the journal keyspace should be auto created.
+    # Not all Cassandra settings are configurable when using autocreate and for
+    # full control of the keyspace and table definitions you should create them
+    # manually (with a script).
+    keyspace-autocreate = true
+
+    # Parameter indicating whether the journal tables should be auto created
+    # Not all Cassandra settings are configurable when using autocreate and for
+    # full control of the keyspace and table definitions you should create them
+    # manually (with a script).
+    tables-autocreate = true
+
+    # Name of the keyspace to be created/used by the journal
+    keyspace = "akka"
 
     # Name of the table to be created/used by the journal.
     # If the table doesn't exist it is automatically created.
@@ -368,6 +368,18 @@ cassandra-journal {
 
     write-profile = "cassandra-journal"
     read-profile = "cassandra-journal"
+
+    # Parameter indicating whether the journal keyspace should be auto created.
+    # Not all Cassandra settings are configurable when using autocreate and for
+    # full control of the keyspace and table definitions you should create them
+    # manually (with a script).
+    keyspace-autocreate = true
+
+    # Parameter indicating whether the journal tables should be auto created
+    # Not all Cassandra settings are configurable when using autocreate and for
+    # full control of the keyspace and table definitions you should create them
+    # manually (with a script).
+    tables-autocreate = true
 
     # Name of the keyspace to be created/used by the snapshot store
     keyspace = "akka_snapshot"

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -8,11 +8,18 @@
 # only those settings that shall be different from the defaults
 # configured here, importing the defaults like so:
 #
-#   my-cassandra-journal = ${cassandra-journal}
-#   my-cassandra-journal {
-#     <settings...>
+#   another-cassandra-journal = ${cassandra-journal}
+#   another-cassandra-journal {
+#     write {
+#       <settings...>
+#     }
+#     query {
+#       <settings...>
+#     }
+#     events-by-tag {
+#       <settings...>
+#     }
 #   }
-
 cassandra-journal {
 
   # The implementation of akka.cassandra.session.SessionProvider
@@ -160,17 +167,23 @@ cassandra-journal {
     support-deletes = on
   }
 
-  # FIXME update docs
   # This configures the default settings for all CassandraReadJournal plugin
   # instances in the system.
+  #
+  # Settings for eventsByTag are defined in cassandra-journal.events-by-tag section.
   #
   # If you use multiple plugin instances you need to create differently named
   # sections containing only those settings that shall be different from the defaults
   # configured here, importing the defaults like so:
   #
-  #   my-cassandra-query-journal = ${cassandra-query-journal}
-  #   my-cassandra-query-journal {
-  #     <settings...>
+  #   another-cassandra-journal = ${cassandra-journal}
+  #   another-cassandra-journal {
+  #     query {
+  #       <settings...>
+  #     }
+  #     events-by-tag {
+  #       <settings...>
+  #     }
   #   }
   query {
     # Implementation class of the Cassandra ReadJournalProvider
@@ -179,7 +192,6 @@ cassandra-journal {
     # Dispatcher for the plugin actors.
     plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
-    # FIXME #81 is this needed in read section?
     read-profile = "cassandra-journal"
 
     # New events are retrieved (polled) with this interval.
@@ -355,7 +367,6 @@ cassandra-journal {
     cleanup-old-persistence-ids = "<default>"
   }
 
-  # FIXME #81 update docs
   # This configures the default settings for all Cassandra Snapshot plugin
   # instances in the system. If you are using just one configuration for
   # all persistent actors then you should point your akka.persistence.snapshot-store.plugin
@@ -365,9 +376,11 @@ cassandra-journal {
   # only those settings that shall be different from the defaults
   # configured here, importing the defaults like so:
   #
-  #   my-cassandra-snapshot-store = ${cassandra-snapshot-store}
-  #   my-cassandra-snapshot-store {
-  #     <settings...>
+  #   another-cassandra-journal = ${cassandra-journal}
+  #   another-cassandra-journal {
+  #     snapshot {
+  #       <settings...>
+  #     }
   #   }
   snapshot {
 

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2,7 +2,7 @@
 # This configures the default settings for all Cassandra Journal plugin
 # instances in the system. If you are using just one configuration for
 # all persistent actors then you should point your akka.persistence.journal.plugin
-# setting to this section.
+# setting to "cassandra-journal.write".
 #
 # Otherwise you need to create differently named sections containing
 # only those settings that shall be different from the defaults
@@ -13,22 +13,7 @@
 #     <settings...>
 #   }
 
-datastax-java-driver {
-  profiles {
-    cassandra-journal {
-      basic.request {
-        consistency = QUORUM
-        # the journal does not use any counters or collections
-        default-idempotence = true
-      }
-    }
-  }
-}
-
 cassandra-journal {
-
-  # FQCN of the cassandra journal plugin
-  class = "akka.persistence.cassandra.journal.CassandraJournal"
 
   # The implementation of akka.cassandra.session.SessionProvider
   # is used for creating the CqlSession. By default it loads all the driver's default
@@ -91,9 +76,6 @@ cassandra-journal {
   # meta data columns in the materialized view by setting this property to off.
   meta-in-events-by-tag-view = on
 
-  # The query journal to use when recovering
-  query-plugin = "cassandra-query-journal"
-
   # Dispatcher for the plugin actor.
   plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
@@ -130,6 +112,9 @@ cassandra-journal {
   coordinated-shutdown-on-error = off
 
   write {
+
+    # FQCN of the cassandra journal plugin
+    class = "akka.persistence.cassandra.journal.CassandraJournal"
 
     # Name of the table to be created/used by the journal.
     # If the table doesn't exist it is automatically created.
@@ -171,6 +156,68 @@ cassandra-journal {
     # cfr. gc_grace_seconds table property documentation on
     # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
     gc-grace-seconds = 864000
+  }
+
+  # FIXME update docs
+  # This configures the default settings for all CassandraReadJournal plugin
+  # instances in the system.
+  #
+  # If you use multiple plugin instances you need to create differently named
+  # sections containing only those settings that shall be different from the defaults
+  # configured here, importing the defaults like so:
+  #
+  #   my-cassandra-query-journal = ${cassandra-query-journal}
+  #   my-cassandra-query-journal {
+  #     <settings...>
+  #   }
+  read {
+    # Implementation class of the Cassandra ReadJournalProvider
+    class = "akka.persistence.cassandra.query.CassandraReadJournalProvider"
+
+    # FIXME #81 is this needed in read section?
+    read-profile = "cassandra-journal"
+
+    # New events are retrieved (polled) with this interval.
+    refresh-interval = 3s
+
+    # Sequence numbers for a persistenceId is assumed to be monotonically increasing
+    # without gaps. That is used for detecting missing events.
+    # In early versions of the journal that might not be true and therefore
+    # this can be relaxed by setting this property to off.
+    gap-free-sequence-numbers = on
+
+    # When using LQ writing in one DC and querying in another, the events for an entity may
+    # appear in the querying DC out of order, when that happens, try for this amount of
+    # time to find the in-order sequence number before failing the stream
+    events-by-persistence-id-gap-timeout = 10s
+
+    # How many events to fetch in one query (replay) and keep buffered until they
+    # are delivered downstreams.
+    max-buffer-size = 500
+
+    # Configure this to the first bucket eventByTag queries will start from in the format
+    # yyyyMMddTHH:mm yyyyMMdd is also supported if using Day as a bucket size
+    # Will be rounded down to the start of whatever time bucket it falls into
+    # When NoOffset is used it will look for events from this day and forward.
+    first-time-bucket = "20151120T00:00"
+
+    # Deserialization of events is perfomed in an Akka streams mapAsync operator and this is the
+    # parallelism for that. Increasing to means that deserialization is pipelined, which can
+    # be an advantage for machines with many CPU cores but otherwise it might be slower because
+    # of higher CPU saturation and more competing tasks when there are many concurrent queries or
+    # replays.
+    deserialization-parallelism = 1
+
+    # Dispatcher for the plugin actors.
+    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
+
+    # Enable Dropwizard Metrics for Cluster.
+    # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
+    metrics-enabled = on
+
+    # Enable JMX reporter for Dropwizard Metrics.
+    # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
+    jmx-reporting-enabled = on
   }
 
   events-by-tag {
@@ -222,6 +269,94 @@ cassandra-journal {
     # per tag per bucket
     # Valid options: Day, Hour, Minute
     bucket-size = "Hour"
+
+    # FIXME #81 the following events-by-tag were originally in the read section, do we need separatation of write/read for events-by-tag?
+
+    # How long to look for delayed events
+    # This works by adding an additional (internal) sequence number to each tag / persistence id
+    # event stream so that the read side can detect missing events. When a gap is detected no new events
+    # are emitted from the stream until either the missing events are found or the timeout is reached
+    # If the event is not found it is checked every `refresh-interval` so do not set this lower than that
+    # if you want at least one retry
+    # When looking for missing events only the current time bucket and the previous bucket are checked meaning that if
+    # clocks are out of sync, or cassandra replication is out by more than your bucket size (minute, hour or day)
+    # then the missing events won't be found
+    gap-timeout = 10s
+
+    # When a new persistenceId is found in an eventsByTag query that wasn't found in the initial offset scanning
+    # period as it didn't have any events in the current time bucket, this is how long the stage will delay events
+    # looking for any lower tag pid sequence nrs. 0s means that the found event is assumed to be the first.
+    # The edge case is if events for a not previously seen persistenceId come out of order then if this is set to
+    # 0s the newer event will be delivered and when the older event is found the stream will fail as events have
+    # to be delivered in order.
+    new-persistence-id-scan-timeout = 100ms
+
+    # For offset queries that start in the current time bucket a period of scanning
+    # takes place before deliverying events to look for the lowest sequence number
+    # for each persistenceId. Any value above 0 will result in at least one scan from
+    # the offset to (offset + period). Larger values will result in a longer period of time
+    # before the stream starts emitting events.
+    offset-scanning-period = 200ms
+
+
+    //#backtrack
+    back-track {
+      # Interval at which events by tag stages trigger a query to look for delayed events from before the
+      # current offset. Delayed events are also searched for when a subsequent event for the same persistence id
+      # is received. The purpose of this back track is to find delayed events for persistence ids that are no
+      # longer receiving events. Depending on the size of the period of the back track this can be expensive.
+      interval = 1s
+
+      # How far back to go in time for the scan. This is the maxinum amount of time an event can be delayed
+      # and be found without receiving a new event for the same persistence id. Set to a duration or "max" to search back
+      # to the start of the previous bucket which is the furthest a search can go back.
+      period = 5s
+
+      # at a less frequent interval for a longer back track is done to find any events that were delayed significantly
+      long-interval = 120s
+
+      # long-period can be max, off, or a duration where max is to the start of the previous bucket or cleanup-old-persistence-ids,
+      # which ever is shorter. Back tracks can not be longer than the cleanup-old-persistence-ids otherwise old events
+      # will be redelivered due to the metadat having been dropped
+      long-period = "max"
+    }
+    //#backtrack
+
+
+    # For eventsByTag queries how long to delay the query for by setting the upper bound of the event TimeUUID to be slightly in the past.
+    # This is very important as event writes that come from different nodes
+    # will have slightly different clocks meaning events aren't received in TimeUUID order in C*.
+    # Keeping clocks in sync with ntp is not sufficient to prevent this as it only takes a milisecond.
+    #
+    # In addition events written from the same node in an unlogged batch, meant to be isolated in C*, have been
+    # found in load testing to come partially to a concurrent query, and the partial results are not always the
+    # ones with the lowest TimeUUID.
+    #
+    # Events coming out of order are detected for persitenceIds that the query has already seen by using the previous
+    # tag pid sequence number. However for persistenceIds that the query has not seen the expecdted tag pid sequence number
+    # is not known.
+    #
+    # Another reason this is important is if the events are delivered to the
+    # query immediately and the offset is greater than some delayed events if the query is restarted from that offset
+    # the delayed events will never be delivered.
+    #
+    # Setting this to anything lower than 2s is highly discouraged.
+    eventual-consistency-delay = 5s
+
+    # Verbose debug logging for offset updates for events by tag queries. Any logging that is per event is
+    # affected by this flag. Debug logging that is per query to Cassandra is enabled if DEBUG logging is enabled
+    verbose-debug-logging = false
+
+    # Set to a duration to have events by tag queries drop state about persistence ids
+    # this can be set to reduce memory usage of events by tag queries for use cases where there
+    # are many short lived persistence ids
+    # If the metadata for a persistence-id is dropped and the persistence-id is encoutered it will
+    # add a delay of the new-persistence-id-scan-timeout before delivering any new events
+    # This should be set to a large value e.g. 2 x the bucket size. It can be set lower but if the metadata is dropped
+    # for a persistence id and an event is received afterwards then old events in the current and previous bucket may
+    # be redelivered
+    # By default it is set to 2 x the bucket size
+    cleanup-old-persistence-ids = "<default>"
   }
 
 }
@@ -333,160 +468,6 @@ cassandra-snapshot-store {
   jmx-reporting-enabled = on
 }
 
-# This configures the default settings for all CassandraReadJournal plugin
-# instances in the system.
-#
-# If you use multiple plugin instances you need to create differently named 
-# sections containing only those settings that shall be different from the defaults
-# configured here, importing the defaults like so:
-#
-#   my-cassandra-query-journal = ${cassandra-query-journal}
-#   my-cassandra-query-journal {
-#     <settings...>
-#   }
-cassandra-query-journal {
-  # Implementation class of the Cassandra ReadJournalProvider
-  class = "akka.persistence.cassandra.query.CassandraReadJournalProvider"
-
-
-  session-provider = "akka.cassandra.session.DefaultSessionProvider"
-  session-name = ""
-
-  # Absolute path to the write journal plugin configuration section
-  write-plugin = "cassandra-journal"
-
-  read-profile = "cassandra-journal"
-
-  # New events are retrieved (polled) with this interval.
-  refresh-interval = 3s
-
-  # Sequence numbers for a persistenceId is assumed to be monotonically increasing
-  # without gaps. That is used for detecting missing events.
-  # In early versions of the journal that might not be true and therefore
-  # this can be relaxed by setting this property to off.
-  gap-free-sequence-numbers = on
-
-  # When using LQ writing in one DC and querying in another, the events for an entity may
-  # appear in the querying DC out of order, when that happens, try for this amount of
-  # time to find the in-order sequence number before failing the stream
-  events-by-persistence-id-gap-timeout = 10s
-
-  # How many events to fetch in one query (replay) and keep buffered until they
-  # are delivered downstreams.
-  max-buffer-size = 500
-
- # Configure this to the first bucket eventByTag queries will start from in the format
-  # yyyyMMddTHH:mm yyyyMMdd is also supported if using Day as a bucket size
-  # Will be rounded down to the start of whatever time bucket it falls into
-  # When NoOffset is used it will look for events from this day and forward.
-  first-time-bucket = "20151120T00:00"
-
-  events-by-tag {
-    # How long to look for delayed events
-    # This works by adding an additional (internal) sequence number to each tag / persistence id
-    # event stream so that the read side can detect missing events. When a gap is detected no new events
-    # are emitted from the stream until either the missing events are found or the timeout is reached
-    # If the event is not found it is checked every `refresh-interval` so do not set this lower than that
-    # if you want at least one retry
-    # When looking for missing events only the current time bucket and the previous bucket are checked meaning that if
-    # clocks are out of sync, or cassandra replication is out by more than your bucket size (minute, hour or day)
-    # then the missing events won't be found
-    gap-timeout = 10s
-
-    # When a new persistenceId is found in an eventsByTag query that wasn't found in the initial offset scanning
-    # period as it didn't have any events in the current time bucket, this is how long the stage will delay events
-    # looking for any lower tag pid sequence nrs. 0s means that the found event is assumed to be the first.
-    # The edge case is if events for a not previously seen persistenceId come out of order then if this is set to
-    # 0s the newer event will be delivered and when the older event is found the stream will fail as events have
-    # to be delivered in order.
-    new-persistence-id-scan-timeout = 100ms
-
-    # For offset queries that start in the current time bucket a period of scanning
-    # takes place before deliverying events to look for the lowest sequence number
-    # for each persistenceId. Any value above 0 will result in at least one scan from
-    # the offset to (offset + period). Larger values will result in a longer period of time
-    # before the stream starts emitting events.
-    offset-scanning-period = 200ms
-
-
-    //#backtrack
-    back-track {
-      # Interval at which events by tag stages trigger a query to look for delayed events from before the
-      # current offset. Delayed events are also searched for when a subsequent event for the same persistence id
-      # is received. The purpose of this back track is to find delayed events for persistence ids that are no
-      # longer receiving events. Depending on the size of the period of the back track this can be expensive.
-      interval = 1s
-
-      # How far back to go in time for the scan. This is the maxinum amount of time an event can be delayed
-      # and be found without receiving a new event for the same persistence id. Set to a duration or "max" to search back
-      # to the start of the previous bucket which is the furthest a search can go back.
-      period = 5s
-
-      # at a less frequent interval for a longer back track is done to find any events that were delayed significantly
-      long-interval = 120s
-
-      # long-period can be max, off, or a duration where max is to the start of the previous bucket or cleanup-old-persistence-ids,
-      # which ever is shorter. Back tracks can not be longer than the cleanup-old-persistence-ids otherwise old events
-      # will be redelivered due to the metadat having been dropped
-      long-period = "max"
-    }
-    //#backtrack
-
-
-    # For eventsByTag queries how long to delay the query for by setting the upper bound of the event TimeUUID to be slightly in the past.
-    # This is very important as event writes that come from different nodes
-    # will have slightly different clocks meaning events aren't received in TimeUUID order in C*.
-    # Keeping clocks in sync with ntp is not sufficient to prevent this as it only takes a milisecond.
-    #
-    # In addition events written from the same node in an unlogged batch, meant to be isolated in C*, have been
-    # found in load testing to come partially to a concurrent query, and the partial results are not always the
-    # ones with the lowest TimeUUID.
-    #
-    # Events coming out of order are detected for persitenceIds that the query has already seen by using the previous
-    # tag pid sequence number. However for persistenceIds that the query has not seen the expecdted tag pid sequence number
-    # is not known.
-    #
-    # Another reason this is important is if the events are delivered to the
-    # query immediately and the offset is greater than some delayed events if the query is restarted from that offset
-    # the delayed events will never be delivered.
-    #
-    # Setting this to anything lower than 2s is highly discouraged.
-    eventual-consistency-delay = 5s
-
-    # Verbose debug logging for offset updates for events by tag queries. Any logging that is per event is
-    # affected by this flag. Debug logging that is per query to Cassandra is enabled if DEBUG logging is enabled
-    verbose-debug-logging = false
-
-    # Set to a duration to have events by tag queries drop state about persistence ids
-    # this can be set to reduce memory usage of events by tag queries for use cases where there
-    # are many short lived persistence ids
-    # If the metadata for a persistence-id is dropped and the persistence-id is encoutered it will
-    # add a delay of the new-persistence-id-scan-timeout before delivering any new events
-    # This should be set to a large value e.g. 2 x the bucket size. It can be set lower but if the metadata is dropped
-    # for a persistence id and an event is received afterwards then old events in the current and previous bucket may
-    # be redelivered
-    # By default it is set to 2 x the bucket size
-    cleanup-old-persistence-ids = "<default>"
-  }
-
-  # Deserialization of events is perfomed in an Akka streams mapAsync operator and this is the
-  # parallelism for that. Increasing to means that deserialization is pipelined, which can
-  # be an advantage for machines with many CPU cores but otherwise it might be slower because
-  # of higher CPU saturation and more competing tasks when there are many concurrent queries or
-  # replays.
-  deserialization-parallelism = 1
-
-  # Dispatcher for the plugin actors.
-  plugin-dispatcher = "cassandra-plugin-default-dispatcher"
-
-  # Enable Dropwizard Metrics for Cluster.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  metrics-enabled = on
-
-  # Enable JMX reporter for Dropwizard Metrics.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  jmx-reporting-enabled = on
-}
 
 # Default dispatcher for plugin actor and tasks.
 cassandra-plugin-default-dispatcher {
@@ -499,3 +480,14 @@ cassandra-plugin-default-dispatcher {
   }
 }
 
+datastax-java-driver {
+  profiles {
+    cassandra-journal {
+      basic.request {
+        consistency = QUORUM
+        # the journal does not use any counters or collections
+        default-idempotence = true
+      }
+    }
+  }
+}

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -244,7 +244,9 @@ cassandra-journal {
     scanning-flush-interval = 30s
 
     table = "tag_views"
+
     gc-grace-seconds = 864000
+
     compaction-strategy {
       class = "SizeTieredCompactionStrategy"
       # If setting a time-to-live then consider using TimeWindowCompactionStratery
@@ -298,7 +300,6 @@ cassandra-journal {
     # before the stream starts emitting events.
     offset-scanning-period = 200ms
 
-
     //#backtrack
     back-track {
       # Interval at which events by tag stages trigger a query to look for delayed events from before the
@@ -321,7 +322,6 @@ cassandra-journal {
       long-period = "max"
     }
     //#backtrack
-
 
     # For eventsByTag queries how long to delay the query for by setting the upper bound of the event TimeUUID to be slightly in the past.
     # This is very important as event writes that come from different nodes
@@ -359,115 +359,69 @@ cassandra-journal {
     cleanup-old-persistence-ids = "<default>"
   }
 
-}
+  # FIXME #81 update docs
+  # This configures the default settings for all Cassandra Snapshot plugin
+  # instances in the system. If you are using just one configuration for
+  # all persistent actors then you should point your akka.persistence.snapshot-store.plugin
+  # setting to this section.
+  #
+  # Otherwise you need to create differently named sections containing
+  # only those settings that shall be different from the defaults
+  # configured here, importing the defaults like so:
+  #
+  #   my-cassandra-snapshot-store = ${cassandra-snapshot-store}
+  #   my-cassandra-snapshot-store {
+  #     <settings...>
+  #   }
+  snapshot {
 
-# This configures the default settings for all Cassandra Snapshot plugin
-# instances in the system. If you are using just one configuration for
-# all persistent actors then you should point your akka.persistence.snapshot-store.plugin
-# setting to this section.
-#
-# Otherwise you need to create differently named sections containing
-# only those settings that shall be different from the defaults
-# configured here, importing the defaults like so:
-#
-#   my-cassandra-snapshot-store = ${cassandra-snapshot-store}
-#   my-cassandra-snapshot-store {
-#     <settings...>
-#   }
-cassandra-snapshot-store {
+    # FQCN of the cassandra snapshot store plugin
+    class = "akka.persistence.cassandra.snapshot.CassandraSnapshotStore"
 
-  # FQCN of the cassandra snapshot store plugin
-  class = "akka.persistence.cassandra.snapshot.CassandraSnapshotStore"
+    write-profile = "cassandra-journal"
+    read-profile = "cassandra-journal"
 
-  session-provider = "akka.cassandra.session.DefaultSessionProvider"
+    # Name of the keyspace to be created/used by the snapshot store
+    keyspace = "akka_snapshot"
 
-  session-name = ""
+    # Name of the table to be created/used by the snapshot store.
+    # If the table doesn't exist it is automatically created.
+    table = "snapshots"
 
-  write-profile = "cassandra-journal"
-  read-profile = "cassandra-journal"
+    # Compaction strategy for the snapshot table
+    # Please refer to the tests for example configurations.
+    # Refer to http://docs.datastax.com/en/cql/3.1/cql/cql_reference/compactSubprop.html
+    # for more information regarding the properties.
+    table-compaction-strategy {
+      class = "SizeTieredCompactionStrategy"
+    }
 
-  # Name of the keyspace to be created/used by the snapshot store
-  keyspace = "akka_snapshot"
+    # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
+    replication-strategy = "SimpleStrategy"
 
-  # Parameter indicating whether the snapshot keyspace should be auto created
-  # Not all Cassandra settings are configurable when using autocreate and for
-  # full control of the keyspace and table definitions you should create them
-  # manually (with a script).
-  keyspace-autocreate = true
+    # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
+    replication-factor = 1
 
-  # Parameter indicating whether the snapshot tables should be auto created
-  # Not all Cassandra settings are configurable when using autocreate and for
-  # full control of the keyspace and table definitions you should create them
-  # manually (with a script).
-  tables-autocreate = true
+    # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
+    data-center-replication-factors = []
 
-  # Name of the table to be created/used by the snapshot store.
-  # If the table doesn't exist it is automatically created.
-  table = "snapshots"
+    # Dispatcher for the plugin actor and task.
+    plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
-  # Compaction strategy for the snapshot table
-  # Please refer to the tests for example configurations.
-  # Refer to http://docs.datastax.com/en/cql/3.1/cql/cql_reference/compactSubprop.html
-  # for more information regarding the properties.
-  table-compaction-strategy {
-    class = "SizeTieredCompactionStrategy"
+    # The time to wait before cassandra will remove the tombstones created for deleted entries.
+    # cfr. gc_grace_seconds table property documentation on
+    # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
+    gc-grace-seconds = 864000
+
+    # Number load attempts when recovering from the latest snapshot fails
+    # yet older snapshot files are available. Each recovery attempt will try
+    # to recover using an older than previously failed-on snapshot file
+    # (if any are present). If all attempts fail the recovery will fail and
+    # the persistent actor will be stopped.
+    max-load-attempts = 3
   }
 
-  # Name of the table to be created/used for journal config.
-  # If the table doesn't exist it is automatically created.
-  config-table = "config"
-
-  # Set this to on to only use Cassandra 2.x compatible features,
-  # i.e. if you are using a Cassandra 2.x server.
-  cassandra-2x-compat = off
-
-  # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
-  replication-strategy = "SimpleStrategy"
-
-  # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
-  replication-factor = 1
-
-  # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
-  data-center-replication-factors = []
-
-  # To limit the Cassandra hosts this plugin connects with to a specific datacenter.
-  # (DCAwareRoundRobinPolicy withLocalDc)
-  # The id for the local datacenter of the Cassandra hosts it should connect to.
-  # By default, this property is not set resulting in Datastax's standard round robin policy being used.
-  local-datacenter = ""
-
-  # Number of hosts from non-local datacenter to use as a fall-back policy.
-  # Works only when local-datacenter is set
-  used-hosts-per-remote-dc = 0
-
-  # Dispatcher for the plugin actor and task.
-  plugin-dispatcher = "cassandra-plugin-default-dispatcher"
-
-  # Set the protocol version explicitly, should only be used for compatibility testing.
-  # Supported values: 3, 4
-  protocol-version = ""
-
-  # The time to wait before cassandra will remove the tombstones created for deleted entries.
-  # cfr. gc_grace_seconds table property documentation on
-  # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
-  gc-grace-seconds = 864000
-
-  # Number load attempts when recovering from the latest snapshot fails
-  # yet older snapshot files are available. Each recovery attempt will try
-  # to recover using an older than previously failed-on snapshot file
-  # (if any are present). If all attempts fail the recovery will fail and
-  # the persistent actor will be stopped.
-  max-load-attempts = 3
-
-  # Enable Dropwizard Metrics for Cluster.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  metrics-enabled = on
-
-  # Enable JMX reporter for Dropwizard Metrics.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  jmx-reporting-enabled = on
 }
-
 
 # Default dispatcher for plugin actor and tasks.
 cassandra-plugin-default-dispatcher {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -2,15 +2,15 @@
 # This configures the default settings for all Cassandra Journal plugin
 # instances in the system. If you are using just one configuration for
 # all persistent actors then you should point your akka.persistence.journal.plugin
-# setting to "cassandra-journal.write".
+# setting to "cassandra-plugin.journal".
 #
 # Otherwise you need to create differently named sections containing
 # only those settings that shall be different from the defaults
 # configured here, importing the defaults like so:
 #
-#   another-cassandra-journal = ${cassandra-journal}
-#   another-cassandra-journal {
-#     write {
+#   another-cassandra-plugin = ${cassandra-plugin}
+#   another-cassandra-plugin {
+#     journal {
 #       <settings...>
 #     }
 #     query {
@@ -20,7 +20,7 @@
 #       <settings...>
 #     }
 #   }
-cassandra-journal {
+cassandra-plugin {
 
   # The implementation of akka.cassandra.session.SessionProvider
   # is used for creating the CqlSession. By default it loads all the driver's default
@@ -35,8 +35,8 @@ cassandra-journal {
   # profile to use, can set separate ones for reads and writes
   # See https://docs.datastax.com/en/developer/java-driver/4.3/manual/core/configuration/
   # for overriding any settings
-  read-profile = "cassandra-journal"
-  write-profile = "cassandra-journal"
+  read-profile = "cassandra-plugin"
+  write-profile = "cassandra-plugin"
 
     # TODO remove this and just query cassandra to see what version it is
   # Set this to on to only use Cassandra 2.x compatible features,
@@ -57,7 +57,7 @@ cassandra-journal {
   # wait. In order enable this feature, make the following settings:
   #
   #    - enable clustering for your actor system
-  #    - cassandra-journal.pubsub-notification=on              (send real-time announcements at most every sec)
+  #    - cassandra-plugin.pubsub-notification=on              (send real-time announcements at most every sec)
   #
   # Setting pubsub-notification to "off" will disable the journal sending these announcements.
   # When enabled with `on` it will throttle the number of notfication messages per tag to at most 10 per second.
@@ -76,7 +76,7 @@ cassandra-journal {
   # won't function.
   coordinated-shutdown-on-error = off
 
-  write {
+  journal {
 
     # FQCN of the cassandra journal plugin
     class = "akka.persistence.cassandra.journal.CassandraJournal"
@@ -170,14 +170,14 @@ cassandra-journal {
   # This configures the default settings for all CassandraReadJournal plugin
   # instances in the system.
   #
-  # Settings for eventsByTag are defined in cassandra-journal.events-by-tag section.
+  # Settings for eventsByTag are defined in cassandra-plugin.events-by-tag section.
   #
   # If you use multiple plugin instances you need to create differently named
   # sections containing only those settings that shall be different from the defaults
   # configured here, importing the defaults like so:
   #
-  #   another-cassandra-journal = ${cassandra-journal}
-  #   another-cassandra-journal {
+  #   another-cassandra-plugin = ${cassandra-plugin}
+  #   another-cassandra-plugin {
   #     query {
   #       <settings...>
   #     }
@@ -192,7 +192,7 @@ cassandra-journal {
     # Dispatcher for the plugin actors.
     plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
-    read-profile = "cassandra-journal"
+    read-profile = "cassandra-plugin"
 
     # New events are retrieved (polled) with this interval.
     refresh-interval = 3s
@@ -376,8 +376,8 @@ cassandra-journal {
   # only those settings that shall be different from the defaults
   # configured here, importing the defaults like so:
   #
-  #   another-cassandra-journal = ${cassandra-journal}
-  #   another-cassandra-journal {
+  #   another-cassandra-plugin = ${cassandra-plugin}
+  #   another-cassandra-plugin {
   #     snapshot {
   #       <settings...>
   #     }
@@ -390,8 +390,8 @@ cassandra-journal {
     # Dispatcher for the plugin actor
     plugin-dispatcher = "cassandra-plugin-default-dispatcher"
 
-    write-profile = "cassandra-journal"
-    read-profile = "cassandra-journal"
+    write-profile = "cassandra-plugin"
+    read-profile = "cassandra-plugin"
 
     # Parameter indicating whether the journal keyspace should be auto created.
     # Not all Cassandra settings are configurable when using autocreate and for
@@ -467,7 +467,7 @@ cassandra-plugin-default-dispatcher {
 
 datastax-java-driver {
   profiles {
-    cassandra-journal {
+    cassandra-plugin {
       basic.request {
         consistency = QUORUM
         # the journal does not use any counters or collections

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -77,14 +77,6 @@ cassandra-journal {
   # Supported values: 3, 4
   protocol-version = ""
 
-  # Enable Dropwizard Metrics for Cluster.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  metrics-enabled = on
-
-  # Enable JMX reporter for Dropwizard Metrics.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  jmx-reporting-enabled = on
-
   # If there is an unexpected error in the Cassandra Journal the journal shuts down
   # to prevent any data corruption. Set to true to also run coordinated shutdown so
   # that the application shuts down. Useful in environments where applicatons are
@@ -211,13 +203,6 @@ cassandra-journal {
     # replays.
     deserialization-parallelism = 1
 
-    # Enable Dropwizard Metrics for Cluster.
-    # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-    metrics-enabled = on
-
-    # Enable JMX reporter for Dropwizard Metrics.
-    # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-    jmx-reporting-enabled = on
   }
 
   events-by-tag {

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -46,23 +46,7 @@ cassandra-journal {
   # manually (with a script).
   tables-autocreate = true
 
-  # Akka-persistence allows multiple pending deletes for the same persistence id however this plugin only executes one
-  # at a time per persistence id (deletes for different persistenceIds can happen concurrently).
-  #
-  # If multiple deletes for the same persistence id are received then they are queued.
-  #
-  # If the queue is full any subsequent deletes are failed immediately without attempting them in Cassandra.
-  #
-  # Deleting should be used with snapshots for efficiency for recovery thus deleting should be infrequent
-  max-concurrent-deletes = 10
-
-  # For applications that are not deleting any events this can be set to 'off', which will optimize
-  # the recovery to not query for highest deleted sequence number from the metadata table.
-  # It must not be off if deletes of events are used or have been used previously.
-  # If this is set to off then delete attempts will fail with an IllegalArgumentException.
-  support-deletes = on
-
-  # TODO remove this and just query cassandra to see what version it is
+    # TODO remove this and just query cassandra to see what version it is
   # Set this to on to only use Cassandra 2.x compatible features,
   # i.e. if you are using a Cassandra 2.x server.
   cassandra-2x-compat = off
@@ -156,6 +140,22 @@ cassandra-journal {
     # cfr. gc_grace_seconds table property documentation on
     # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
     gc-grace-seconds = 864000
+
+    # Akka-persistence allows multiple pending deletes for the same persistence id however this plugin only executes one
+    # at a time per persistence id (deletes for different persistenceIds can happen concurrently).
+    #
+    # If multiple deletes for the same persistence id are received then they are queued.
+    #
+    # If the queue is full any subsequent deletes are failed immediately without attempting them in Cassandra.
+    #
+    # Deleting should be used with snapshots for efficiency for recovery thus deleting should be infrequent
+    max-concurrent-deletes = 10
+
+    # For applications that are not deleting any events this can be set to 'off', which will optimize
+    # the recovery to not query for highest deleted sequence number from the metadata table.
+    # It must not be off if deletes of events are used or have been used previously.
+    # If this is set to off then delete attempts will fail with an IllegalArgumentException.
+    support-deletes = on
   }
 
   # FIXME update docs

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -172,7 +172,7 @@ cassandra-journal {
   #   my-cassandra-query-journal {
   #     <settings...>
   #   }
-  read {
+  query {
     # Implementation class of the Cassandra ReadJournalProvider
     class = "akka.persistence.cassandra.query.CassandraReadJournalProvider"
 
@@ -269,8 +269,6 @@ cassandra-journal {
     # per tag per bucket
     # Valid options: Day, Hour, Minute
     bucket-size = "Hour"
-
-    # FIXME #81 the following events-by-tag were originally in the read section, do we need separatation of write/read for events-by-tag?
 
     # How long to look for delayed events
     # This works by adding an additional (internal) sequence number to each tag / persistence id

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -100,6 +100,8 @@ cassandra-journal {
     # Please refer to the tests for example configurations.
     # Refer to http://docs.datastax.com/en/cql/3.1/cql/cql_reference/compactSubprop.html
     # for more information regarding the properties.
+    # This is only used for auto-create of messages table, i.e. when tables-autocreate is
+    # enabled and the table doesn't exist already.
     table-compaction-strategy {
       class = "SizeTieredCompactionStrategy"
     }
@@ -108,15 +110,21 @@ cassandra-journal {
     # If the table doesn't exist it is automatically created.
     metadata-table = "metadata"
 
-    # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
+    # Replication strategy to use. SimpleStrategy or NetworkTopologyStrategy.
+    # This is only used for auto-create of keyspace, i.e. when keyspace-autocreate is
+    # enabled and the keyspace doesn't exist already.
     replication-strategy = "SimpleStrategy"
 
     # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
+    # This is only used for auto-create of keyspace, i.e. when keyspace-autocreate is
+    # enabled and the keyspace doesn't exist already.
     replication-factor = 1
 
     # Replication factor list for data centers. Is only used when replication-strategy is NetworkTopologyStrategy.
     # The value can be either a proper list, e.g. ["dc1:3", "dc2:2"],
     # or a comma-separated list within a single string, e.g. "dc1:3,dc2:2".
+    # This is only used for auto-create of keyspace, i.e. when keyspace-autocreate is
+    # enabled and the keyspace doesn't exist already.
     data-center-replication-factors = []
 
     # Maximum number of messages that will be batched when using `persistAsync`.
@@ -131,6 +139,8 @@ cassandra-journal {
     # The time to wait before cassandra will remove the tombstones created for deleted entries.
     # cfr. gc_grace_seconds table property documentation on
     # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
+    # This is only used for auto-create of messages table, i.e. when tables-autocreate is
+    # enabled and the table doesn't exist already.
     gc-grace-seconds = 864000
 
     # Akka-persistence allows multiple pending deletes for the same persistence id however this plugin only executes one
@@ -230,8 +240,10 @@ cassandra-journal {
 
     table = "tag_views"
 
+    # This is only used for auto-create of tag_views table.
     gc-grace-seconds = 864000
 
+    # This is only used for auto-create of tag_views table.
     compaction-strategy {
       class = "SizeTieredCompactionStrategy"
       # If setting a time-to-live then consider using TimeWindowCompactionStratery
@@ -246,7 +258,8 @@ cassandra-journal {
 
     # How long events are kept for in the tag_views table
     # By default the events are kept for ever. Uncomment and set to an appropriate
-    # duration for your use case. See the compaction-strategy.class if you set this
+    # duration for your use case. See the compaction-strategy.class if you set this.
+    # This is only used for auto-create of tag_views table.
     #time-to-live = 2d
 
     # WARNING: Can not be changed after data has been written
@@ -392,22 +405,32 @@ cassandra-journal {
     # Please refer to the tests for example configurations.
     # Refer to http://docs.datastax.com/en/cql/3.1/cql/cql_reference/compactSubprop.html
     # for more information regarding the properties.
+    # This is only used for auto-create of snapshots table, i.e. when tables-autocreate is
+    # enabled and the table doesn't exist already.
     table-compaction-strategy {
       class = "SizeTieredCompactionStrategy"
     }
 
-    # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
+    # Replication strategy to use. SimpleStrategy or NetworkTopologyStrategy.
+    # This is only used for auto-create of keyspace, i.e. when keyspace-autocreate is
+    # enabled and the keyspace doesn't exist already.
     replication-strategy = "SimpleStrategy"
 
     # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
+    # This is only used for auto-create of keyspace, i.e. when keyspace-autocreate is
+    # enabled and the keyspace doesn't exist already.
     replication-factor = 1
 
     # Replication factor list for data centers, e.g. ["dc1:3", "dc2:2"]. Is only used when replication-strategy is NetworkTopologyStrategy.
+    # This is only used for auto-create of keyspace, i.e. when keyspace-autocreate is
+    # enabled and the keyspace doesn't exist already.
     data-center-replication-factors = []
 
     # The time to wait before cassandra will remove the tombstones created for deleted entries.
     # cfr. gc_grace_seconds table property documentation on
     # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
+    # This is only used for auto-create of snapshots table, i.e. when tables-autocreate is
+    # enabled and the table doesn't exist already.
     gc-grace-seconds = 864000
 
     # Number load attempts when recovering from the latest snapshot fails

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -77,26 +77,101 @@ cassandra-journal {
   # If this is set to off then delete attempts will fail with an IllegalArgumentException.
   support-deletes = on
 
-  # Name of the table to be created/used by the journal.
-  # If the table doesn't exist it is automatically created.
-  table = "messages"
-
-  # Compaction strategy for the journal table.
-  # Please refer to the tests for example configurations.
-  # Refer to http://docs.datastax.com/en/cql/3.1/cql/cql_reference/compactSubprop.html 
-  # for more information regarding the properties.
-  table-compaction-strategy {
-    class = "SizeTieredCompactionStrategy"
-  }
-
-  # Name of the table to be created/used for storing metadata.
-  # If the table doesn't exist it is automatically created.
-  metadata-table = "metadata"
-
   # TODO remove this and just query cassandra to see what version it is
   # Set this to on to only use Cassandra 2.x compatible features,
   # i.e. if you are using a Cassandra 2.x server.
   cassandra-2x-compat = off
+
+  # meta columns were added in version 0.55. If you don't alter existing messages table and still
+  # use `tables-autocreate=on` you have to set this property to off.
+  # When trying to create the materialized view with the meta columns before corresponding columns
+  # have been added the messages table an exception "Undefined column name meta_ser_id" is raised,
+  # because Cassandra validates the "CREATE MATERIALIZED VIEW IF NOT EXISTS"
+  # even though the view already exists and will not be created. To work around that issue you can disable the
+  # meta data columns in the materialized view by setting this property to off.
+  meta-in-events-by-tag-view = on
+
+  # The query journal to use when recovering
+  query-plugin = "cassandra-query-journal"
+
+  # Dispatcher for the plugin actor.
+  plugin-dispatcher = "cassandra-plugin-default-dispatcher"
+
+  # Enable DistributedPubSub to announce events for a specific tag have
+  # been written. These announcements cause any ongoing getEventsByTag to immediately re-poll, rather than
+  # wait. In order enable this feature, make the following settings:
+  #
+  #    - enable clustering for your actor system
+  #    - cassandra-journal.pubsub-notification=on              (send real-time announcements at most every sec)
+  #
+  # Setting pubsub-notification to "off" will disable the journal sending these announcements.
+  # When enabled with `on` it will throttle the number of notfication messages per tag to at most 10 per second.
+  # Alternatively a duration can be defined, such as pubsub-notification=300ms, which will be throttling interval
+  # for sending the notifications.
+  pubsub-notification = off
+
+  # Set the protocol version explicitly, should only be used for compatibility testing.
+  # Supported values: 3, 4
+  protocol-version = ""
+
+  # Enable Dropwizard Metrics for Cluster.
+  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
+  metrics-enabled = on
+
+  # Enable JMX reporter for Dropwizard Metrics.
+  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
+  jmx-reporting-enabled = on
+
+  # If there is an unexpected error in the Cassandra Journal the journal shuts down
+  # to prevent any data corruption. Set to true to also run coordinated shutdown so
+  # that the application shuts down. Useful in environments where applicatons are
+  # automatically shutdown or if the Cassandra Journal not working means the application
+  # won't function.
+  coordinated-shutdown-on-error = off
+
+  write {
+
+    # Name of the table to be created/used by the journal.
+    # If the table doesn't exist it is automatically created.
+    table = "messages"
+
+    # Compaction strategy for the journal table.
+    # Please refer to the tests for example configurations.
+    # Refer to http://docs.datastax.com/en/cql/3.1/cql/cql_reference/compactSubprop.html
+    # for more information regarding the properties.
+    table-compaction-strategy {
+      class = "SizeTieredCompactionStrategy"
+    }
+
+    # Name of the table to be created/used for storing metadata.
+    # If the table doesn't exist it is automatically created.
+    metadata-table = "metadata"
+
+    # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
+    replication-strategy = "SimpleStrategy"
+
+    # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
+    replication-factor = 1
+
+    # Replication factor list for data centers. Is only used when replication-strategy is NetworkTopologyStrategy.
+    # The value can be either a proper list, e.g. ["dc1:3", "dc2:2"],
+    # or a comma-separated list within a single string, e.g. "dc1:3,dc2:2".
+    data-center-replication-factors = []
+
+    # Maximum number of messages that will be batched when using `persistAsync`.
+    # Also used as the max batch size for deletes.
+    max-message-batch-size = 100
+
+    # Target number of entries per partition (= columns per row).
+    # Must not be changed after table creation (currently not checked).
+    # This is "target" as AtomicWrites that span partition boundaries will result in bigger partitions to ensure atomicity.
+    target-partition-size = 500000
+
+    # The time to wait before cassandra will remove the tombstones created for deleted entries.
+    # cfr. gc_grace_seconds table property documentation on
+    # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
+    gc-grace-seconds = 864000
+  }
 
   events-by-tag {
     # Enable/disable events by tag. If eventsByTag queries aren't required then this should be set to
@@ -149,78 +224,6 @@ cassandra-journal {
     bucket-size = "Hour"
   }
 
-  # meta columns were added in version 0.55. If you don't alter existing messages table and still
-  # use `tables-autocreate=on` you have to set this property to off.
-  # When trying to create the materialized view with the meta columns before corresponding columns
-  # have been added the messages table an exception "Undefined column name meta_ser_id" is raised,
-  # because Cassandra validates the "CREATE MATERIALIZED VIEW IF NOT EXISTS"
-  # even though the view already exists and will not be created. To work around that issue you can disable the
-  # meta data columns in the materialized view by setting this property to off.
-  meta-in-events-by-tag-view = on
-
-  # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
-  replication-strategy = "SimpleStrategy"
-
-  # Replication factor to use when creating a keyspace. Is only used when replication-strategy is SimpleStrategy.
-  replication-factor = 1
-
-  # Replication factor list for data centers. Is only used when replication-strategy is NetworkTopologyStrategy.
-  # The value can be either a proper list, e.g. ["dc1:3", "dc2:2"],
-  # or a comma-separated list within a single string, e.g. "dc1:3,dc2:2".
-  data-center-replication-factors = []
-
-  # Maximum number of messages that will be batched when using `persistAsync`.
-  # Also used as the max batch size for deletes.
-  max-message-batch-size = 100
-
-  # Target number of entries per partition (= columns per row).
-  # Must not be changed after table creation (currently not checked).
-  # This is "target" as AtomicWrites that span partition boundaries will result in bigger partitions to ensure atomicity.
-  target-partition-size = 500000
-
-  # The query journal to use when recovering
-  query-plugin = "cassandra-query-journal"
-
-  # Dispatcher for the plugin actor.
-  plugin-dispatcher = "cassandra-plugin-default-dispatcher"
-
-  # The time to wait before cassandra will remove the tombstones created for deleted entries.
-  # cfr. gc_grace_seconds table property documentation on
-  # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
-  gc-grace-seconds = 864000
-
-  # Enable DistributedPubSub to announce events for a specific tag have
-  # been written. These announcements cause any ongoing getEventsByTag to immediately re-poll, rather than
-  # wait. In order enable this feature, make the following settings:
-  #
-  #    - enable clustering for your actor system
-  #    - cassandra-journal.pubsub-notification=on              (send real-time announcements at most every sec)
-  #
-  # Setting pubsub-notification to "off" will disable the journal sending these announcements.
-  # When enabled with `on` it will throttle the number of notfication messages per tag to at most 10 per second.
-  # Alternatively a duration can be defined, such as pubsub-notification=300ms, which will be throttling interval
-  # for sending the notifications.
-  pubsub-notification = off
-
-  # Set the protocol version explicitly, should only be used for compatibility testing.
-  # Supported values: 3, 4
-  protocol-version = ""
-
-
-  # Enable Dropwizard Metrics for Cluster.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  metrics-enabled = on
-
-  # Enable JMX reporter for Dropwizard Metrics.
-  # See: https://docs.datastax.com/en/developer/java-driver/3.5/manual/metrics/
-  jmx-reporting-enabled = on
-
-  # If there is an unexpected error in the Cassandra Journal the journal shuts down
-  # to prevent any data corruption. Set to true to also run coordinated shutdown so
-  # that the application shuts down. Useful in environments where applicatons are
-  # automatically shutdown or if the Cassandra Journal not working means the application
-  # won't function.
-  coordinated-shutdown-on-error = off
 }
 
 # This configures the default settings for all Cassandra Snapshot plugin
@@ -283,10 +286,6 @@ cassandra-snapshot-store {
   # i.e. if you are using a Cassandra 2.x server.
   cassandra-2x-compat = off
 
-  # Name of the table to be created/used for storing metadata.
-  # If the table doesn't exist it is automatically created.
-  metadata-table = "metadata"
-
   # replication strategy to use. SimpleStrategy or NetworkTopologyStrategy
   replication-strategy = "SimpleStrategy"
 
@@ -314,13 +313,13 @@ cassandra-snapshot-store {
   protocol-version = ""
 
   # The time to wait before cassandra will remove the tombstones created for deleted entries.
-  # cfr. gc_grace_seconds table property documentation on 
+  # cfr. gc_grace_seconds table property documentation on
   # http://www.datastax.com/documentation/cql/3.1/cql/cql_reference/tabProp.html
   gc-grace-seconds = 864000
 
   # Number load attempts when recovering from the latest snapshot fails
   # yet older snapshot files are available. Each recovery attempt will try
-  # to recover using an older than previously failed-on snapshot file 
+  # to recover using an older than previously failed-on snapshot file
   # (if any are present). If all attempts fail the recovery will fail and
   # the persistent actor will be stopped.
   max-load-attempts = 3

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -4,34 +4,20 @@
 
 package akka.persistence.cassandra
 
-import akka.persistence.cassandra.compaction.CassandraCompactionStrategy
-import com.typesafe.config.Config
-import akka.actor.{ ActorSystem, ExtendedActorSystem }
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
 import akka.cassandra.session.CqlSessionProvider
+import com.typesafe.config.Config
 
 class CassandraPluginConfig(system: ActorSystem, config: Config) {
-
-  import akka.persistence.cassandra.CassandraPluginConfig._
 
   val sessionProvider: CqlSessionProvider =
     CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], config)
 
   val keyspace: String = config.getString("keyspace")
-  val table: String = config.getString("table")
-  val metadataTable: String = config.getString("metadata-table")
-
-  val tableCompactionStrategy: CassandraCompactionStrategy =
-    CassandraCompactionStrategy(config.getConfig("table-compaction-strategy"))
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
   val tablesAutoCreate: Boolean = config.getBoolean("tables-autocreate")
-
-  val replicationStrategy: String = getReplicationStrategy(
-    config.getString("replication-strategy"),
-    config.getInt("replication-factor"),
-    getListFromConfig(config, "data-center-replication-factors"))
-
-  val gcGraceSeconds: Long = config.getLong("gc-grace-seconds")
 
 }
 

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -12,11 +12,6 @@ import com.typesafe.config.Config
 class CassandraPluginConfig(system: ActorSystem, config: Config) {
   val sessionProvider: CqlSessionProvider = CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], config)
 
-  val keyspace: String = config.getString("keyspace")
-
-  val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
-  val tablesAutoCreate: Boolean = config.getBoolean("tables-autocreate")
-
   // TODO this is now only used when deciding how to delete, remove this config and just
   // query what version of cassandra we're connected to and do the right thing
   val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -10,14 +10,16 @@ import akka.cassandra.session.CqlSessionProvider
 import com.typesafe.config.Config
 
 class CassandraPluginConfig(system: ActorSystem, config: Config) {
-
-  val sessionProvider: CqlSessionProvider =
-    CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], config)
+  val sessionProvider: CqlSessionProvider = CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], config)
 
   val keyspace: String = config.getString("keyspace")
 
   val keyspaceAutoCreate: Boolean = config.getBoolean("keyspace-autocreate")
   val tablesAutoCreate: Boolean = config.getBoolean("tables-autocreate")
+
+  // TODO this is now only used when deciding how to delete, remove this config and just
+  // query what version of cassandra we're connected to and do the right thing
+  val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
 
 }
 

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -95,13 +95,13 @@ object EventsByTagMigration {
 
 /**
  *
- * @param journalNamespace The config namespace where the journal is configured, default is `cassandra-journal`
+ * @param journalNamespace The config namespace where the journal is configured, default is `cassandra-plugin`
  * @param readJournalNamespace The config namespace where the query-journal is configured, default is the same
  *                             as `CassandraReadJournal.Identifier`
  */
 class EventsByTagMigration(
     system: ActorSystem,
-    journalNamespace: String = "cassandra-journal",
+    journalNamespace: String = "cassandra-plugin",
     readJournalNamespace: String = CassandraReadJournal.Identifier)
     extends CassandraStatements
     with TaggedPreparedStatements
@@ -112,7 +112,7 @@ class EventsByTagMigration(
   private implicit val materialiser = ActorMaterializer()(system)
 
   implicit val ec =
-    system.dispatchers.lookup(system.settings.config.getString(s"$journalNamespace.write.plugin-dispatcher"))
+    system.dispatchers.lookup(system.settings.config.getString(s"$journalNamespace.journal.plugin-dispatcher"))
   override def config: CassandraJournalConfig =
     new CassandraJournalConfig(system, system.settings.config.getConfig(journalNamespace))
   val session: CassandraSession = {

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -111,7 +111,8 @@ class EventsByTagMigration(
   private lazy val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](readJournalNamespace)
   private implicit val materialiser = ActorMaterializer()(system)
 
-  implicit val ec = system.dispatchers.lookup(system.settings.config.getString(s"$journalNamespace.plugin-dispatcher"))
+  implicit val ec =
+    system.dispatchers.lookup(system.settings.config.getString(s"$journalNamespace.write.plugin-dispatcher"))
   override def config: CassandraJournalConfig =
     new CassandraJournalConfig(system, system.settings.config.getConfig(journalNamespace))
   val session: CassandraSession = {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -61,7 +61,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
     with NoSerializationVerificationNeeded {
 
   // shared config is one level above the journal specific
-  private val sharedConfigPath = cfgPath.replaceAll("""\.write$""", "")
+  private val sharedConfigPath = cfgPath.replaceAll("""\.journal$""", "")
   val config = {
     val sharedConfig = context.system.settings.config.getConfig(sharedConfigPath)
     new CassandraJournalConfig(context.system, sharedConfig)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -158,7 +158,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
 
   private[akka] lazy val queries =
     PersistenceQuery(context.system.asInstanceOf[ExtendedActorSystem])
-      .readJournalFor[CassandraReadJournal](s"$sharedConfigPath.read")
+      .readJournalFor[CassandraReadJournal](s"$sharedConfigPath.query")
 
   override def preStart(): Unit = {
     // eager initialization, but not from constructor

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -60,7 +60,12 @@ class CassandraJournal(cfg: Config, cfgPath: String)
     with CassandraStatements
     with NoSerializationVerificationNeeded {
 
-  val config = new CassandraJournalConfig(context.system, cfg)
+  // shared config is one level above the journal specific
+  private val sharedConfigPath = cfgPath.replaceAll("""\.write$""", "")
+  val config = {
+    val sharedConfig = context.system.settings.config.getConfig(sharedConfigPath)
+    new CassandraJournalConfig(context.system, sharedConfig)
+  }
   val serialization = SerializationExtension(context.system)
   val log: LoggingAdapter = Logging(context.system, getClass)
 
@@ -153,7 +158,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
 
   private[akka] lazy val queries =
     PersistenceQuery(context.system.asInstanceOf[ExtendedActorSystem])
-      .readJournalFor[CassandraReadJournal](config.queryPlugin)
+      .readJournalFor[CassandraReadJournal](s"$sharedConfigPath.read")
 
   override def preStart(): Unit = {
     // eager initialization, but not from constructor

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -84,8 +84,6 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
 
   val supportDeletes: Boolean = config.getBoolean("support-deletes")
 
-  val queryPlugin: String = config.getString("query-plugin")
-
   val eventsByTagEnabled: Boolean = config.getBoolean("events-by-tag.enabled")
 
   val bucketSize: BucketSize =

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -63,6 +63,11 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
   CassandraPluginConfig.checkProfile(system, writeProfile)
   CassandraPluginConfig.checkProfile(system, readProfile)
 
+  val keyspaceAutoCreate: Boolean = writeConfig.getBoolean("keyspace-autocreate")
+  val tablesAutoCreate: Boolean = writeConfig.getBoolean("tables-autocreate")
+
+  val keyspace: String = writeConfig.getString("keyspace")
+
   val table: String = writeConfig.getString("table")
   val metadataTable: String = writeConfig.getString("metadata-table")
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -54,7 +54,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
     extends CassandraPluginConfig(system, config)
     with NoSerializationVerificationNeeded {
 
-  private val writeConfig = config.getConfig("write")
+  private val writeConfig = config.getConfig("journal")
   private val eventsByTagConfig = config.getConfig("events-by-tag")
 
   val writeProfile: String = config.getString("write-profile")
@@ -126,7 +126,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraJournalConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-journal")).createKeyspaceStatement
+   * new CassandraJournalConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-plugin")).createKeyspaceStatement
    * }}}
    *
    * @see [[CassandraJournalConfig#createTablesStatements]]
@@ -141,7 +141,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraJournalConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-journal")).createTablesStatements
+   * new CassandraJournalConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-plugin")).createTablesStatements
    * }}}
    * *
    * * @see [[CassandraJournalConfig#createKeyspaceStatement]]
@@ -161,7 +161,7 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraJournalConfig(actorSystem, actorSystem.settings().config().getConfig("cassandra-journal")).getCreateTablesStatements();
+   * new CassandraJournalConfig(actorSystem, actorSystem.settings().config().getConfig("cassandra-plugin")).getCreateTablesStatements();
    * }}}
    * *
    * * @see [[CassandraJournalConfig#createKeyspaceStatement]]

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -79,10 +79,6 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
   val targetPartitionSize: Long = writeConfig.getLong("target-partition-size")
   val maxMessageBatchSize: Int = writeConfig.getInt("max-message-batch-size")
 
-  // TODO this is now only used when deciding how to delete, remove this config and just
-  // query what version of cassandra we're connected to and do the right thing
-  val cassandra2xCompat: Boolean = config.getBoolean("cassandra-2x-compat")
-
   val maxConcurrentDeletes: Int = writeConfig.getInt("max-concurrent-deletes")
 
   val supportDeletes: Boolean = writeConfig.getBoolean("support-deletes")

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalUnexpectedError.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalUnexpectedError.scala
@@ -7,6 +7,6 @@ package akka.persistence.cassandra.journal
 import akka.actor.CoordinatedShutdown.Reason
 
 /**
- * Cassandra Journal unexpected error with cassandra-journal.coordinated-shutdown-on-error set to true
+ * Cassandra Journal unexpected error with cassandra-plugin.coordinated-shutdown-on-error set to true
  */
 case object CassandraJournalUnexpectedError extends Reason

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -120,21 +120,21 @@ import com.typesafe.config.Config
 
   val log = Logging(system, classOf[CassandraReadJournalConfig])
 
-  private val readConfig = config.getConfig("read")
+  private val queryConfig = config.getConfig("query")
   private val eventsByTagConfig = config.getConfig("events-by-tag")
 
-  val readProfile: String = readConfig.getString("read-profile")
+  val readProfile: String = queryConfig.getString("read-profile")
   CassandraPluginConfig.checkProfile(system, readProfile)
 
   val refreshInterval: FiniteDuration =
-    readConfig.getDuration("refresh-interval", MILLISECONDS).millis
+    queryConfig.getDuration("refresh-interval", MILLISECONDS).millis
 
-  val gapFreeSequenceNumbers: Boolean = readConfig.getBoolean("gap-free-sequence-numbers")
+  val gapFreeSequenceNumbers: Boolean = queryConfig.getBoolean("gap-free-sequence-numbers")
 
-  val maxBufferSize: Int = readConfig.getInt("max-buffer-size")
+  val maxBufferSize: Int = queryConfig.getInt("max-buffer-size")
 
   val firstTimeBucket: TimeBucket = {
-    val firstBucket = readConfig.getString("first-time-bucket")
+    val firstBucket = queryConfig.getString("first-time-bucket")
     val firstBucketPadded = (writePluginConfig.bucketSize, firstBucket) match {
       case (_, fb) if fb.length == 14    => fb
       case (Hour, fb) if fb.length == 11 => s"$fb:00"
@@ -147,9 +147,9 @@ import com.typesafe.config.Config
     TimeBucket(date.toInstant(ZoneOffset.UTC).toEpochMilli, writePluginConfig.bucketSize)
   }
 
-  val deserializationParallelism: Int = readConfig.getInt("deserialization-parallelism")
+  val deserializationParallelism: Int = queryConfig.getInt("deserialization-parallelism")
 
-  val pluginDispatcher: String = readConfig.getString("plugin-dispatcher")
+  val pluginDispatcher: String = queryConfig.getString("plugin-dispatcher")
 
   val keyspace: String = writePluginConfig.keyspace
   val targetPartitionSize: Long = writePluginConfig.targetPartitionSize
@@ -157,7 +157,7 @@ import com.typesafe.config.Config
   val pubsubNotification: Duration =
     writePluginConfig.tagWriterSettings.pubsubNotification
   val eventsByPersistenceIdEventTimeout: FiniteDuration =
-    readConfig.getDuration("events-by-persistence-id-gap-timeout", MILLISECONDS).millis
+    queryConfig.getDuration("events-by-persistence-id-gap-timeout", MILLISECONDS).millis
 
   val eventsByTagGapTimeout: FiniteDuration =
     eventsByTagConfig.getDuration("gap-timeout", MILLISECONDS).millis

--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadJournalConfig.scala
@@ -4,19 +4,25 @@
 
 package akka.persistence.cassandra.query
 
-import java.time.{ LocalDateTime, ZoneOffset }
-
-import akka.actor.{ ActorSystem, ExtendedActorSystem, NoSerializationVerificationNeeded }
-import akka.annotation.InternalApi
-import akka.cassandra.session.CqlSessionProvider
-import akka.event.Logging
-import akka.persistence.cassandra.CassandraPluginConfig
-import akka.persistence.cassandra.journal.{ CassandraJournalConfig, Day, Hour, TimeBucket }
-import akka.persistence.cassandra.query.CassandraReadJournalConfig.Period
-import akka.persistence.cassandra.query.CassandraReadJournalConfig.{ BackTrackConfig, Fixed, Max }
-import com.typesafe.config.Config
+import java.time.LocalDateTime
+import java.time.ZoneOffset
 
 import scala.concurrent.duration._
+
+import akka.actor.ActorSystem
+import akka.actor.NoSerializationVerificationNeeded
+import akka.annotation.InternalApi
+import akka.event.Logging
+import akka.persistence.cassandra.CassandraPluginConfig
+import akka.persistence.cassandra.journal.CassandraJournalConfig
+import akka.persistence.cassandra.journal.Day
+import akka.persistence.cassandra.journal.Hour
+import akka.persistence.cassandra.journal.TimeBucket
+import akka.persistence.cassandra.query.CassandraReadJournalConfig.BackTrackConfig
+import akka.persistence.cassandra.query.CassandraReadJournalConfig.Fixed
+import akka.persistence.cassandra.query.CassandraReadJournalConfig.Max
+import akka.persistence.cassandra.query.CassandraReadJournalConfig.Period
+import com.typesafe.config.Config
 
 /**
  * INTERNAL API
@@ -119,8 +125,6 @@ import scala.concurrent.duration._
 
   val readProfile: String = readConfig.getString("read-profile")
   CassandraPluginConfig.checkProfile(system, readProfile)
-
-  val sessionProvider: CqlSessionProvider = CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], config)
 
   val refreshInterval: FiniteDuration =
     readConfig.getDuration("refresh-interval", MILLISECONDS).millis

--- a/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -23,7 +23,7 @@ object CassandraReadJournal {
    * The default identifier for [[CassandraReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#getReadJournalFor`.
    *
-   * The value is `"cassandra-journal.read"` and corresponds
+   * The value is `"cassandra-journal.query"` and corresponds
    * to the absolute path to the read journal configuration entry.
    */
   final val Identifier =
@@ -42,7 +42,7 @@ object CassandraReadJournal {
  * Corresponding Scala API is in [[akka.persistence.cassandra.query.scaladsl.CassandraReadJournal]].
  *
  * Configuration settings can be defined in the configuration section with the
- * absolute path corresponding to the identifier, which is `"cassandra-journal.read"`
+ * absolute path corresponding to the identifier, which is `"cassandra-journal.query"`
  * for the default [[CassandraReadJournal#Identifier]]. See `reference.conf`.
  *
  */

--- a/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -23,7 +23,7 @@ object CassandraReadJournal {
    * The default identifier for [[CassandraReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#getReadJournalFor`.
    *
-   * The value is `"cassandra-query-journal"` and corresponds
+   * The value is `"cassandra-journal.read"` and corresponds
    * to the absolute path to the read journal configuration entry.
    */
   final val Identifier =
@@ -42,7 +42,7 @@ object CassandraReadJournal {
  * Corresponding Scala API is in [[akka.persistence.cassandra.query.scaladsl.CassandraReadJournal]].
  *
  * Configuration settings can be defined in the configuration section with the
- * absolute path corresponding to the identifier, which is `"cassandra-query-journal"`
+ * absolute path corresponding to the identifier, which is `"cassandra-journal.read"`
  * for the default [[CassandraReadJournal#Identifier]]. See `reference.conf`.
  *
  */

--- a/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournal.scala
@@ -23,7 +23,7 @@ object CassandraReadJournal {
    * The default identifier for [[CassandraReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#getReadJournalFor`.
    *
-   * The value is `"cassandra-journal.query"` and corresponds
+   * The value is `"cassandra-plugin.query"` and corresponds
    * to the absolute path to the read journal configuration entry.
    */
   final val Identifier =
@@ -42,7 +42,7 @@ object CassandraReadJournal {
  * Corresponding Scala API is in [[akka.persistence.cassandra.query.scaladsl.CassandraReadJournal]].
  *
  * Configuration settings can be defined in the configuration section with the
- * absolute path corresponding to the identifier, which is `"cassandra-journal.query"`
+ * absolute path corresponding to the identifier, which is `"cassandra-plugin.query"`
  * for the default [[CassandraReadJournal#Identifier]]. See `reference.conf`.
  *
  */
@@ -105,7 +105,7 @@ class CassandraReadJournal(scaladslReadJournal: akka.persistence.cassandra.query
    *
    * To tag events you create an `akka.persistence.journal.EventAdapter` that wraps the events
    * in a `akka.persistence.journal.Tagged` with the given `tags`.
-   * The tags must be defined in the `tags` section of the `cassandra-journal` configuration.
+   * The tags must be defined in the `tags` section of the `cassandra-plugin` configuration.
    *
    * You can use [[akka.persistence.query.NoOffset]] to retrieve all events with a given tag or
    * retrieve a subset of all events by specifying a [[TimeBasedUUID]] `offset`.

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -44,10 +44,10 @@ object CassandraReadJournal {
    * The default identifier for [[CassandraReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#readJournalFor`.
    *
-   * The value is `"cassandra-journal.read"` and corresponds
+   * The value is `"cassandra-journal.query"` and corresponds
    * to the absolute path to the read journal configuration entry.
    */
-  final val Identifier = "cassandra-journal.read"
+  final val Identifier = "cassandra-journal.query"
 
   /**
    * INTERNAL API
@@ -71,7 +71,7 @@ object CassandraReadJournal {
  * Corresponding Java API is in [[akka.persistence.cassandra.query.javadsl.CassandraReadJournal]].
  *
  * Configuration settings can be defined in the configuration section with the
- * absolute path corresponding to the identifier, which is `"cassandra-journal.read"`
+ * absolute path corresponding to the identifier, which is `"cassandra-journal.query"`
  * for the default [[CassandraReadJournal#Identifier]]. See `reference.conf`.
  */
 class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: String)
@@ -89,7 +89,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
   private val log = Logging.getLogger(system, getClass)
 
   // shared config is one level above the journal specific
-  private val sharedConfigPath = cfgPath.replaceAll("""\.read$""", "")
+  private val sharedConfigPath = cfgPath.replaceAll("""\.query$""", "")
   private val sharedConfig = system.settings.config.getConfig(sharedConfigPath)
   private val writePluginConfig = new CassandraJournalConfig(system, sharedConfig)
   private val queryPluginConfig = new CassandraReadJournalConfig(system, sharedConfig, writePluginConfig)

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -44,10 +44,10 @@ object CassandraReadJournal {
    * The default identifier for [[CassandraReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#readJournalFor`.
    *
-   * The value is `"cassandra-journal.query"` and corresponds
+   * The value is `"cassandra-plugin.query"` and corresponds
    * to the absolute path to the read journal configuration entry.
    */
-  final val Identifier = "cassandra-journal.query"
+  final val Identifier = "cassandra-plugin.query"
 
   /**
    * INTERNAL API
@@ -71,7 +71,7 @@ object CassandraReadJournal {
  * Corresponding Java API is in [[akka.persistence.cassandra.query.javadsl.CassandraReadJournal]].
  *
  * Configuration settings can be defined in the configuration section with the
- * absolute path corresponding to the identifier, which is `"cassandra-journal.query"`
+ * absolute path corresponding to the identifier, which is `"cassandra-plugin.query"`
  * for the default [[CassandraReadJournal#Identifier]]. See `reference.conf`.
  */
 class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: String)
@@ -102,7 +102,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       "EventsByTag eventual consistency set below 2 seconds. This can result in missed events. See reference.conf for details.")
   }
   // event adapters are defined in the write section
-  private val eventAdapters = Persistence(system).adaptersFor(s"$sharedConfigPath.write")
+  private val eventAdapters = Persistence(system).adaptersFor(s"$sharedConfigPath.journal")
 
   // The EventDeserializer is caching some things based on the column structure and
   // therefore different instances must be used for the eventsByPersistenceId and eventsByTag
@@ -228,7 +228,7 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
    *
    * To tag events you create an `akka.persistence.journal.EventAdapter` that wraps the events
    * in a `akka.persistence.journal.Tagged` with the given `tags`.
-   * The tags must be defined in the `tags` section of the `cassandra-journal` configuration.
+   * The tags must be defined in the `tags` section of the `cassandra-plugin` configuration.
    *
    * You can use [[NoOffset]] to retrieve all events with a given tag or
    * retrieve a subset of all events by specifying a `TimeBasedUUID` `offset`.

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -44,10 +44,10 @@ object CassandraReadJournal {
    * The default identifier for [[CassandraReadJournal]] to be used with
    * `akka.persistence.query.PersistenceQuery#readJournalFor`.
    *
-   * The value is `"cassandra-query-journal"` and corresponds
+   * The value is `"cassandra-journal.read"` and corresponds
    * to the absolute path to the read journal configuration entry.
    */
-  final val Identifier = "cassandra-query-journal"
+  final val Identifier = "cassandra-journal.read"
 
   /**
    * INTERNAL API
@@ -71,7 +71,7 @@ object CassandraReadJournal {
  * Corresponding Java API is in [[akka.persistence.cassandra.query.javadsl.CassandraReadJournal]].
  *
  * Configuration settings can be defined in the configuration section with the
- * absolute path corresponding to the identifier, which is `"cassandra-query-journal"`
+ * absolute path corresponding to the identifier, which is `"cassandra-journal.read"`
  * for the default [[CassandraReadJournal#Identifier]]. See `reference.conf`.
  */
 class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: String)
@@ -87,10 +87,12 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
   import CassandraReadJournal.CombinedEventsByPersistenceIdStmts
 
   private val log = Logging.getLogger(system, getClass)
-  private val writePluginId = cfg.getString("write-plugin")
-  private val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig(writePluginId))
-  private val queryPluginConfig =
-    new CassandraReadJournalConfig(system, cfg, writePluginConfig)
+
+  // shared config is one level above the journal specific
+  private val sharedConfigPath = cfgPath.replaceAll("""\.read$""", "")
+  private val sharedConfig = system.settings.config.getConfig(sharedConfigPath)
+  private val writePluginConfig = new CassandraJournalConfig(system, sharedConfig)
+  private val queryPluginConfig = new CassandraReadJournalConfig(system, sharedConfig, writePluginConfig)
 
   if (queryPluginConfig.eventsByTagEventualConsistency < 1.seconds) {
     log.warning(
@@ -99,7 +101,8 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
     log.info(
       "EventsByTag eventual consistency set below 2 seconds. This can result in missed events. See reference.conf for details.")
   }
-  private val eventAdapters = Persistence(system).adaptersFor(writePluginId)
+  // event adapters are defined in the write section
+  private val eventAdapters = Persistence(system).adaptersFor(s"$sharedConfigPath.write")
 
   // The EventDeserializer is caching some things based on the column structure and
   // therefore different instances must be used for the eventsByPersistenceId and eventsByTag

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -42,7 +42,12 @@ class CassandraSnapshotStore(cfg: Config, cfgPath: String)
 
   import CassandraSnapshotStore._
 
-  val snapshotConfig = new CassandraSnapshotStoreConfig(context.system, cfg)
+  val snapshotConfig = {
+    // shared config is one level above the journal specific
+    val sharedConfigPath = cfgPath.replaceAll("""\.snapshot""", "")
+    val sharedConfig = context.system.settings.config.getConfig(sharedConfigPath)
+    new CassandraSnapshotStoreConfig(context.system, sharedConfig)
+  }
   val serialization = SerializationExtension(context.system)
   val snapshotDeserializer = new SnapshotDeserializer(context.system)
   implicit val ec: ExecutionContext = context.dispatcher

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -48,7 +48,7 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-journal.snapshot")).createKeyspaceStatement
+   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-plugin.snapshot")).createKeyspaceStatement
    * }}}
    *
    * @see [[CassandraSnapshotStoreConfig#createTablesStatements]]
@@ -63,7 +63,7 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-journal.snapshot")).createTablesStatements
+   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-plugin.snapshot")).createTablesStatements
    * }}}
    * *
    * * @see [[CassandraSnapshotStoreConfig#createKeyspaceStatement]]
@@ -78,7 +78,7 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings().config().getConfig("cassandra-journal.snapshot")).getCreateTablesStatements();
+   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings().config().getConfig("cassandra-plugin.snapshot")).getCreateTablesStatements();
    * }}}
    * *
    * * @see [[CassandraSnapshotStoreConfig#createKeyspaceStatement]]

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -22,6 +22,11 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
   CassandraPluginConfig.checkProfile(system, readProfile)
   CassandraPluginConfig.checkProfile(system, writeProfile)
 
+  val keyspaceAutoCreate: Boolean = snapshotConfig.getBoolean("keyspace-autocreate")
+  val tablesAutoCreate: Boolean = snapshotConfig.getBoolean("tables-autocreate")
+
+  val keyspace: String = snapshotConfig.getString("keyspace")
+
   val table: String = snapshotConfig.getString("table")
 
   val tableCompactionStrategy: CassandraCompactionStrategy =

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -14,26 +14,27 @@ import akka.persistence.cassandra.compaction.CassandraCompactionStrategy
 import akka.persistence.cassandra.getListFromConfig
 
 class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends CassandraPluginConfig(system, config) {
-  val writeProfile: String = config.getString("write-profile")
-  val readProfile: String = config.getString("read-profile")
+  private val snapshotConfig = config.getConfig("snapshot")
+
+  val writeProfile: String = snapshotConfig.getString("write-profile")
+  val readProfile: String = snapshotConfig.getString("read-profile")
 
   CassandraPluginConfig.checkProfile(system, readProfile)
   CassandraPluginConfig.checkProfile(system, writeProfile)
 
-  val table: String = config.getString("table")
+  val table: String = snapshotConfig.getString("table")
 
   val tableCompactionStrategy: CassandraCompactionStrategy =
-    CassandraCompactionStrategy(config.getConfig("table-compaction-strategy"))
+    CassandraCompactionStrategy(snapshotConfig.getConfig("table-compaction-strategy"))
 
   val replicationStrategy: String = getReplicationStrategy(
-    config.getString("replication-strategy"),
-    config.getInt("replication-factor"),
-    getListFromConfig(config, "data-center-replication-factors"))
+    snapshotConfig.getString("replication-strategy"),
+    snapshotConfig.getInt("replication-factor"),
+    getListFromConfig(snapshotConfig, "data-center-replication-factors"))
 
-  val gcGraceSeconds: Long = config.getLong("gc-grace-seconds")
+  val gcGraceSeconds: Long = snapshotConfig.getLong("gc-grace-seconds")
 
-  val maxLoadAttempts = config.getInt("max-load-attempts")
-  val cassandra2xCompat = config.getBoolean("cassandra-2x-compat")
+  val maxLoadAttempts: Int = snapshotConfig.getInt("max-load-attempts")
 
   /**
    * The Cassandra Statement[_]that can be used to create the configured keyspace.
@@ -57,7 +58,7 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-snapshot-store")).createTablesStatements
+   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings.config.getConfig("cassandra-journal.snapshot")).createTablesStatements
    * }}}
    * *
    * * @see [[CassandraSnapshotStoreConfig#createKeyspaceStatement]]
@@ -72,7 +73,7 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
    * Cassandra plugin actor.
    *
    * {{{
-   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings().config().getConfig("cassandra-snapshot-store")).getCreateTablesStatements();
+   * new CassandraSnapshotStoreConfig(actorSystem, actorSystem.settings().config().getConfig("cassandra-journal.snapshot")).getCreateTablesStatements();
    * }}}
    * *
    * * @see [[CassandraSnapshotStoreConfig#createKeyspaceStatement]]

--- a/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -34,7 +34,9 @@ object EventsByTagMultiJvmSpec extends MultiNodeConfig {
       }
 
       cassandra-journal {
-        keyspace = $name
+        write {
+          keyspace = $name
+        }
         
         events-by-tag {
           bucket-size = Minute

--- a/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -35,7 +35,6 @@ object EventsByTagMultiJvmSpec extends MultiNodeConfig {
 
       cassandra-journal {
         keyspace = $name
-        port = $CassPort
         
         read {
           first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(firstBucketFormatter)}"
@@ -45,10 +44,10 @@ object EventsByTagMultiJvmSpec extends MultiNodeConfig {
         events-by-tag {
           bucket-size = Minute
         }
-      }
-      cassandra-snapshot-store {
-        keyspace = $name
-        port = $CassPort
+        
+        snapshot {
+          keyspace = $name
+        }
       }
     """).withFallback(CassandraLifecycle.config))
 

--- a/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -33,8 +33,8 @@ object EventsByTagMultiJvmSpec extends MultiNodeConfig {
         testconductor.barrier-timeout = 60 s
       }
 
-      cassandra-journal {
-        write {
+      cassandra-plugin {
+        journal {
           keyspace = $name
         }
         

--- a/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -36,19 +36,19 @@ object EventsByTagMultiJvmSpec extends MultiNodeConfig {
       cassandra-journal {
         keyspace = $name
         port = $CassPort
+        
+        read {
+          first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(firstBucketFormatter)}"
+          # first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusSeconds(10).format(firstBucketFormatter)}"
+        }
 
         events-by-tag {
           bucket-size = Minute
         }
-
       }
       cassandra-snapshot-store {
         keyspace = $name
         port = $CassPort
-      }
-      cassandra-query-journal {
-       first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(firstBucketFormatter)}"
-       # first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusSeconds(10).format(firstBucketFormatter)}"
       }
     """).withFallback(CassandraLifecycle.config))
 

--- a/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
+++ b/core/src/multi-jvm/scala/akka/cluster/persistence/cassandra/EventsByTagMultiJvmSpec.scala
@@ -36,11 +36,6 @@ object EventsByTagMultiJvmSpec extends MultiNodeConfig {
       cassandra-journal {
         keyspace = $name
         
-        read {
-          first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusMinutes(10).format(firstBucketFormatter)}"
-          # first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusSeconds(10).format(firstBucketFormatter)}"
-        }
-
         events-by-tag {
           bucket-size = Minute
         }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraCorruptJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraCorruptJournalSpec.scala
@@ -61,7 +61,7 @@ class CassandraCorruptJournalSpec extends CassandraSpec(s"""
       loggers = ["akka.testkit.TestEventListener"]
     }
 
-    cassandra-journal.write.replay-filter {
+    cassandra-plugin.journal.replay-filter {
    # What the filter should do when detecting invalid events.
    # Supported values:
    # `repair-by-discard-old` : discard events from old writers,
@@ -73,18 +73,18 @@ class CassandraCorruptJournalSpec extends CassandraSpec(s"""
       debug = yes
     }
 
-    cassandra-journal-fail = $${cassandra-journal}
-    cassandra-journal-fail {
-      write.replay-filter.mode = fail
+    cassandra-plugin-fail = $${cassandra-plugin}
+    cassandra-plugin-fail {
+      journal.replay-filter.mode = fail
     }
 
-    cassandra-journal-warn = $${cassandra-journal}
-    cassandra-journal-warn {
-      write.replay-filter.mode = warn
+    cassandra-plugin-warn = $${cassandra-plugin}
+    cassandra-plugin-warn {
+      journal.replay-filter.mode = warn
     }
   """.stripMargin) {
 
-  def setup(persistenceId: String, journalId: String = "cassandra-journal.write"): ActorRef = {
+  def setup(persistenceId: String, journalId: String = "cassandra-plugin.journal"): ActorRef = {
     val ref = system.actorOf(FullEventLog.props(persistenceId, journalId))
     ref
   }
@@ -122,7 +122,7 @@ class CassandraCorruptJournalSpec extends CassandraSpec(s"""
   "Cassandra recovery" must {
     "work with replay-filter = repair-by-discard-old" in {
 
-      val pid = runConcurrentPersistentActors("cassandra-journal.write")
+      val pid = runConcurrentPersistentActors("cassandra-plugin.journal")
 
       EventFilter.warning(pattern = "Invalid replayed event", occurrences = 2).intercept {
         val p1c = setup(pid)
@@ -135,18 +135,18 @@ class CassandraCorruptJournalSpec extends CassandraSpec(s"""
 
     "work with replay-filter = fail" in {
 
-      val pid = runConcurrentPersistentActors("cassandra-journal-fail.write")
+      val pid = runConcurrentPersistentActors("cassandra-plugin-fail.journal")
 
       EventFilter[IllegalStateException](pattern = "Invalid replayed event", occurrences = 1).intercept {
-        setup(pid, journalId = "cassandra-journal-fail.write")
+        setup(pid, journalId = "cassandra-plugin-fail.journal")
       }
     }
 
     "work with replay-filter = warn" in {
 
-      val pid = runConcurrentPersistentActors("cassandra-journal-warn.write")
+      val pid = runConcurrentPersistentActors("cassandra-plugin-warn.journal")
       EventFilter.warning(pattern = "Invalid replayed event", occurrences = 2).intercept {
-        val p1c = setup(pid, journalId = "cassandra-journal-warn.write")
+        val p1c = setup(pid, journalId = "cassandra-plugin-warn.journal")
         p1c ! "p1c-1"
         expectMsg("p1c-1-done")
         p1c ! GetEventLog

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
@@ -30,8 +30,8 @@ object CassandraEventsByTagLoadSpec {
             max-message-batch-size = 25
             bucket-size = "Minute"
          }
+         snapshot.keyspace=CassandraEventsByTagLoadSpecSnapshot
        }
-       cassandra-snapshot-store.keyspace=CassandraEventsByTagLoadSpecSnapshot
        akka.actor.serialize-messages=off
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
@@ -4,8 +4,6 @@
 
 package akka.persistence.cassandra
 
-import java.time.{ LocalDateTime, ZoneOffset }
-
 import akka.persistence.cassandra.TestTaggingActor.Ack
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.{ NoOffset, PersistenceQuery }
@@ -18,14 +16,10 @@ import org.scalatest.time.{ Seconds, Span }
 import scala.concurrent.duration._
 
 object CassandraEventsByTagLoadSpec {
-  val today = LocalDateTime.now(ZoneOffset.UTC)
 
   val config = ConfigFactory.parseString(s"""
        cassandra-journal {
          log-queries = off
-         read {
-           first-time-bucket = "${today.minusMinutes(5).format(query.firstBucketFormatter)}"
-         }
          events-by-tag {
             max-message-batch-size = 25
             bucket-size = "Minute"

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration._
 object CassandraEventsByTagLoadSpec {
 
   val config = ConfigFactory.parseString(s"""
-       cassandra-journal {
+       cassandra-plugin {
          log-queries = off
          events-by-tag {
             max-message-batch-size = 25

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
@@ -23,15 +23,15 @@ object CassandraEventsByTagLoadSpec {
   val config = ConfigFactory.parseString(s"""
        cassandra-journal {
          log-queries = off
+         read {
+           first-time-bucket = "${today.minusMinutes(5).format(query.firstBucketFormatter)}"
+         }
          events-by-tag {
             max-message-batch-size = 25
             bucket-size = "Minute"
          }
        }
        cassandra-snapshot-store.keyspace=CassandraEventsByTagLoadSpecSnapshot
-       cassandra-query-journal = {
-          first-time-bucket = "${today.minusMinutes(5).format(query.firstBucketFormatter)}"
-       }
        akka.actor.serialize-messages=off
     """).withFallback(CassandraLifecycle.config)
 }
@@ -60,7 +60,7 @@ class CassandraEventsByTagLoadSpec extends CassandraSpec(CassandraEventsByTagLoa
       }
 
       val readJournal =
-        PersistenceQuery(system).readJournalFor[CassandraReadJournal]("cassandra-query-journal")
+        PersistenceQuery(system).readJournalFor[CassandraReadJournal](CassandraReadJournal.Identifier)
 
       eventTags.foreach({ tag =>
         try {

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -32,7 +32,7 @@ object CassandraLifecycle {
     akka.test.timefactor = $${?AKKA_TEST_TIMEFACTOR}
     akka.persistence.journal.plugin = "cassandra-journal.write"
     akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
-    cassandra-journal.circuit-breaker.call-timeout = 30s
+    cassandra-journal.write.circuit-breaker.call-timeout = 30s
     cassandra-journal.read.first-time-bucket = "$firstTimeBucket"
     akka.test.single-expect-default = 20s
     akka.test.filter-leeway = 20s
@@ -125,7 +125,7 @@ trait CassandraLifecycle extends BeforeAndAfterAll with TestKitBase {
   }
 
   def dropKeyspaces(): Unit = {
-    val journalKeyspace = system.settings.config.getString("cassandra-journal.keyspace")
+    val journalKeyspace = system.settings.config.getString("cassandra-journal.write.keyspace")
     val snapshotKeyspace = system.settings.config.getString("cassandra-journal.snapshot.keyspace")
     val dropped = Try {
       cluster.execute(s"drop keyspace if exists ${journalKeyspace}")

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -22,7 +22,7 @@ object CassandraLifecycle {
   val config =
     ConfigFactory.parseString(s"""
     akka.test.timefactor = $${?AKKA_TEST_TIMEFACTOR}
-    akka.persistence.journal.plugin = "cassandra-journal"
+    akka.persistence.journal.plugin = "cassandra-journal.write"
     akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
     cassandra-journal.circuit-breaker.call-timeout = 30s
     akka.test.single-expect-default = 20s

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -23,7 +23,7 @@ object CassandraLifecycle {
     ConfigFactory.parseString(s"""
     akka.test.timefactor = $${?AKKA_TEST_TIMEFACTOR}
     akka.persistence.journal.plugin = "cassandra-journal.write"
-    akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
+    akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
     cassandra-journal.circuit-breaker.call-timeout = 30s
     akka.test.single-expect-default = 20s
     akka.test.filter-leeway = 20s
@@ -117,7 +117,7 @@ trait CassandraLifecycle extends BeforeAndAfterAll with TestKitBase {
 
   def dropKeyspaces(): Unit = {
     val journalKeyspace = system.settings.config.getString("cassandra-journal.keyspace")
-    val snapshotKeyspace = system.settings.config.getString("cassandra-snapshot-store.keyspace")
+    val snapshotKeyspace = system.settings.config.getString("cassandra-journal.snapshot.keyspace")
     val dropped = Try {
       cluster.execute(s"drop keyspace if exists ${journalKeyspace}")
       cluster.execute(s"drop keyspace if exists ${snapshotKeyspace}")

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -33,7 +33,7 @@ object CassandraLifecycle {
     akka.persistence.journal.plugin = "cassandra-journal.write"
     akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
     cassandra-journal.write.circuit-breaker.call-timeout = 30s
-    cassandra-journal.read.first-time-bucket = "$firstTimeBucket"
+    cassandra-journal.query.first-time-bucket = "$firstTimeBucket"
     akka.test.single-expect-default = 20s
     akka.test.filter-leeway = 20s
     akka.actor.serialize-messages=on

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -30,10 +30,10 @@ object CassandraLifecycle {
   val config =
     ConfigFactory.parseString(s"""
     akka.test.timefactor = $${?AKKA_TEST_TIMEFACTOR}
-    akka.persistence.journal.plugin = "cassandra-journal.write"
-    akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
-    cassandra-journal.write.circuit-breaker.call-timeout = 30s
-    cassandra-journal.query.first-time-bucket = "$firstTimeBucket"
+    akka.persistence.journal.plugin = "cassandra-plugin.journal"
+    akka.persistence.snapshot-store.plugin = "cassandra-plugin.snapshot"
+    cassandra-plugin.journal.circuit-breaker.call-timeout = 30s
+    cassandra-plugin.query.first-time-bucket = "$firstTimeBucket"
     akka.test.single-expect-default = 20s
     akka.test.filter-leeway = 20s
     akka.actor.serialize-messages=on
@@ -125,8 +125,8 @@ trait CassandraLifecycle extends BeforeAndAfterAll with TestKitBase {
   }
 
   def dropKeyspaces(): Unit = {
-    val journalKeyspace = system.settings.config.getString("cassandra-journal.write.keyspace")
-    val snapshotKeyspace = system.settings.config.getString("cassandra-journal.snapshot.keyspace")
+    val journalKeyspace = system.settings.config.getString("cassandra-plugin.journal.keyspace")
+    val snapshotKeyspace = system.settings.config.getString("cassandra-plugin.snapshot.keyspace")
     val dropped = Try {
       cluster.execute(s"drop keyspace if exists ${journalKeyspace}")
       cluster.execute(s"drop keyspace if exists ${snapshotKeyspace}")

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraLifecycle.scala
@@ -5,6 +5,9 @@
 package akka.persistence.cassandra
 
 import java.net.InetSocketAddress
+import java.time.LocalDateTime
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
 import java.util.concurrent.TimeUnit
 
 import akka.actor.{ ActorSystem, PoisonPill, Props }
@@ -13,11 +16,16 @@ import akka.testkit.{ TestKitBase, TestProbe }
 import com.datastax.oss.driver.api.core.CqlSession
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
-
 import scala.concurrent.duration._
 import scala.util.{ Failure, Success, Try }
 
 object CassandraLifecycle {
+
+  val firstTimeBucket: String = {
+    val today = LocalDateTime.now(ZoneOffset.UTC)
+    val firstBucketFormat: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HH:mm")
+    today.minusMinutes(5).format(firstBucketFormat)
+  }
 
   val config =
     ConfigFactory.parseString(s"""
@@ -25,6 +33,7 @@ object CassandraLifecycle {
     akka.persistence.journal.plugin = "cassandra-journal.write"
     akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
     cassandra-journal.circuit-breaker.call-timeout = 30s
+    cassandra-journal.read.first-time-bucket = "$firstTimeBucket"
     akka.test.single-expect-default = 20s
     akka.test.filter-leeway = 20s
     akka.actor.serialize-messages=on

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
@@ -21,7 +21,7 @@ class CassandraPluginConfigSpec
     with MustMatchers
     with BeforeAndAfterAll {
 
-  lazy val defaultConfig = ConfigFactory.load().getConfig("cassandra-journal")
+  lazy val defaultConfig = ConfigFactory.load().getConfig("cassandra-plugin")
 
   lazy val keyspaceNames = {
     // Generate a key that is the max acceptable length ensuring the first char is alpha
@@ -73,8 +73,8 @@ class CassandraPluginConfigSpec
     "parse config with a list of datacenters configured for NetworkTopologyStrategy" in {
       lazy val configWithNetworkStrategy =
         ConfigFactory.parseString("""
-          |write.replication-strategy = "NetworkTopologyStrategy"
-          |write.data-center-replication-factors = ["dc1:3", "dc2:2"]
+          |journal.replication-strategy = "NetworkTopologyStrategy"
+          |journal.data-center-replication-factors = ["dc1:3", "dc2:2"]
         """.stripMargin).withFallback(defaultConfig)
       val config = new CassandraJournalConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
@@ -83,9 +83,9 @@ class CassandraPluginConfigSpec
     "parse config with a list of datacenters configured for NetworkTopologyStrategy using dot syntax" in {
       lazy val configWithNetworkStrategy =
         ConfigFactory.parseString("""
-          |write.replication-strategy = "NetworkTopologyStrategy"
-          |write.data-center-replication-factors.0 = "dc1:3"
-          |write.data-center-replication-factors.1 = "dc2:2"
+          |journal.replication-strategy = "NetworkTopologyStrategy"
+          |journal.data-center-replication-factors.0 = "dc1:3"
+          |journal.data-center-replication-factors.1 = "dc2:2"
         """.stripMargin).withFallback(defaultConfig)
       val config = new CassandraJournalConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
@@ -94,8 +94,8 @@ class CassandraPluginConfigSpec
     "parse config with comma-separated data-center-replication-factors" in {
       lazy val configWithNetworkStrategy =
         ConfigFactory.parseString("""
-          |write.replication-strategy = "NetworkTopologyStrategy"
-          |write.data-center-replication-factors = "dc1:3,dc2:2"
+          |journal.replication-strategy = "NetworkTopologyStrategy"
+          |journal.data-center-replication-factors = "dc1:3,dc2:2"
         """.stripMargin).withFallback(defaultConfig)
       val config = new CassandraJournalConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
@@ -141,7 +141,7 @@ class CassandraPluginConfigSpec
 
     "parse keyspace-autocreate parameter" in {
       val configWithFalseKeyspaceAutocreate =
-        ConfigFactory.parseString("write.keyspace-autocreate = false").withFallback(defaultConfig)
+        ConfigFactory.parseString("journal.keyspace-autocreate = false").withFallback(defaultConfig)
 
       val config = new CassandraJournalConfig(system, configWithFalseKeyspaceAutocreate)
       config.keyspaceAutoCreate must be(false)
@@ -149,7 +149,7 @@ class CassandraPluginConfigSpec
 
     "parse tables-autocreate parameter" in {
       val configWithFalseTablesAutocreate =
-        ConfigFactory.parseString("write.tables-autocreate = false").withFallback(defaultConfig)
+        ConfigFactory.parseString("journal.tables-autocreate = false").withFallback(defaultConfig)
 
       val config = new CassandraJournalConfig(system, configWithFalseTablesAutocreate)
       config.tablesAutoCreate must be(false)

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
@@ -141,17 +141,17 @@ class CassandraPluginConfigSpec
 
     "parse keyspace-autocreate parameter" in {
       val configWithFalseKeyspaceAutocreate =
-        ConfigFactory.parseString("""keyspace-autocreate = false""").withFallback(defaultConfig)
+        ConfigFactory.parseString("write.keyspace-autocreate = false").withFallback(defaultConfig)
 
-      val config = new CassandraPluginConfig(system, configWithFalseKeyspaceAutocreate)
+      val config = new CassandraJournalConfig(system, configWithFalseKeyspaceAutocreate)
       config.keyspaceAutoCreate must be(false)
     }
 
     "parse tables-autocreate parameter" in {
       val configWithFalseTablesAutocreate =
-        ConfigFactory.parseString("""tables-autocreate = false""").withFallback(defaultConfig)
+        ConfigFactory.parseString("write.tables-autocreate = false").withFallback(defaultConfig)
 
-      val config = new CassandraPluginConfig(system, configWithFalseTablesAutocreate)
+      val config = new CassandraJournalConfig(system, configWithFalseTablesAutocreate)
       config.tablesAutoCreate must be(false)
     }
   }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraPluginConfigSpec.scala
@@ -11,8 +11,9 @@ import org.scalatest.BeforeAndAfterAll
 import org.scalatest.MustMatchers
 import org.scalatest.WordSpecLike
 import org.scalatest.prop.TableDrivenPropertyChecks._
-
 import scala.util.Random
+
+import akka.persistence.cassandra.journal.CassandraJournalConfig
 
 class CassandraPluginConfigSpec
     extends TestKit(ActorSystem("CassandraPluginConfigSpec"))
@@ -57,44 +58,46 @@ class CassandraPluginConfigSpec
     super.afterAll()
   }
 
-  "A CassandraPluginConfig" must {
+  "A CassandraJournalConfig" must {
 
     "set the metadata table" in {
-      val config = new CassandraPluginConfig(system, defaultConfig)
+      val config = new CassandraJournalConfig(system, defaultConfig)
       config.metadataTable must be("metadata")
     }
 
     "parse config with SimpleStrategy as default for replication-strategy" in {
-      val config = new CassandraPluginConfig(system, defaultConfig)
+      val config = new CassandraJournalConfig(system, defaultConfig)
       config.replicationStrategy must be("'SimpleStrategy','replication_factor':1")
     }
 
     "parse config with a list of datacenters configured for NetworkTopologyStrategy" in {
       lazy val configWithNetworkStrategy =
         ConfigFactory.parseString("""
-          |replication-strategy = "NetworkTopologyStrategy"
-          |data-center-replication-factors = ["dc1:3", "dc2:2"]
+          |write.replication-strategy = "NetworkTopologyStrategy"
+          |write.data-center-replication-factors = ["dc1:3", "dc2:2"]
         """.stripMargin).withFallback(defaultConfig)
-      val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
+      val config = new CassandraJournalConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
     }
 
     "parse config with a list of datacenters configured for NetworkTopologyStrategy using dot syntax" in {
-      lazy val configWithNetworkStrategy = ConfigFactory.parseString("""
-          |replication-strategy = "NetworkTopologyStrategy"
-          |data-center-replication-factors.0 = "dc1:3"
-          |data-center-replication-factors.1 = "dc2:2"
+      lazy val configWithNetworkStrategy =
+        ConfigFactory.parseString("""
+          |write.replication-strategy = "NetworkTopologyStrategy"
+          |write.data-center-replication-factors.0 = "dc1:3"
+          |write.data-center-replication-factors.1 = "dc2:2"
         """.stripMargin).withFallback(defaultConfig)
-      val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
+      val config = new CassandraJournalConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
     }
 
     "parse config with comma-separated data-center-replication-factors" in {
-      lazy val configWithNetworkStrategy = ConfigFactory.parseString("""
-          |replication-strategy = "NetworkTopologyStrategy"
-          |data-center-replication-factors = "dc1:3,dc2:2"
+      lazy val configWithNetworkStrategy =
+        ConfigFactory.parseString("""
+          |write.replication-strategy = "NetworkTopologyStrategy"
+          |write.data-center-replication-factors = "dc1:3,dc2:2"
         """.stripMargin).withFallback(defaultConfig)
-      val config = new CassandraPluginConfig(system, configWithNetworkStrategy)
+      val config = new CassandraJournalConfig(system, configWithNetworkStrategy)
       config.replicationStrategy must be("'NetworkTopologyStrategy','dc1':3,'dc2':2")
     }
 
@@ -152,4 +155,5 @@ class CassandraPluginConfigSpec
       config.tablesAutoCreate must be(false)
     }
   }
+
 }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraQueryJournalConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraQueryJournalConfigSpec.scala
@@ -15,7 +15,7 @@ import com.typesafe.config.ConfigFactory
 import org.scalatest.WordSpec
 import org.scalatest.{ BeforeAndAfterAll, Matchers, WordSpecLike }
 
-class CassandraReadJournalConfigSpec
+class CassandraQueryJournalConfigSpec
     extends TestKit(ActorSystem("CassandraReadJournalConfigSpec"))
     with WordSpecLike
     with Matchers
@@ -23,7 +23,7 @@ class CassandraReadJournalConfigSpec
 
   override protected def afterAll(): Unit = shutdown()
 
-  "Cassandra read journal config" must {
+  "Cassandra query journal config" must {
 
     "default persistence id cleanup to 2x bucket" in {
       import scala.concurrent.duration._
@@ -32,60 +32,60 @@ class CassandraReadJournalConfigSpec
         """).withFallback(system.settings.config)
 
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
-      readConfig.eventsByTagCleanUpPersistenceIds.get shouldEqual 2.hours
+      queryConfig.eventsByTagCleanUpPersistenceIds.get shouldEqual 2.hours
     }
 
     "support Day with just day format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Day
-          |cassandra-journal.read.first-time-bucket = "20151120"
+          |cassandra-journal.query.first-time-bucket = "20151120"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
-      readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
+      queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
     }
 
     "support Day with full time format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Day
-          |cassandra-journal.read.first-time-bucket = "20151120T12:20"
+          |cassandra-journal.query.first-time-bucket = "20151120T12:20"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
       // Rounded down
-      readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
+      queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
     }
 
     "support Hour with just hour format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-journal.read.first-time-bucket = "20151120T00"
+          |cassandra-journal.query.first-time-bucket = "20151120T00"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
-      readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
+      queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
     }
 
     "support Hour with full time format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-journal.read.first-time-bucket = "20151120T00:20"
+          |cassandra-journal.query.first-time-bucket = "20151120T00:20"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
-      readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
+      queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
     }
 
     "validate format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-journal.read.first-time-bucket = "cats"
+          |cassandra-journal.query.first-time-bucket = "cats"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
       val e = intercept[IllegalArgumentException] {

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraQueryJournalConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraQueryJournalConfigSpec.scala
@@ -28,33 +28,33 @@ class CassandraQueryJournalConfigSpec
     "default persistence id cleanup to 2x bucket" in {
       import scala.concurrent.duration._
       val config = ConfigFactory.parseString("""
-         cassandra-journal.events-by-tag.bucket-size = Hour
+         cassandra-plugin.events-by-tag.bucket-size = Hour
         """).withFallback(system.settings.config)
 
-      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-plugin"))
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-plugin"), writeConfig)
 
       queryConfig.eventsByTagCleanUpPersistenceIds.get shouldEqual 2.hours
     }
 
     "support Day with just day format" in {
       val config = ConfigFactory.parseString("""
-          |cassandra-journal.events-by-tag.bucket-size = Day
-          |cassandra-journal.query.first-time-bucket = "20151120"
+          |cassandra-plugin.events-by-tag.bucket-size = Day
+          |cassandra-plugin.query.first-time-bucket = "20151120"
         """.stripMargin).withFallback(system.settings.config)
-      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-plugin"))
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-plugin"), writeConfig)
 
       queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
     }
 
     "support Day with full time format" in {
       val config = ConfigFactory.parseString("""
-          |cassandra-journal.events-by-tag.bucket-size = Day
-          |cassandra-journal.query.first-time-bucket = "20151120T12:20"
+          |cassandra-plugin.events-by-tag.bucket-size = Day
+          |cassandra-plugin.query.first-time-bucket = "20151120T12:20"
         """.stripMargin).withFallback(system.settings.config)
-      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-plugin"))
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-plugin"), writeConfig)
 
       // Rounded down
       queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
@@ -62,34 +62,34 @@ class CassandraQueryJournalConfigSpec
 
     "support Hour with just hour format" in {
       val config = ConfigFactory.parseString("""
-          |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-journal.query.first-time-bucket = "20151120T00"
+          |cassandra-plugin.events-by-tag.bucket-size = Hour
+          |cassandra-plugin.query.first-time-bucket = "20151120T00"
         """.stripMargin).withFallback(system.settings.config)
-      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-plugin"))
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-plugin"), writeConfig)
 
       queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
     }
 
     "support Hour with full time format" in {
       val config = ConfigFactory.parseString("""
-          |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-journal.query.first-time-bucket = "20151120T00:20"
+          |cassandra-plugin.events-by-tag.bucket-size = Hour
+          |cassandra-plugin.query.first-time-bucket = "20151120T00:20"
         """.stripMargin).withFallback(system.settings.config)
-      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-plugin"))
+      val queryConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-plugin"), writeConfig)
 
       queryConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
     }
 
     "validate format" in {
       val config = ConfigFactory.parseString("""
-          |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-journal.query.first-time-bucket = "cats"
+          |cassandra-plugin.events-by-tag.bucket-size = Hour
+          |cassandra-plugin.query.first-time-bucket = "cats"
         """.stripMargin).withFallback(system.settings.config)
-      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
+      val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-plugin"))
       val e = intercept[IllegalArgumentException] {
-        new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
+        new CassandraReadJournalConfig(system, config.getConfig("cassandra-plugin"), writeConfig)
       }
       e.getMessage shouldEqual "Invalid first-time-bucket format. Use: yyyyMMdd'T'HH:mm"
     }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraReadJournalConfigSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraReadJournalConfigSpec.scala
@@ -32,7 +32,7 @@ class CassandraReadJournalConfigSpec
         """).withFallback(system.settings.config)
 
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
       readConfig.eventsByTagCleanUpPersistenceIds.get shouldEqual 2.hours
     }
@@ -40,10 +40,10 @@ class CassandraReadJournalConfigSpec
     "support Day with just day format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Day
-          |cassandra-query-journal.first-time-bucket = "20151120"
+          |cassandra-journal.read.first-time-bucket = "20151120"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
       readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
     }
@@ -51,10 +51,10 @@ class CassandraReadJournalConfigSpec
     "support Day with full time format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Day
-          |cassandra-query-journal.first-time-bucket = "20151120T12:20"
+          |cassandra-journal.read.first-time-bucket = "20151120T12:20"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
       // Rounded down
       readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Day)
@@ -63,10 +63,10 @@ class CassandraReadJournalConfigSpec
     "support Hour with just hour format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-query-journal.first-time-bucket = "20151120T00"
+          |cassandra-journal.read.first-time-bucket = "20151120T00"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
       readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
     }
@@ -74,10 +74,10 @@ class CassandraReadJournalConfigSpec
     "support Hour with full time format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-query-journal.first-time-bucket = "20151120T00:20"
+          |cassandra-journal.read.first-time-bucket = "20151120T00:20"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
-      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+      val readConfig = new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
 
       readConfig.firstTimeBucket shouldEqual TimeBucket(1447977600000L, Hour)
     }
@@ -85,11 +85,11 @@ class CassandraReadJournalConfigSpec
     "validate format" in {
       val config = ConfigFactory.parseString("""
           |cassandra-journal.events-by-tag.bucket-size = Hour
-          |cassandra-query-journal.first-time-bucket = "cats"
+          |cassandra-journal.read.first-time-bucket = "cats"
         """.stripMargin).withFallback(system.settings.config)
       val writeConfig = new CassandraJournalConfig(system, config.getConfig("cassandra-journal"))
       val e = intercept[IllegalArgumentException] {
-        new CassandraReadJournalConfig(system, config.getConfig("cassandra-query-journal"), writeConfig)
+        new CassandraReadJournalConfig(system, config.getConfig("cassandra-journal"), writeConfig)
       }
       e.getMessage shouldEqual "Invalid first-time-bucket format. Use: yyyyMMdd'T'HH:mm"
     }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -50,7 +50,7 @@ object CassandraSpec {
       cassandra-journal {
         session-name = $journalKeyspace
         write.keyspace = $journalKeyspace
-        # FIXME #81 this is not the way to configure port. Do we need port config in tests?
+        # FIXME this is not the way to configure port. Do we need port config in tests?
         port = $port
         
         snapshot {

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -47,9 +47,9 @@ object CassandraSpec {
 
   def configOverrides(journalKeyspace: String, snapshotStoreKeyspace: String, port: Int): Config =
     ConfigFactory.parseString(s"""
-      cassandra-journal {
+      cassandra-plugin {
         session-name = $journalKeyspace
-        write.keyspace = $journalKeyspace
+        journal.keyspace = $journalKeyspace
         # FIXME this is not the way to configure port. Do we need port config in tests?
         port = $port
         
@@ -69,7 +69,7 @@ object CassandraSpec {
         }
       }
   
-      cassandra-journal {
+      cassandra-plugin {
         events-by-tag {
           eventual-consistency-delay = 200ms
         }
@@ -160,7 +160,7 @@ abstract class CassandraSpec(
       if (failed && dumpRowsOnFailure) {
         println("RowDump::")
         import scala.collection.JavaConverters._
-        if (system.settings.config.getBoolean("cassandra-journal.events-by-tag.enabled")) {
+        if (system.settings.config.getBoolean("cassandra-plugin.events-by-tag.enabled")) {
           println("tag_views")
           cluster
             .execute(s"select * from ${journalName}.tag_views")

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -5,7 +5,6 @@
 package akka.persistence.cassandra
 
 import java.io.{ OutputStream, PrintStream }
-import java.time.{ LocalDateTime, ZoneOffset }
 import java.util.concurrent.atomic.AtomicInteger
 
 import akka.actor.ActorSystem
@@ -34,7 +33,6 @@ import akka.serialization.SerializationExtension
 import scala.util.control.NonFatal
 
 object CassandraSpec {
-  val today = LocalDateTime.now(ZoneOffset.UTC)
   def getCallerName(clazz: Class[_]): String = {
     val s = Thread.currentThread.getStackTrace
       .map(_.getClassName)
@@ -72,7 +70,6 @@ object CassandraSpec {
       }
   
       cassandra-journal {
-        read.first-time-bucket = "${today.minusHours(2).format(query.firstBucketFormatter)}"
         events-by-tag {
           eventual-consistency-delay = 200ms
         }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -49,7 +49,7 @@ object CassandraSpec {
     ConfigFactory.parseString(s"""
       cassandra-journal {
         session-name = $journalKeyspace
-        keyspace = $journalKeyspace
+        write.keyspace = $journalKeyspace
         # FIXME #81 this is not the way to configure port. Do we need port config in tests?
         port = $port
         

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -76,12 +76,12 @@ object CassandraSpec {
         }
       }
   
-        cassandra-query-journal {
-          first-time-bucket = "${today.minusHours(2).format(query.firstBucketFormatter)}"
-          events-by-tag {
-            eventual-consistency-delay = 200ms
-          }
+      cassandra-journal {
+        read.first-time-bucket = "${today.minusHours(2).format(query.firstBucketFormatter)}"
+        events-by-tag {
+          eventual-consistency-delay = 200ms
         }
+      }
     """)
 
 }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -52,17 +52,12 @@ object CassandraSpec {
       cassandra-journal {
         session-name = $journalKeyspace
         keyspace = $journalKeyspace
+        # FIXME #81 this is not the way to configure port. Do we need port config in tests?
         port = $port
-      }
-
-      cassandra-snapshot-store {
-        session-name = ${snapshotStoreKeyspace}Snapshot
-        keyspace = $snapshotStoreKeyspace
-        port = $port
-      }
-    
-      cassandra-query-plugin { 
-        session-name = ${journalKeyspace}Query
+        
+        snapshot {
+          keyspace = $snapshotStoreKeyspace
+        }
       }     
     """)
 

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -41,16 +41,16 @@ object EventsByTagMigrationSpec {
        // so if one fails need the logs for all
        akka.loggers = []
        akka {
-        actor.serialize-messages=off
-        actor.debug.unhandled = on
+         actor.serialize-messages=off
+         actor.debug.unhandled = on
        }
        cassandra-journal {
-        keyspace-autocreate = true
-        tables-autocreate = true
-       }
-       cassandra-query-journal {
-         first-time-bucket = "${today.minusHours(3).format(query.firstBucketFormatter)}"
-         events-by-persistence-id-gap-timeout = 1s
+         keyspace-autocreate = true
+         tables-autocreate = true
+         read {
+           first-time-bucket = "${today.minusHours(3).format(query.firstBucketFormatter)}"
+           events-by-persistence-id-gap-timeout = 1s
+         }
        }
     """).withFallback(CassandraLifecycle.config).withFallback(ConfigFactory.load())
 

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -42,8 +42,8 @@ object EventsByTagMigrationSpec {
          actor.serialize-messages=off
          actor.debug.unhandled = on
        }
-       cassandra-journal {
-         write {
+       cassandra-plugin {
+         journal {
            keyspace-autocreate = true
            tables-autocreate = true
          }
@@ -354,7 +354,7 @@ abstract class AbstractEventsByTagMigrationSpec
 
   val statements = new CassandraStatements {
     override def config: CassandraJournalConfig =
-      new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+      new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
   }
 
   implicit val materialiser = ActorMaterializer()(system)

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -5,7 +5,6 @@
 package akka.persistence.cassandra
 
 import java.nio.ByteBuffer
-import java.time.{ LocalDateTime, ZoneOffset }
 import java.lang.{ Long => JLong }
 
 import akka.actor.{ ActorSystem, PoisonPill }
@@ -33,7 +32,6 @@ import com.datastax.oss.driver.api.core.uuid.Uuids
 /**
  */
 object EventsByTagMigrationSpec {
-  val today = LocalDateTime.now(ZoneOffset.UTC)
 
   val config = ConfigFactory.parseString(s"""
   
@@ -48,7 +46,6 @@ object EventsByTagMigrationSpec {
          keyspace-autocreate = true
          tables-autocreate = true
          read {
-           first-time-bucket = "${today.minusHours(3).format(query.firstBucketFormatter)}"
            events-by-persistence-id-gap-timeout = 1s
          }
        }

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -43,8 +43,10 @@ object EventsByTagMigrationSpec {
          actor.debug.unhandled = on
        }
        cassandra-journal {
-         keyspace-autocreate = true
-         tables-autocreate = true
+         write {
+           keyspace-autocreate = true
+           tables-autocreate = true
+         }
          read {
            events-by-persistence-id-gap-timeout = 1s
          }

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -47,7 +47,7 @@ object EventsByTagMigrationSpec {
            keyspace-autocreate = true
            tables-autocreate = true
          }
-         read {
+         query {
            events-by-persistence-id-gap-timeout = 1s
          }
        }

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -26,16 +26,15 @@ object EventsByTagRecoverySpec {
        cassandra-journal {
          keyspace = $keyspaceName
          log-queries = off
+         read {
+           first-time-bucket = "${today.minusMinutes(5).format(query.firstBucketFormatter)}"
+         }
          events-by-tag {
             max-message-batch-size = 2
             bucket-size = "Day"
          }
        }
        cassandra-snapshot-store.keyspace=$keyspaceName
-       
-       cassandra-query-journal = {
-          first-time-bucket = "${today.minusMinutes(5).format(query.firstBucketFormatter)}"
-       }
        
        akka.actor.serialize-messages=off
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -33,8 +33,8 @@ object EventsByTagRecoverySpec {
             max-message-batch-size = 2
             bucket-size = "Day"
          }
+         snapshot.keyspace=$keyspaceName
        }
-       cassandra-snapshot-store.keyspace=$keyspaceName
        
        akka.actor.serialize-messages=off
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -21,7 +21,7 @@ object EventsByTagRecoverySpec {
          actor.debug.unhandled = on
        }
        cassandra-journal {
-         keyspace = $keyspaceName
+         write.keyspace = $keyspaceName
          log-queries = off
          events-by-tag {
             max-message-batch-size = 2

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -4,8 +4,6 @@
 
 package akka.persistence.cassandra
 
-import java.time.{ LocalDateTime, ZoneOffset }
-
 import akka.actor.{ ActorSystem, PoisonPill }
 import akka.persistence.cassandra.TestTaggingActor.{ Ack, DoASnapshotPlease, SnapShotAck }
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
@@ -17,7 +15,6 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 
 object EventsByTagRecoverySpec {
-  val today = LocalDateTime.now(ZoneOffset.UTC)
   val keyspaceName = "EventsByTagRecoverySpec"
   val config = ConfigFactory.parseString(s"""
        akka {
@@ -26,9 +23,6 @@ object EventsByTagRecoverySpec {
        cassandra-journal {
          keyspace = $keyspaceName
          log-queries = off
-         read {
-           first-time-bucket = "${today.minusMinutes(5).format(query.firstBucketFormatter)}"
-         }
          events-by-tag {
             max-message-batch-size = 2
             bucket-size = "Day"

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRecoverySpec.scala
@@ -20,8 +20,8 @@ object EventsByTagRecoverySpec {
        akka {
          actor.debug.unhandled = on
        }
-       cassandra-journal {
-         write.keyspace = $keyspaceName
+       cassandra-plugin {
+         journal.keyspace = $keyspaceName
          log-queries = off
          events-by-tag {
             max-message-batch-size = 2

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRestartSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRestartSpec.scala
@@ -28,7 +28,7 @@ object EventsByTagRestartSpec {
        |akka {
        |  actor.debug.unhandled = on
        |}
-       |cassandra-journal {
+       |cassandra-plugin {
        |  log-queries = off
        |  events-by-tag {
        |     max-message-batch-size = 250 // make it likely we have messages in the buffer

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRestartSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRestartSpec.scala
@@ -30,14 +30,13 @@ object EventsByTagRestartSpec {
        |}
        |cassandra-journal {
        |  log-queries = off
+       |  read {
+       |    first-time-bucket = "${today.minusMinutes(5).format(firstBucketFormat)}"
+       |  }
        |  events-by-tag {
        |     max-message-batch-size = 250 // make it likely we have messages in the buffer
        |     bucket-size = "Day"
        |  }
-       |}
-       |
-       |cassandra-query-journal = {
-       |   first-time-bucket = "${today.minusMinutes(5).format(firstBucketFormat)}"
        |}
        |
        |akka.actor.serialize-messages=off

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagRestartSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagRestartSpec.scala
@@ -30,9 +30,6 @@ object EventsByTagRestartSpec {
        |}
        |cassandra-journal {
        |  log-queries = off
-       |  read {
-       |    first-time-bucket = "${today.minusMinutes(5).format(firstBucketFormat)}"
-       |  }
        |  events-by-tag {
        |     max-message-batch-size = 250 // make it likely we have messages in the buffer
        |     bucket-size = "Day"

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagStressSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagStressSpec.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable
 import scala.concurrent.Future
 
 class EventsByTagStressSpec extends CassandraSpec(s"""
-    cassandra-journal {
+    cassandra-plugin {
       events-by-tag {
         max-message-batch-size = 25
       }

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagStressSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagStressSpec.scala
@@ -18,12 +18,12 @@ import scala.concurrent.Future
 
 class EventsByTagStressSpec extends CassandraSpec(s"""
     cassandra-journal {
+      read {
+        first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusHours(2).format(firstBucketFormatter)}"
+      }
       events-by-tag {
         max-message-batch-size = 25
       }
-    }
-    cassandra-query-journal {
-       first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusHours(2).format(firstBucketFormatter)}"
     }
   """) {
 

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagStressSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagStressSpec.scala
@@ -4,8 +4,6 @@
 
 package akka.persistence.cassandra
 
-import java.time.{ LocalDateTime, ZoneOffset }
-
 import akka.persistence.cassandra.query.TestActor
 import akka.persistence.cassandra.query._
 import akka.persistence.journal.Tagged
@@ -18,9 +16,6 @@ import scala.concurrent.Future
 
 class EventsByTagStressSpec extends CassandraSpec(s"""
     cassandra-journal {
-      read {
-        first-time-bucket = "${LocalDateTime.now(ZoneOffset.UTC).minusHours(2).format(firstBucketFormatter)}"
-      }
       events-by-tag {
         max-message-batch-size = 25
       }

--- a/core/src/test/scala/akka/persistence/cassandra/PrintCreateStatements.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/PrintCreateStatements.scala
@@ -11,7 +11,7 @@ import akka.actor.ActorSystem
 
 /**
  * Main application that prints the create keyspace and create table statements.
- * It's using `cassandra-journal` and `cassandra-snapshot-store` configuration from default application.conf.
+ * It's using `cassandra-journal` and `cassandra-journal.snapshot` configuration from default application.conf.
  *
  * These statements can be copy-pasted and run in `cqlsh`.
  */
@@ -27,7 +27,7 @@ object PrintCreateStatements {
     println("")
 
     val snapshotSettings =
-      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-snapshot-store"))
+      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-journal.snapshot"))
     println(snapshotSettings.createKeyspaceStatement + ";")
     println("")
     println(snapshotSettings.createTablesStatements.mkString(";\n\n") + ";")

--- a/core/src/test/scala/akka/persistence/cassandra/PrintCreateStatements.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/PrintCreateStatements.scala
@@ -11,7 +11,7 @@ import akka.actor.ActorSystem
 
 /**
  * Main application that prints the create keyspace and create table statements.
- * It's using `cassandra-journal` and `cassandra-journal.snapshot` configuration from default application.conf.
+ * It's using `cassandra-plugin` and `cassandra-plugin.snapshot` configuration from default application.conf.
  *
  * These statements can be copy-pasted and run in `cqlsh`.
  */
@@ -20,14 +20,14 @@ object PrintCreateStatements {
   def main(args: Array[String]): Unit = {
     val system = ActorSystem("PrintCreateStatements")
 
-    val journalSettings = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+    val journalSettings = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
     println(journalSettings.createKeyspaceStatement + ";")
     println("")
     println(journalSettings.createTablesStatements.mkString(";\n\n") + ";")
     println("")
 
     val snapshotSettings =
-      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-journal.snapshot"))
+      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-plugin.snapshot"))
     println(snapshotSettings.createKeyspaceStatement + ";")
     println("")
     println(snapshotSettings.createTablesStatements.mkString(";\n\n") + ";")

--- a/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -32,14 +32,14 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
   "A CassandraCompactionStrategy" must {
 
     "successfully create a TimeWindowCompactionStrategy" in {
-      val twConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val twConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "TimeWindowCompactionStrategy"
           | compaction_window_size = 10
           | compaction_window_unit = "DAYS"
           |}
         """.stripMargin)
 
-      val compactionStrategy = CassandraCompactionStrategy(twConfig.getConfig("table-compaction-strategy"))
+      val compactionStrategy = CassandraCompactionStrategy(twConfig.getConfig("write.table-compaction-strategy"))
         .asInstanceOf[TimeWindowCompactionStrategy]
 
       compactionStrategy.compactionWindowSize shouldEqual 10
@@ -47,7 +47,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create CQL from TimeWindowCompactionStrategy" in {
-      val twConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val twConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "TimeWindowCompactionStrategy"
           | compaction_window_size = 1
           | compaction_window_unit = "MINUTES"
@@ -56,7 +56,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
 
       val cqlExpression =
         s"CREATE TABLE IF NOT EXISTS testKeyspace.testTable1 (testId TEXT PRIMARY KEY) WITH compaction = ${CassandraCompactionStrategy(
-          twConfig.getConfig("table-compaction-strategy")).asCQL}"
+          twConfig.getConfig("write.table-compaction-strategy")).asCQL}"
 
       noException must be thrownBy {
         cluster.execute(cqlExpression)
@@ -64,7 +64,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "fail if unrecognised property for TimeWindowCompactionStrategy" in {
-      val twConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val twConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "TimeWindowCompactionStrategy"
           | compaction_window_size = 10
           | banana = "cherry"
@@ -72,13 +72,13 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
         """.stripMargin)
 
       assertThrows[IllegalArgumentException] {
-        CassandraCompactionStrategy(twConfig.getConfig("table-compaction-strategy"))
+        CassandraCompactionStrategy(twConfig.getConfig("write.table-compaction-strategy"))
           .asInstanceOf[TimeWindowCompactionStrategy]
       }
     }
 
     "successfully create a LeveledCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "LeveledCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -88,7 +88,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
           |}
         """.stripMargin)
 
-      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("table-compaction-strategy"))
+      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("write.table-compaction-strategy"))
         .asInstanceOf[LeveledCompactionStrategy]
 
       compactionStrategy.enabled shouldEqual true
@@ -99,7 +99,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create CQL from LeveledCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "LeveledCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -111,7 +111,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
 
       val cqlExpression =
         s"CREATE TABLE IF NOT EXISTS testKeyspace.testTable2 (testId TEXT PRIMARY KEY) WITH compaction = ${CassandraCompactionStrategy(
-          uniqueConfig.getConfig("table-compaction-strategy")).asCQL}"
+          uniqueConfig.getConfig("write.table-compaction-strategy")).asCQL}"
 
       noException must be thrownBy {
         cluster.execute(cqlExpression)
@@ -119,7 +119,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create a SizeTieredCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "SizeTieredCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -133,7 +133,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
           |}
         """.stripMargin)
 
-      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("table-compaction-strategy"))
+      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("write.table-compaction-strategy"))
         .asInstanceOf[SizeTieredCompactionStrategy]
 
       compactionStrategy.enabled shouldEqual true
@@ -148,7 +148,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create CQL from SizeTieredCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
           | class = "SizeTieredCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -164,7 +164,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
 
       val cqlExpression =
         s"CREATE TABLE IF NOT EXISTS testKeyspace.testTable3 (testId TEXT PRIMARY KEY) WITH compaction = ${CassandraCompactionStrategy(
-          uniqueConfig.getConfig("table-compaction-strategy")).asCQL}"
+          uniqueConfig.getConfig("write.table-compaction-strategy")).asCQL}"
 
       noException must be thrownBy {
         cluster.execute(cqlExpression)

--- a/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -12,7 +12,7 @@ import org.scalatest.WordSpecLike
 
 object CassandraCompactionStrategySpec {
   lazy val config = ConfigFactory.parseString(s"""
-       |cassandra-journal.keyspace=CassandraCompactionStrategySpec
+       |cassandra-journal.write.keyspace=CassandraCompactionStrategySpec
        |cassandra-journal.snapshot.keyspace=CassandraCompactionStrategySpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -13,7 +13,7 @@ import org.scalatest.WordSpecLike
 object CassandraCompactionStrategySpec {
   lazy val config = ConfigFactory.parseString(s"""
        |cassandra-journal.keyspace=CassandraCompactionStrategySpec
-       |cassandra-snapshot-store.keyspace=CassandraCompactionStrategySpecSnapshot
+       |cassandra-journal.snapshot.keyspace=CassandraCompactionStrategySpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/compaction/CassandraCompactionStrategySpec.scala
@@ -12,14 +12,14 @@ import org.scalatest.WordSpecLike
 
 object CassandraCompactionStrategySpec {
   lazy val config = ConfigFactory.parseString(s"""
-       |cassandra-journal.write.keyspace=CassandraCompactionStrategySpec
-       |cassandra-journal.snapshot.keyspace=CassandraCompactionStrategySpecSnapshot
+       |cassandra-plugin.journal.keyspace=CassandraCompactionStrategySpec
+       |cassandra-plugin.snapshot.keyspace=CassandraCompactionStrategySpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 }
 
 class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionStrategySpec.config) with WordSpecLike {
 
-  val defaultConfigs = system.settings.config.getConfig("cassandra-journal")
+  val defaultConfigs = system.settings.config.getConfig("cassandra-plugin")
 
   val cassandraPluginConfig = new CassandraPluginConfig(system, defaultConfigs)
 
@@ -32,14 +32,14 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
   "A CassandraCompactionStrategy" must {
 
     "successfully create a TimeWindowCompactionStrategy" in {
-      val twConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val twConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "TimeWindowCompactionStrategy"
           | compaction_window_size = 10
           | compaction_window_unit = "DAYS"
           |}
         """.stripMargin)
 
-      val compactionStrategy = CassandraCompactionStrategy(twConfig.getConfig("write.table-compaction-strategy"))
+      val compactionStrategy = CassandraCompactionStrategy(twConfig.getConfig("journal.table-compaction-strategy"))
         .asInstanceOf[TimeWindowCompactionStrategy]
 
       compactionStrategy.compactionWindowSize shouldEqual 10
@@ -47,7 +47,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create CQL from TimeWindowCompactionStrategy" in {
-      val twConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val twConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "TimeWindowCompactionStrategy"
           | compaction_window_size = 1
           | compaction_window_unit = "MINUTES"
@@ -56,7 +56,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
 
       val cqlExpression =
         s"CREATE TABLE IF NOT EXISTS testKeyspace.testTable1 (testId TEXT PRIMARY KEY) WITH compaction = ${CassandraCompactionStrategy(
-          twConfig.getConfig("write.table-compaction-strategy")).asCQL}"
+          twConfig.getConfig("journal.table-compaction-strategy")).asCQL}"
 
       noException must be thrownBy {
         cluster.execute(cqlExpression)
@@ -64,7 +64,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "fail if unrecognised property for TimeWindowCompactionStrategy" in {
-      val twConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val twConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "TimeWindowCompactionStrategy"
           | compaction_window_size = 10
           | banana = "cherry"
@@ -72,13 +72,13 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
         """.stripMargin)
 
       assertThrows[IllegalArgumentException] {
-        CassandraCompactionStrategy(twConfig.getConfig("write.table-compaction-strategy"))
+        CassandraCompactionStrategy(twConfig.getConfig("journal.table-compaction-strategy"))
           .asInstanceOf[TimeWindowCompactionStrategy]
       }
     }
 
     "successfully create a LeveledCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "LeveledCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -88,7 +88,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
           |}
         """.stripMargin)
 
-      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("write.table-compaction-strategy"))
+      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("journal.table-compaction-strategy"))
         .asInstanceOf[LeveledCompactionStrategy]
 
       compactionStrategy.enabled shouldEqual true
@@ -99,7 +99,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create CQL from LeveledCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "LeveledCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -111,7 +111,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
 
       val cqlExpression =
         s"CREATE TABLE IF NOT EXISTS testKeyspace.testTable2 (testId TEXT PRIMARY KEY) WITH compaction = ${CassandraCompactionStrategy(
-          uniqueConfig.getConfig("write.table-compaction-strategy")).asCQL}"
+          uniqueConfig.getConfig("journal.table-compaction-strategy")).asCQL}"
 
       noException must be thrownBy {
         cluster.execute(cqlExpression)
@@ -119,7 +119,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create a SizeTieredCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "SizeTieredCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -133,7 +133,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
           |}
         """.stripMargin)
 
-      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("write.table-compaction-strategy"))
+      val compactionStrategy = CassandraCompactionStrategy(uniqueConfig.getConfig("journal.table-compaction-strategy"))
         .asInstanceOf[SizeTieredCompactionStrategy]
 
       compactionStrategy.enabled shouldEqual true
@@ -148,7 +148,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
     }
 
     "successfully create CQL from SizeTieredCompactionStrategy" in {
-      val uniqueConfig = ConfigFactory.parseString("""write.table-compaction-strategy {
+      val uniqueConfig = ConfigFactory.parseString("""journal.table-compaction-strategy {
           | class = "SizeTieredCompactionStrategy"
           | enabled = true
           | tombstone_compaction_interval = 86400
@@ -164,7 +164,7 @@ class CassandraCompactionStrategySpec extends CassandraSpec(CassandraCompactionS
 
       val cqlExpression =
         s"CREATE TABLE IF NOT EXISTS testKeyspace.testTable3 (testId TEXT PRIMARY KEY) WITH compaction = ${CassandraCompactionStrategy(
-          uniqueConfig.getConfig("write.table-compaction-strategy")).asCQL}"
+          uniqueConfig.getConfig("journal.table-compaction-strategy")).asCQL}"
 
       noException must be thrownBy {
         cluster.execute(cqlExpression)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -32,7 +32,7 @@ class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.co
 
     override private[akka] val log = s.log
     override private[akka] def config: CassandraJournalConfig =
-      new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+      new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
     override private[akka] implicit val ec: ExecutionContext = system.dispatcher
     override private[akka] val session: CassandraSession =
       new CassandraSession(system, config.sessionProvider, ec, log, systemName, init = _ => Future.successful(Done))

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -20,7 +20,7 @@ object CassandraIntegrationSpec {
       |akka.persistence.publish-plugin-commands = on
       |cassandra-journal.write.target-partition-size = 5
       |cassandra-journal.max-result-size = 3
-      |cassandra-journal.keyspace=CassandraIntegrationSpec
+      |cassandra-journal.write.keyspace=CassandraIntegrationSpec
       |cassandra-journal.snapshot.keyspace=CassandraIntegrationSpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -18,10 +18,10 @@ object CassandraIntegrationSpec {
       |akka.persistence.journal.max-deletion-batch-size = 3
       |akka.persistence.publish-confirmations = on
       |akka.persistence.publish-plugin-commands = on
-      |cassandra-journal.write.target-partition-size = 5
-      |cassandra-journal.max-result-size = 3
-      |cassandra-journal.write.keyspace=CassandraIntegrationSpec
-      |cassandra-journal.snapshot.keyspace=CassandraIntegrationSpecSnapshot
+      |cassandra-plugin.journal.target-partition-size = 5
+      |cassandra-plugin.max-result-size = 3
+      |cassandra-plugin.journal.keyspace=CassandraIntegrationSpec
+      |cassandra-plugin.snapshot.keyspace=CassandraIntegrationSpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 
   case class DeleteTo(snr: Long)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -21,7 +21,7 @@ object CassandraIntegrationSpec {
       |cassandra-journal.write.target-partition-size = 5
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.keyspace=CassandraIntegrationSpec
-      |cassandra-snapshot-store.keyspace=CassandraIntegrationSpecSnapshot
+      |cassandra-journal.snapshot.keyspace=CassandraIntegrationSpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 
   case class DeleteTo(snr: Long)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraIntegrationSpec.scala
@@ -18,7 +18,7 @@ object CassandraIntegrationSpec {
       |akka.persistence.journal.max-deletion-batch-size = 3
       |akka.persistence.publish-confirmations = on
       |akka.persistence.publish-plugin-commands = on
-      |cassandra-journal.target-partition-size = 5
+      |cassandra-journal.write.target-partition-size = 5
       |cassandra-journal.max-result-size = 3
       |cassandra-journal.keyspace=CassandraIntegrationSpec
       |cassandra-snapshot-store.keyspace=CassandraIntegrationSpecSnapshot

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -27,7 +27,7 @@ object CassandraJournalDeletionSpec {
       val persistenceId: String,
       deleteSuccessProbe: ActorRef,
       deleteFailProbe: ActorRef,
-      override val journalPluginId: String = "cassandra-journal")
+      override val journalPluginId: String = "cassandra-journal.write")
       extends PersistentActor {
 
     var recoveredEvents: List[Any] = List.empty
@@ -68,32 +68,17 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
     cassandra-journal-low-concurrent-deletes = $${cassandra-journal}
     cassandra-journal-low-concurrent-deletes {
       max-concurrent-deletes = 5
-      query-plugin = cassandra-query-journal-low-concurrent-deletes
-    }
-    cassandra-query-journal-low-concurrent-deletes = $${cassandra-query-journal}
-    cassandra-query-journal-low-concurrent-deletes {
-      write-plugin = cassandra-journal-low-concurrent-deletes
     }
 
     cassandra-journal-small-partition-size = $${cassandra-journal}
     cassandra-journal-small-partition-size {
       write.target-partition-size = 3
       keyspace = "DeletionSpecMany"
-      query-plugin = cassandra-query-journal-small-partition-size
-    }
-    cassandra-query-journal-small-partition-size = $${cassandra-query-journal}
-    cassandra-query-journal-small-partition-size {
-      write-plugin = cassandra-journal-small-partition-size
     }
     
     cassandra-journal-no-delete = $${cassandra-journal}
     cassandra-journal-no-delete {
       support-deletes = off
-      query-plugin = cassandra-query-journal-no-delete
-    }
-    cassandra-query-journal-no-delete = $${cassandra-query-journal}
-    cassandra-query-journal-no-delete {
-      write-plugin = cassandra-journal-no-delete
     }
   """) {
 
@@ -134,7 +119,8 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val p1 = system.actorOf(
-        Props(new PAThatDeletes("p2", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-low-concurrent-deletes")))
+        Props(
+          new PAThatDeletes("p2", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-low-concurrent-deletes.write")))
 
       (1 to 100).foreach { i =>
         p1 ! PersistMe(i)
@@ -183,7 +169,8 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val props =
-        Props(new PAThatDeletes("p4", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size"))
+        Props(
+          new PAThatDeletes("p4", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size.write"))
       val p1 = system.actorOf(props)
       (1 to 100).foreach { i =>
         p1 ! PersistMe(i)
@@ -225,7 +212,8 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val props =
-        Props(new PAThatDeletes("p5", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size"))
+        Props(
+          new PAThatDeletes("p5", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-small-partition-size.write"))
       val p1 = system.actorOf(props)
       (1 to 100).foreach { i =>
         p1 ! PersistMe(i)
@@ -249,7 +237,8 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val p1 =
-        system.actorOf(Props(new PAThatDeletes("p6", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
+        system.actorOf(
+          Props(new PAThatDeletes("p6", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete.write")))
 
       (1 to 3).foreach { i =>
         p1 ! PersistMe(i)
@@ -267,7 +256,8 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
       val deleteSuccess = TestProbe()
       val deleteFail = TestProbe()
       val p1 =
-        system.actorOf(Props(new PAThatDeletes("p7", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete")))
+        system.actorOf(
+          Props(new PAThatDeletes("p7", deleteSuccess.ref, deleteFail.ref, "cassandra-journal-no-delete.write")))
 
       (1 to 3).foreach { i =>
         p1 ! PersistMe(i)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -63,11 +63,11 @@ object CassandraJournalDeletionSpec {
 class CassandraJournalDeletionSpec extends CassandraSpec(s"""
     akka.loggers = ["akka.testkit.TestEventListener"]
     akka.log-dead-letters = off
-    cassandra-journal.max-concurrent-deletes = 100
+    cassandra-journal.write.max-concurrent-deletes = 100
 
     cassandra-journal-low-concurrent-deletes = $${cassandra-journal}
     cassandra-journal-low-concurrent-deletes {
-      max-concurrent-deletes = 5
+      write.max-concurrent-deletes = 5
     }
 
     cassandra-journal-small-partition-size = $${cassandra-journal}
@@ -78,7 +78,7 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
     
     cassandra-journal-no-delete = $${cassandra-journal}
     cassandra-journal-no-delete {
-      support-deletes = off
+      write.support-deletes = off
     }
   """) {
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -77,7 +77,7 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
 
     cassandra-journal-small-partition-size = $${cassandra-journal}
     cassandra-journal-small-partition-size {
-      target-partition-size = 3
+      write.target-partition-size = 3
       keyspace = "DeletionSpecMany"
       query-plugin = cassandra-query-journal-small-partition-size
     }

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalDeletionSpec.scala
@@ -73,7 +73,7 @@ class CassandraJournalDeletionSpec extends CassandraSpec(s"""
     cassandra-journal-small-partition-size = $${cassandra-journal}
     cassandra-journal-small-partition-size {
       write.target-partition-size = 3
-      keyspace = "DeletionSpecMany"
+      write.keyspace = "DeletionSpecMany"
     }
     
     cassandra-journal-no-delete = $${cassandra-journal}

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -18,19 +18,19 @@ import com.typesafe.config.ConfigFactory
 object CassandraJournalConfiguration {
   val config = ConfigFactory.parseString(s"""
        |cassandra-journal.keyspace=CassandraJournalSpec
-       |cassandra-snapshot-store.keyspace=CassandraJournalSpecSnapshot
+       |cassandra-journal.snapshot.keyspace=CassandraJournalSpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 
   lazy val perfConfig = ConfigFactory.parseString("""
     akka.actor.serialize-messages=off
     cassandra-journal.keyspace=CassandraJournalPerfSpec
-    cassandra-snapshot-store.keyspace=CassandraJournalPerfSpecSnapshot
+    cassandra-journal.snapshot.keyspace=CassandraJournalPerfSpecSnapshot
     """).withFallback(config)
 
   lazy val compat2Config = ConfigFactory.parseString(s"""
       cassandra-journal.cassandra-2x-compat = on
       cassandra-journal.keyspace=CassandraJournalCompat2Spec
-      cassandra-snapshot-store.keyspace=CassandraJournalCompat2Spec
+      cassandra-journal.snapshot.keyspace=CassandraJournalCompat2Spec
     """).withFallback(config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -17,20 +17,20 @@ import com.typesafe.config.ConfigFactory
 
 object CassandraJournalConfiguration {
   val config = ConfigFactory.parseString(s"""
-       |cassandra-journal.write.keyspace=CassandraJournalSpec
-       |cassandra-journal.snapshot.keyspace=CassandraJournalSpecSnapshot
+       |cassandra-plugin.journal.keyspace=CassandraJournalSpec
+       |cassandra-plugin.snapshot.keyspace=CassandraJournalSpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 
   lazy val perfConfig = ConfigFactory.parseString("""
     akka.actor.serialize-messages=off
-    cassandra-journal.write.keyspace=CassandraJournalPerfSpec
-    cassandra-journal.snapshot.keyspace=CassandraJournalPerfSpecSnapshot
+    cassandra-plugin.journal.keyspace=CassandraJournalPerfSpec
+    cassandra-plugin.snapshot.keyspace=CassandraJournalPerfSpecSnapshot
     """).withFallback(config)
 
   lazy val compat2Config = ConfigFactory.parseString(s"""
-      cassandra-journal.cassandra-2x-compat = on
-      cassandra-journal.write.keyspace=CassandraJournalCompat2Spec
-      cassandra-journal.snapshot.keyspace=CassandraJournalCompat2Spec
+      cassandra-plugin.cassandra-2x-compat = on
+      cassandra-plugin.journal.keyspace=CassandraJournalCompat2Spec
+      cassandra-plugin.snapshot.keyspace=CassandraJournalCompat2Spec
     """).withFallback(config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -17,19 +17,19 @@ import com.typesafe.config.ConfigFactory
 
 object CassandraJournalConfiguration {
   val config = ConfigFactory.parseString(s"""
-       |cassandra-journal.keyspace=CassandraJournalSpec
+       |cassandra-journal.write.keyspace=CassandraJournalSpec
        |cassandra-journal.snapshot.keyspace=CassandraJournalSpecSnapshot
     """.stripMargin).withFallback(CassandraLifecycle.config)
 
   lazy val perfConfig = ConfigFactory.parseString("""
     akka.actor.serialize-messages=off
-    cassandra-journal.keyspace=CassandraJournalPerfSpec
+    cassandra-journal.write.keyspace=CassandraJournalPerfSpec
     cassandra-journal.snapshot.keyspace=CassandraJournalPerfSpecSnapshot
     """).withFallback(config)
 
   lazy val compat2Config = ConfigFactory.parseString(s"""
       cassandra-journal.cassandra-2x-compat = on
-      cassandra-journal.keyspace=CassandraJournalCompat2Spec
+      cassandra-journal.write.keyspace=CassandraJournalCompat2Spec
       cassandra-journal.snapshot.keyspace=CassandraJournalCompat2Spec
     """).withFallback(config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
@@ -16,8 +16,8 @@ import org.scalatest._
 
 object CassandraLoadSpec {
   val config = ConfigFactory.parseString(s"""
-      cassandra-journal.write.replication-strategy = NetworkTopologyStrategy
-      cassandra-journal.write.data-center-replication-factors = ["datacenter1:1"]
+      cassandra-plugin.journal.replication-strategy = NetworkTopologyStrategy
+      cassandra-plugin.journal.data-center-replication-factors = ["datacenter1:1"]
       akka.actor.serialize-messages=off
      """).withFallback(CassandraLifecycle.config)
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadSpec.scala
@@ -16,8 +16,8 @@ import org.scalatest._
 
 object CassandraLoadSpec {
   val config = ConfigFactory.parseString(s"""
-      cassandra-journal.replication-strategy = NetworkTopologyStrategy
-      cassandra-journal.data-center-replication-factors = ["datacenter1:1"]
+      cassandra-journal.write.replication-strategy = NetworkTopologyStrategy
+      cassandra-journal.write.data-center-replication-factors = ["datacenter1:1"]
       akka.actor.serialize-messages=off
      """).withFallback(CassandraLifecycle.config)
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
@@ -23,7 +23,7 @@ object CassandraSerializationSpec {
        |akka.persistence.journal.max-deletion-batch-size = 3
        |akka.persistence.publish-confirmations = on
        |akka.persistence.publish-plugin-commands = on
-       |cassandra-journal.target-partition-size = 5
+       |cassandra-journal.write.target-partition-size = 5
        |cassandra-journal.max-result-size = 3
        |cassandra-journal.keyspace=CassandraIntegrationSpec
        |cassandra-snapshot-store.keyspace=CassandraIntegrationSpecSnapshot

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
@@ -25,7 +25,7 @@ object CassandraSerializationSpec {
        |akka.persistence.publish-plugin-commands = on
        |cassandra-journal.write.target-partition-size = 5
        |cassandra-journal.max-result-size = 3
-       |cassandra-journal.keyspace=CassandraIntegrationSpec
+       |cassandra-journal.write.keyspace=CassandraIntegrationSpec
        |cassandra-journal.snapshot.keyspace=CassandraIntegrationSpecSnapshot
        |
     """.stripMargin).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
@@ -23,10 +23,10 @@ object CassandraSerializationSpec {
        |akka.persistence.journal.max-deletion-batch-size = 3
        |akka.persistence.publish-confirmations = on
        |akka.persistence.publish-plugin-commands = on
-       |cassandra-journal.write.target-partition-size = 5
-       |cassandra-journal.max-result-size = 3
-       |cassandra-journal.write.keyspace=CassandraIntegrationSpec
-       |cassandra-journal.snapshot.keyspace=CassandraIntegrationSpecSnapshot
+       |cassandra-plugin.journal.target-partition-size = 5
+       |cassandra-plugin.max-result-size = 3
+       |cassandra-plugin.journal.keyspace=CassandraIntegrationSpec
+       |cassandra-plugin.snapshot.keyspace=CassandraIntegrationSpecSnapshot
        |
     """.stripMargin).withFallback(CassandraLifecycle.config)
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraSerializationSpec.scala
@@ -26,7 +26,7 @@ object CassandraSerializationSpec {
        |cassandra-journal.write.target-partition-size = 5
        |cassandra-journal.max-result-size = 3
        |cassandra-journal.keyspace=CassandraIntegrationSpec
-       |cassandra-snapshot-store.keyspace=CassandraIntegrationSpecSnapshot
+       |cassandra-journal.snapshot.keyspace=CassandraIntegrationSpecSnapshot
        |
     """.stripMargin).withFallback(CassandraLifecycle.config)
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/ManyActorsLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/ManyActorsLoadSpec.scala
@@ -22,8 +22,7 @@ object ManyActorsLoadSpec {
       # increase this to 3s when benchmarking
       cassandra-journal.events-by-tag.scanning-flush-interval = 1s
       #cassandra-journal.log-queries = on
-      cassandra-snapshot-store.keyspace=ManyActorsLoadSpecSnapshot
-      #cassandra-snapshot-store.log-queries = on
+      cassandra-journal.snapshot.keyspace=ManyActorsLoadSpecSnapshot
     """).withFallback(CassandraLifecycle.config)
 
   final case class Init(numberOfEvents: Int)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/ManyActorsLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/ManyActorsLoadSpec.scala
@@ -17,7 +17,7 @@ import com.typesafe.config.ConfigFactory
 
 object ManyActorsLoadSpec {
   val config = ConfigFactory.parseString(s"""
-      cassandra-journal.keyspace=ManyActorsLoadSpec
+      cassandra-journal.write.keyspace=ManyActorsLoadSpec
       cassandra-journal.events-by-tag.enabled = on
       # increase this to 3s when benchmarking
       cassandra-journal.events-by-tag.scanning-flush-interval = 1s

--- a/core/src/test/scala/akka/persistence/cassandra/journal/ManyActorsLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/ManyActorsLoadSpec.scala
@@ -17,12 +17,12 @@ import com.typesafe.config.ConfigFactory
 
 object ManyActorsLoadSpec {
   val config = ConfigFactory.parseString(s"""
-      cassandra-journal.write.keyspace=ManyActorsLoadSpec
-      cassandra-journal.events-by-tag.enabled = on
+      cassandra-plugin.journal.keyspace=ManyActorsLoadSpec
+      cassandra-plugin.events-by-tag.enabled = on
       # increase this to 3s when benchmarking
-      cassandra-journal.events-by-tag.scanning-flush-interval = 1s
-      #cassandra-journal.log-queries = on
-      cassandra-journal.snapshot.keyspace=ManyActorsLoadSpecSnapshot
+      cassandra-plugin.events-by-tag.scanning-flush-interval = 1s
+      #cassandra-plugin.log-queries = on
+      cassandra-plugin.snapshot.keyspace=ManyActorsLoadSpecSnapshot
     """).withFallback(CassandraLifecycle.config)
 
   final case class Init(numberOfEvents: Int)
@@ -75,7 +75,7 @@ class ManyActorsLoadSpec extends CassandraSpec(ManyActorsLoadSpec.config) {
       val rounds = 1 // increase this to 10 when benchmarking
       val deadline =
         Deadline.now + rounds * system.settings.config
-          .getDuration("cassandra-journal.events-by-tag.scanning-flush-interval", TimeUnit.MILLISECONDS)
+          .getDuration("cassandra-plugin.events-by-tag.scanning-flush-interval", TimeUnit.MILLISECONDS)
           .millis + 2.seconds
 
       val tagging: Long => Set[String] = { _ =>

--- a/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
@@ -19,9 +19,9 @@ object MultiPluginSpec {
        |akka.test.single-expect-default = 20s
        |akka.test.filter-leeway = 20s
        |
-       |cassandra-journal.keyspace = $journalKeyspace
-       |cassandra-journal.keyspace-autocreate=false
-       |cassandra-journal.circuit-breaker.call-timeout = 30s
+       |cassandra-journal.write.keyspace = $journalKeyspace
+       |cassandra-journal.write.keyspace-autocreate=false
+       |cassandra-journal.write.circuit-breaker.call-timeout = 30s
        |cassandra-journal.snapshot.keyspace=$snapshotKeyspace
        |
        |cassandra-journal-a=$${cassandra-journal}

--- a/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
@@ -26,18 +26,18 @@ object MultiPluginSpec {
        |cassandra-snapshot-store.keyspace-autocreate=false
        |
        |cassandra-journal-a=$${cassandra-journal}
-       |cassandra-journal-a.table=processor_a_messages
+       |cassandra-journal-a.write.table=processor_a_messages
        |
        |cassandra-journal-b=$${cassandra-journal}
-       |cassandra-journal-b.table=processor_b_messages
+       |cassandra-journal-b.write.table=processor_b_messages
        |
         |cassandra-journal-c=$${cassandra-journal}
-       |cassandra-journal-c.table=processor_c_messages
+       |cassandra-journal-c.write.table=processor_c_messages
        |cassandra-snapshot-c=$${cassandra-snapshot-store}
        |cassandra-snapshot-c.table=snapshot_c_messages
        |
        |cassandra-journal-d=$${cassandra-journal}
-       |cassandra-journal-d.table=processor_d_messages
+       |cassandra-journal-d.write.table=processor_d_messages
        |cassandra-snapshot-d=$${cassandra-snapshot-store}
        |cassandra-snapshot-d.table=snapshot_d_messages
        |

--- a/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/MultiPluginSpec.scala
@@ -19,24 +19,24 @@ object MultiPluginSpec {
        |akka.test.single-expect-default = 20s
        |akka.test.filter-leeway = 20s
        |
-       |cassandra-journal.write.keyspace = $journalKeyspace
-       |cassandra-journal.write.keyspace-autocreate=false
-       |cassandra-journal.write.circuit-breaker.call-timeout = 30s
-       |cassandra-journal.snapshot.keyspace=$snapshotKeyspace
+       |cassandra-plugin.journal.keyspace = $journalKeyspace
+       |cassandra-plugin.journal.keyspace-autocreate=false
+       |cassandra-plugin.journal.circuit-breaker.call-timeout = 30s
+       |cassandra-plugin.snapshot.keyspace=$snapshotKeyspace
        |
-       |cassandra-journal-a=$${cassandra-journal}
-       |cassandra-journal-a.write.table=processor_a_messages
+       |cassandra-plugin-a=$${cassandra-plugin}
+       |cassandra-plugin-a.journal.table=processor_a_messages
        |
-       |cassandra-journal-b=$${cassandra-journal}
-       |cassandra-journal-b.write.table=processor_b_messages
+       |cassandra-plugin-b=$${cassandra-plugin}
+       |cassandra-plugin-b.journal.table=processor_b_messages
        |
-       |cassandra-journal-c=$${cassandra-journal}
-       |cassandra-journal-c.write.table=processor_c_messages
-       |cassandra-journal-c.snapshot.table=snapshot_c_messages
+       |cassandra-plugin-c=$${cassandra-plugin}
+       |cassandra-plugin-c.journal.table=processor_c_messages
+       |cassandra-plugin-c.snapshot.table=snapshot_c_messages
        |
-       |cassandra-journal-d=$${cassandra-journal}
-       |cassandra-journal-d.write.table=processor_d_messages
-       |cassandra-journal-d.snapshot.table=snapshot_d_messages
+       |cassandra-plugin-d=$${cassandra-plugin}
+       |cassandra-plugin-d.journal.table=processor_d_messages
+       |cassandra-plugin-d.snapshot.table=snapshot_d_messages
        |
     """.stripMargin)
 
@@ -62,7 +62,7 @@ object MultiPluginSpec {
 
   class OverrideJournalPluginProcessor(override val journalPluginId: String) extends Processor {
     override val persistenceId: String = "always-the-same"
-    override val snapshotPluginId: String = "cassandra-journal.snapshot"
+    override val snapshotPluginId: String = "cassandra-plugin.snapshot"
   }
 
   class OverrideSnapshotPluginProcessor(override val journalPluginId: String, override val snapshotPluginId: String)
@@ -79,7 +79,7 @@ class MultiPluginSpec
       MultiPluginSpec.snapshotKeyspace) {
 
   lazy val cassandraPluginConfig =
-    new CassandraPluginConfig(system, system.settings.config.getConfig("cassandra-journal"))
+    new CassandraPluginConfig(system, system.settings.config.getConfig("cassandra-plugin"))
 
   // default journal plugin is not configured for this test
   override def awaitPersistenceInit(): Unit = ()
@@ -92,19 +92,19 @@ class MultiPluginSpec
     cluster.execute(
       s"CREATE KEYSPACE IF NOT EXISTS $snapshotKeyspace WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }")
 
-    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-journal-a.write")
-    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-journal-b.write")
-    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-journal-c.write", "cassandra-journal-c.snapshot")
-    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-journal-d.write", "cassandra-journal-d.snapshot")
+    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-plugin-a.journal")
+    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-plugin-b.journal")
+    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-plugin-c.journal", "cassandra-plugin-c.snapshot")
+    CassandraLifecycle.awaitPersistenceInit(system, "cassandra-plugin-d.journal", "cassandra-plugin-d.snapshot")
   }
 
   "A Cassandra journal" must {
     "be usable multiple times with different configurations for two actors having the same persistence id" in {
-      val processorA = system.actorOf(Props(classOf[OverrideJournalPluginProcessor], "cassandra-journal-a.write"))
+      val processorA = system.actorOf(Props(classOf[OverrideJournalPluginProcessor], "cassandra-plugin-a.journal"))
       processorA ! s"msg"
       expectMsgAllOf(s"msg-1")
 
-      val processorB = system.actorOf(Props(classOf[OverrideJournalPluginProcessor], "cassandra-journal-b.write"))
+      val processorB = system.actorOf(Props(classOf[OverrideJournalPluginProcessor], "cassandra-plugin-b.journal"))
       processorB ! s"msg"
       expectMsgAllOf(s"msg-1")
 
@@ -112,7 +112,7 @@ class MultiPluginSpec
       expectMsgAllOf(s"msg-2")
 
       // c is actually a and therefore the next message must be seqNr 2 and not 3
-      val processorC = system.actorOf(Props(classOf[OverrideJournalPluginProcessor], "cassandra-journal-a.write"))
+      val processorC = system.actorOf(Props(classOf[OverrideJournalPluginProcessor], "cassandra-plugin-a.journal"))
       processorC ! s"msg"
       expectMsgAllOf(s"msg-2")
     }
@@ -122,13 +122,13 @@ class MultiPluginSpec
     "be usable multiple times with different configurations for two actors having the same persistence id" in {
       val processorC =
         system.actorOf(
-          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-journal-c.write", "cassandra-journal-c.snapshot"))
+          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-plugin-c.journal", "cassandra-plugin-c.snapshot"))
       processorC ! s"msg"
       expectMsgAllOf(s"msg-1")
 
       val processorD =
         system.actorOf(
-          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-journal-d.write", "cassandra-journal-d.snapshot"))
+          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-plugin-d.journal", "cassandra-plugin-d.snapshot"))
       processorD ! s"msg"
       expectMsgAllOf(s"msg-1")
 
@@ -141,14 +141,14 @@ class MultiPluginSpec
       // e is actually c and therefore the next message must be seqNr 2 after recovery by using the snapshot
       val processorE =
         system.actorOf(
-          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-journal-c.write", "cassandra-journal-c.snapshot"))
+          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-plugin-c.journal", "cassandra-plugin-c.snapshot"))
       processorE ! s"msg"
       expectMsgAllOf(s"msg-2")
 
       // e is actually c and therefore the next message must be seqNr 2 after recovery by using the snapshot
       val processorF =
         system.actorOf(
-          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-journal-d.write", "cassandra-journal-d.snapshot"))
+          Props(classOf[OverrideSnapshotPluginProcessor], "cassandra-plugin-d.journal", "cassandra-plugin-d.snapshot"))
       processorF ! s"msg"
       expectMsgAllOf(s"msg-3")
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
@@ -17,7 +17,7 @@ object RecoveryLoadSpec {
       akka.loglevel = INFO
       cassandra-journal.events-by-tag.enabled = on
       cassandra-journal.events-by-tag.scanning-flush-interval = 2s
-      cassandra-journal.replay-filter.mode = off
+      cassandra-journal.write.replay-filter.mode = off
       cassandra-journal.log-queries = off
       cassandra-snapshot-store.log-queries = off
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
@@ -15,10 +15,10 @@ import scala.concurrent.duration._
 object RecoveryLoadSpec {
   val config = ConfigFactory.parseString(s"""
       akka.loglevel = INFO
-      cassandra-journal.events-by-tag.enabled = on
-      cassandra-journal.events-by-tag.scanning-flush-interval = 2s
-      cassandra-journal.write.replay-filter.mode = off
-      cassandra-journal.log-queries = off
+      cassandra-plugin.events-by-tag.enabled = on
+      cassandra-plugin.events-by-tag.scanning-flush-interval = 2s
+      cassandra-plugin.journal.replay-filter.mode = off
+      cassandra-plugin.log-queries = off
     """).withFallback(CassandraLifecycle.config)
 
   final case class Init(numberOfEvents: Int)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/RecoveryLoadSpec.scala
@@ -19,7 +19,6 @@ object RecoveryLoadSpec {
       cassandra-journal.events-by-tag.scanning-flush-interval = 2s
       cassandra-journal.write.replay-filter.mode = off
       cassandra-journal.log-queries = off
-      cassandra-snapshot-store.log-queries = off
     """).withFallback(CassandraLifecycle.config)
 
   final case class Init(numberOfEvents: Int)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
@@ -12,7 +12,7 @@ object TagScanningSpec {
   val config = ConfigFactory.parseString(s"""
       cassandra-journal.events-by-tag.enabled = on
       cassandra-journal.events-by-tag.scanning-flush-interval = 2s
-      cassandra-journal.replay-filter.mode = off
+      cassandra-journal.write.replay-filter.mode = off
       cassandra-journal.log-queries = off
       cassandra-snapshot-store.log-queries = off
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
@@ -10,10 +10,10 @@ import com.typesafe.config.ConfigFactory
 
 object TagScanningSpec {
   val config = ConfigFactory.parseString(s"""
-      cassandra-journal.events-by-tag.enabled = on
-      cassandra-journal.events-by-tag.scanning-flush-interval = 2s
-      cassandra-journal.write.replay-filter.mode = off
-      cassandra-journal.log-queries = off
+      cassandra-plugin.events-by-tag.enabled = on
+      cassandra-plugin.events-by-tag.scanning-flush-interval = 2s
+      cassandra-plugin.journal.replay-filter.mode = off
+      cassandra-plugin.log-queries = off
     """).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagScanningSpec.scala
@@ -14,7 +14,6 @@ object TagScanningSpec {
       cassandra-journal.events-by-tag.scanning-flush-interval = 2s
       cassandra-journal.write.replay-filter.mode = off
       cassandra-journal.log-queries = off
-      cassandra-snapshot-store.log-queries = off
     """).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
@@ -22,7 +22,7 @@ object AllPersistenceIdsSpec {
   val config = ConfigFactory.parseString(s"""
     cassandra-journal {
       write.target-partition-size = 15
-      read {
+      query {
         max-buffer-size = 10
         refresh-interval = 0.5s
         max-result-size-query = 10

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
@@ -20,8 +20,8 @@ import org.scalatest.BeforeAndAfterEach
 
 object AllPersistenceIdsSpec {
   val config = ConfigFactory.parseString(s"""
-    cassandra-journal {
-      write.target-partition-size = 15
+    cassandra-plugin {
+      journal.target-partition-size = 15
       query {
         max-buffer-size = 10
         refresh-interval = 0.5s
@@ -33,7 +33,7 @@ object AllPersistenceIdsSpec {
 
 class AllPersistenceIdsSpec extends CassandraSpec(AllPersistenceIdsSpec.config) with BeforeAndAfterEach {
 
-  val cfg = system.settings.config.getConfig("cassandra-journal")
+  val cfg = system.settings.config.getConfig("cassandra-plugin")
   val pluginConfig = new CassandraJournalConfig(system, cfg)
 
   override protected def beforeEach() = {

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
@@ -6,29 +6,31 @@ package akka.persistence.cassandra.query
 
 import java.util.UUID
 
+import scala.concurrent.duration._
+
 import akka.NotUsed
 import akka.actor.ActorRef
-import akka.persistence.cassandra.{ CassandraLifecycle, CassandraPluginConfig, CassandraSpec }
+import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.CassandraSpec
+import akka.persistence.cassandra.journal.CassandraJournalConfig
 import akka.stream.scaladsl.Source
 import akka.stream.testkit.scaladsl.TestSink
 import com.typesafe.config.ConfigFactory
 import org.scalatest.BeforeAndAfterEach
-
-import scala.concurrent.duration._
 
 object AllPersistenceIdsSpec {
   val config = ConfigFactory.parseString(s"""
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 10
-    cassandra-journal.target-partition-size = 15
+    cassandra-journal.write.target-partition-size = 15
     """).withFallback(CassandraLifecycle.config)
 }
 
 class AllPersistenceIdsSpec extends CassandraSpec(AllPersistenceIdsSpec.config) with BeforeAndAfterEach {
 
   val cfg = system.settings.config.getConfig("cassandra-journal")
-  val pluginConfig = new CassandraPluginConfig(system, cfg)
+  val pluginConfig = new CassandraJournalConfig(system, cfg)
 
   override protected def beforeEach() = {
     super.beforeEach()

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllPersistenceIdsSpec.scala
@@ -20,10 +20,14 @@ import org.scalatest.BeforeAndAfterEach
 
 object AllPersistenceIdsSpec {
   val config = ConfigFactory.parseString(s"""
-    cassandra-query-journal.max-buffer-size = 10
-    cassandra-query-journal.refresh-interval = 0.5s
-    cassandra-query-journal.max-result-size-query = 10
-    cassandra-journal.write.target-partition-size = 15
+    cassandra-journal {
+      write.target-partition-size = 15
+      read {
+        max-buffer-size = 10
+        refresh-interval = 0.5s
+        max-result-size-query = 10
+      }
+    }  
     """).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/CassandraQueryJournalOverrideSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/CassandraQueryJournalOverrideSpec.scala
@@ -30,7 +30,7 @@ class JournalOverrideProvider(as: ExtendedActorSystem, config: Config, configPat
 object CassandraQueryJournalOverrideSpec {
 
   val config = ConfigFactory.parseString("""
-      cassandra-journal.query {
+      cassandra-plugin.query {
         class = "akka.persistence.cassandra.query.JournalOverrideProvider"
       }
     """.stripMargin).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/CassandraQueryJournalOverrideSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/CassandraQueryJournalOverrideSpec.scala
@@ -27,24 +27,24 @@ class JournalOverrideProvider(as: ExtendedActorSystem, config: Config, configPat
   override def javadslReadJournal() = null
 }
 
-object CassandraReadJournalOverrideSpec {
+object CassandraQueryJournalOverrideSpec {
 
   val config = ConfigFactory.parseString("""
-      cassandra-journal.read {
+      cassandra-journal.query {
         class = "akka.persistence.cassandra.query.JournalOverrideProvider"
       }
     """.stripMargin).withFallback(CassandraLifecycle.config)
 
 }
 
-class CassandraReadJournalOverrideSpec extends CassandraSpec(CassandraReadJournalOverrideSpec.config) {
+class CassandraQueryJournalOverrideSpec extends CassandraSpec(CassandraQueryJournalOverrideSpec.config) {
 
   implicit val materialiser = ActorMaterializer()
 
   lazy val journal =
     PersistenceQuery(system).readJournalFor[JournalOverride](CassandraReadJournal.Identifier)
 
-  "Cassandra read journal override" must {
+  "Cassandra query journal override" must {
     "map events" in {
       val pid = "p1"
       val p1 = system.actorOf(TestTaggingActor.props(pid))

--- a/core/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalOverrideSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/CassandraReadJournalOverrideSpec.scala
@@ -30,7 +30,7 @@ class JournalOverrideProvider(as: ExtendedActorSystem, config: Config, configPat
 object CassandraReadJournalOverrideSpec {
 
   val config = ConfigFactory.parseString("""
-      cassandra-query-journal {
+      cassandra-journal.read {
         class = "akka.persistence.cassandra.query.JournalOverrideProvider"
       }
     """.stripMargin).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/DirectWriting.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/DirectWriting.scala
@@ -25,7 +25,7 @@ trait DirectWriting extends BeforeAndAfterAll {
   def system: ActorSystem
   private lazy val serialization = SerializationExtension(system)
   private lazy val writePluginConfig =
-    new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+    new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
 
   def cluster: CqlSession
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -25,7 +25,7 @@ object EventAdaptersReadSpec {
           "java.lang.String" = test
         }
       } 
-      read {
+      query {
         max-buffer-size = 50
         refresh-interval = 500ms
         max-result-size-query = 2

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -16,9 +16,9 @@ object EventAdaptersReadSpec {
 
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-journal {
+    cassandra-plugin {
       keyspace=EventAdaptersReadSpec
-      write {
+      journal {
         target-partition-size = 15
         event-adapters.test = "akka.persistence.cassandra.query.TestEventAdapter"
         event-adapter-bindings {

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -19,22 +19,24 @@ object EventAdaptersReadSpec {
 
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-journal.keyspace=EventAdaptersReadSpec
-    cassandra-query-journal.max-buffer-size = 10
-    cassandra-query-journal.refresh-interval = 0.5s
-    cassandra-query-journal.max-result-size-query = 2
-    cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.event-adapters.test = "akka.persistence.cassandra.query.TestEventAdapter"
-    cassandra-journal.event-adapter-bindings {
-      "java.lang.String" = test
-    }
-    cassandra-journal.events-by-tag {
-      flush-interval = 0ms
-    }
-    cassandra-query-journal {
-      refresh-interval = 500ms
-      max-buffer-size = 50
-      first-time-bucket = "${today.minusDays(5).format(firstBucketFormatter)}"
+    cassandra-journal {
+      keyspace=EventAdaptersReadSpec
+      write {
+        target-partition-size = 15
+        event-adapters.test = "akka.persistence.cassandra.query.TestEventAdapter"
+        event-adapter-bindings {
+          "java.lang.String" = test
+        }
+      } 
+      read {
+        max-buffer-size = 50
+        refresh-interval = 500ms
+        max-result-size-query = 2
+        first-time-bucket = "${today.minusDays(5).format(firstBucketFormatter)}"
+      }
+      events-by-tag {
+        flush-interval = 0ms
+      }
     }
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -4,8 +4,6 @@
 
 package akka.persistence.cassandra.query
 
-import java.time.{ LocalDateTime, ZoneOffset }
-
 import akka.actor.ActorRef
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec }
 import akka.persistence.query.NoOffset
@@ -15,7 +13,6 @@ import com.typesafe.config.ConfigFactory
 import scala.concurrent.duration._
 
 object EventAdaptersReadSpec {
-  val today = LocalDateTime.now(ZoneOffset.UTC)
 
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
@@ -32,7 +29,6 @@ object EventAdaptersReadSpec {
         max-buffer-size = 50
         refresh-interval = 500ms
         max-result-size-query = 2
-        first-time-bucket = "${today.minusDays(5).format(firstBucketFormatter)}"
       }
       events-by-tag {
         flush-interval = 0ms

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventAdaptersReadSpec.scala
@@ -23,7 +23,7 @@ object EventAdaptersReadSpec {
     cassandra-query-journal.max-buffer-size = 10
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 2
-    cassandra-journal.target-partition-size = 15
+    cassandra-journal.write.target-partition-size = 15
     cassandra-journal.event-adapters.test = "akka.persistence.cassandra.query.TestEventAdapter"
     cassandra-journal.event-adapter-bindings {
       "java.lang.String" = test

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
@@ -17,7 +17,7 @@ object EventsByPersistenceIdFastForwardSpec {
 
   // separate from EventsByPersistenceIdWithControlSpec since it needs the refreshing enabled
   val config = ConfigFactory.parseString(s"""
-    cassandra-journal.keyspace=EventsByPersistenceIdFastForwardSpec
+    cassandra-journal.write.keyspace=EventsByPersistenceIdFastForwardSpec
     cassandra-journal.read.refresh-interval = 250ms
     cassandra-journal.read.max-result-size-query = 2
     cassandra-journal.write.target-partition-size = 15

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
@@ -17,10 +17,10 @@ object EventsByPersistenceIdFastForwardSpec {
 
   // separate from EventsByPersistenceIdWithControlSpec since it needs the refreshing enabled
   val config = ConfigFactory.parseString(s"""
-    cassandra-journal.write.keyspace=EventsByPersistenceIdFastForwardSpec
-    cassandra-journal.query.refresh-interval = 250ms
-    cassandra-journal.query.max-result-size-query = 2
-    cassandra-journal.write.target-partition-size = 15
+    cassandra-plugin.journal.keyspace=EventsByPersistenceIdFastForwardSpec
+    cassandra-plugin.query.refresh-interval = 250ms
+    cassandra-plugin.query.max-result-size-query = 2
+    cassandra-plugin.journal.target-partition-size = 15
     """).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
@@ -18,8 +18,8 @@ object EventsByPersistenceIdFastForwardSpec {
   // separate from EventsByPersistenceIdWithControlSpec since it needs the refreshing enabled
   val config = ConfigFactory.parseString(s"""
     cassandra-journal.keyspace=EventsByPersistenceIdFastForwardSpec
-    cassandra-query-journal.refresh-interval = 250ms
-    cassandra-query-journal.max-result-size-query = 2
+    cassandra-journal.read.refresh-interval = 250ms
+    cassandra-journal.read.max-result-size-query = 2
     cassandra-journal.write.target-partition-size = 15
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
@@ -20,7 +20,7 @@ object EventsByPersistenceIdFastForwardSpec {
     cassandra-journal.keyspace=EventsByPersistenceIdFastForwardSpec
     cassandra-query-journal.refresh-interval = 250ms
     cassandra-query-journal.max-result-size-query = 2
-    cassandra-journal.target-partition-size = 15
+    cassandra-journal.write.target-partition-size = 15
     """).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdFastForwardSpec.scala
@@ -18,8 +18,8 @@ object EventsByPersistenceIdFastForwardSpec {
   // separate from EventsByPersistenceIdWithControlSpec since it needs the refreshing enabled
   val config = ConfigFactory.parseString(s"""
     cassandra-journal.write.keyspace=EventsByPersistenceIdFastForwardSpec
-    cassandra-journal.read.refresh-interval = 250ms
-    cassandra-journal.read.max-result-size-query = 2
+    cassandra-journal.query.refresh-interval = 250ms
+    cassandra-journal.query.max-result-size-query = 2
     cassandra-journal.write.target-partition-size = 15
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
@@ -14,11 +14,11 @@ import com.typesafe.config.ConfigFactory
 object EventsByPersistenceIdMultiPartitionGapSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
-    cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.query.refresh-interval = 0.5s
-    cassandra-journal.query.max-result-size-query = 2
-    cassandra-journal.query.events-by-persistence-id-gap-timeout = 4 seconds
-    cassandra-journal.query.gap-free-sequence-numbers = off
+    cassandra-plugin.journal.target-partition-size = 15
+    cassandra-plugin.query.refresh-interval = 0.5s
+    cassandra-plugin.query.max-result-size-query = 2
+    cassandra-plugin.query.events-by-persistence-id-gap-timeout = 4 seconds
+    cassandra-plugin.query.gap-free-sequence-numbers = off
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
@@ -14,11 +14,11 @@ import com.typesafe.config.ConfigFactory
 object EventsByPersistenceIdMultiPartitionGapSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
-    cassandra-query-journal.refresh-interval = 0.5s
-    cassandra-query-journal.max-result-size-query = 2
-    cassandra-query-journal.events-by-persistence-id-gap-timeout = 4 seconds
     cassandra-journal.write.target-partition-size = 15
-    cassandra-query-journal.gap-free-sequence-numbers = off
+    cassandra-journal.read.refresh-interval = 0.5s
+    cassandra-journal.read.max-result-size-query = 2
+    cassandra-journal.read.events-by-persistence-id-gap-timeout = 4 seconds
+    cassandra-journal.read.gap-free-sequence-numbers = off
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
@@ -15,10 +15,10 @@ object EventsByPersistenceIdMultiPartitionGapSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
     cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.read.refresh-interval = 0.5s
-    cassandra-journal.read.max-result-size-query = 2
-    cassandra-journal.read.events-by-persistence-id-gap-timeout = 4 seconds
-    cassandra-journal.read.gap-free-sequence-numbers = off
+    cassandra-journal.query.refresh-interval = 0.5s
+    cassandra-journal.query.max-result-size-query = 2
+    cassandra-journal.query.events-by-persistence-id-gap-timeout = 4 seconds
+    cassandra-journal.query.gap-free-sequence-numbers = off
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdMultiPartitionGapSpec.scala
@@ -17,7 +17,7 @@ object EventsByPersistenceIdMultiPartitionGapSpec {
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 2
     cassandra-query-journal.events-by-persistence-id-gap-timeout = 4 seconds
-    cassandra-journal.target-partition-size = 15
+    cassandra-journal.write.target-partition-size = 15
     cassandra-query-journal.gap-free-sequence-numbers = off
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -20,9 +20,9 @@ import scala.concurrent.duration._
 object EventsByPersistenceIdSpec {
   val config = ConfigFactory.parseString(s"""
     cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.read.refresh-interval = 0.5s
-    cassandra-journal.read.max-result-size-query = 2
-    cassandra-journal.read.events-by-persistence-id-gap-timeout = 4 seconds
+    cassandra-journal.query.refresh-interval = 0.5s
+    cassandra-journal.query.max-result-size-query = 2
+    cassandra-journal.query.events-by-persistence-id-gap-timeout = 4 seconds
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -19,10 +19,10 @@ import scala.concurrent.duration._
 
 object EventsByPersistenceIdSpec {
   val config = ConfigFactory.parseString(s"""
-    cassandra-query-journal.refresh-interval = 0.5s
-    cassandra-query-journal.max-result-size-query = 2
-    cassandra-query-journal.events-by-persistence-id-gap-timeout = 4 seconds
     cassandra-journal.write.target-partition-size = 15
+    cassandra-journal.read.refresh-interval = 0.5s
+    cassandra-journal.read.max-result-size-query = 2
+    cassandra-journal.read.events-by-persistence-id-gap-timeout = 4 seconds
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -19,10 +19,10 @@ import scala.concurrent.duration._
 
 object EventsByPersistenceIdSpec {
   val config = ConfigFactory.parseString(s"""
-    cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.query.refresh-interval = 0.5s
-    cassandra-journal.query.max-result-size-query = 2
-    cassandra-journal.query.events-by-persistence-id-gap-timeout = 4 seconds
+    cassandra-plugin.journal.target-partition-size = 15
+    cassandra-plugin.query.refresh-interval = 0.5s
+    cassandra-plugin.query.max-result-size-query = 2
+    cassandra-plugin.query.events-by-persistence-id-gap-timeout = 4 seconds
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -22,7 +22,7 @@ object EventsByPersistenceIdSpec {
     cassandra-query-journal.refresh-interval = 0.5s
     cassandra-query-journal.max-result-size-query = 2
     cassandra-query-journal.events-by-persistence-id-gap-timeout = 4 seconds
-    cassandra-journal.target-partition-size = 15
+    cassandra-journal.write.target-partition-size = 15
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
@@ -18,8 +18,8 @@ object EventsByPersistenceIdWithControlSpec {
   val config = ConfigFactory.parseString(s"""
     cassandra-journal.write.keyspace=EventsByPersistenceIdWithControlSpec
     cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.read.refresh-interval = 120s # effectively disabled
-    cassandra-journal.read.max-result-size-query = 20
+    cassandra-journal.query.refresh-interval = 120s # effectively disabled
+    cassandra-journal.query.max-result-size-query = 20
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
@@ -16,7 +16,7 @@ import scala.concurrent.duration._
 
 object EventsByPersistenceIdWithControlSpec {
   val config = ConfigFactory.parseString(s"""
-    cassandra-journal.keyspace=EventsByPersistenceIdWithControlSpec
+    cassandra-journal.write.keyspace=EventsByPersistenceIdWithControlSpec
     cassandra-journal.write.target-partition-size = 15
     cassandra-journal.read.refresh-interval = 120s # effectively disabled
     cassandra-journal.read.max-result-size-query = 20

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
@@ -19,7 +19,7 @@ object EventsByPersistenceIdWithControlSpec {
     cassandra-journal.keyspace=EventsByPersistenceIdWithControlSpec
     cassandra-query-journal.refresh-interval = 120s # effectively disabled
     cassandra-query-journal.max-result-size-query = 20
-    cassandra-journal.target-partition-size = 15
+    cassandra-journal.write.target-partition-size = 15
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
@@ -17,9 +17,9 @@ import scala.concurrent.duration._
 object EventsByPersistenceIdWithControlSpec {
   val config = ConfigFactory.parseString(s"""
     cassandra-journal.keyspace=EventsByPersistenceIdWithControlSpec
-    cassandra-query-journal.refresh-interval = 120s # effectively disabled
-    cassandra-query-journal.max-result-size-query = 20
     cassandra-journal.write.target-partition-size = 15
+    cassandra-journal.read.refresh-interval = 120s # effectively disabled
+    cassandra-journal.read.max-result-size-query = 20
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdWithControlSpec.scala
@@ -16,10 +16,10 @@ import scala.concurrent.duration._
 
 object EventsByPersistenceIdWithControlSpec {
   val config = ConfigFactory.parseString(s"""
-    cassandra-journal.write.keyspace=EventsByPersistenceIdWithControlSpec
-    cassandra-journal.write.target-partition-size = 15
-    cassandra-journal.query.refresh-interval = 120s # effectively disabled
-    cassandra-journal.query.max-result-size-query = 20
+    cassandra-plugin.journal.keyspace=EventsByPersistenceIdWithControlSpec
+    cassandra-plugin.journal.target-partition-size = 15
+    cassandra-plugin.query.refresh-interval = 120s # effectively disabled
+    cassandra-plugin.query.max-result-size-query = 20
     akka.stream.materializer.max-input-buffer-size = 4 # there is an async boundary
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
@@ -28,7 +28,7 @@ object EventsByTagPubsubSpec {
     cassandra-journal {
       pubsub-notification = on
       
-      read.refresh-interval = 10s
+      query.refresh-interval = 10s
 
       events-by-tag {
         flush-interval = 0ms

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
@@ -27,14 +27,11 @@ object EventsByTagPubsubSpec {
     akka.remote.netty.tcp.hostname = "127.0.0.1"
     cassandra-journal {
       pubsub-notification = on
+      
+      read.refresh-interval = 10s
 
       events-by-tag {
         flush-interval = 0ms
-      }
-    }
-    cassandra-query-journal {
-      refresh-interval = 10s
-      events-by-tag {
         eventual-consistency-delay = 0s
       }
     }

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagPubsubSpec.scala
@@ -25,7 +25,7 @@ object EventsByTagPubsubSpec {
     akka.remote.netty.tcp.port = 0
     akka.remote.artery.canonical.port = 0
     akka.remote.netty.tcp.hostname = "127.0.0.1"
-    cassandra-journal {
+    cassandra-plugin {
       pubsub-notification = on
       
       query.refresh-interval = 10s
@@ -40,7 +40,7 @@ object EventsByTagPubsubSpec {
 
 class EventsByTagPubsubSpec extends CassandraSpec(EventsByTagPubsubSpec.config) {
 
-  val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+  val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
 
   override protected def beforeAll(): Unit = {
     super.beforeAll()

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -45,7 +45,7 @@ object EventsByTagSpec {
     akka.actor.serialize-messages = off
     akka.actor.warn-about-java-serializer-usage = off
     cassandra-journal {
-      #target-partition-size = 5
+      #write.target-partition-size = 5
 
       event-adapters {
         color-tagger  = akka.persistence.cassandra.query.ColorFruitTagger

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -109,7 +109,7 @@ object EventsByTagSpec {
 
   val disabledConfig = ConfigFactory.parseString("""
       cassandra-journal {
-        keyspace=EventsByTagDisabled
+        write.keyspace=EventsByTagDisabled
         events-by-tag.enabled = false
       }
     """).withFallback(config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -59,7 +59,7 @@ object EventsByTagSpec {
         }
       }
       
-      read {
+      query {
         refresh-interval = 500ms
         max-buffer-size = 50
         first-time-bucket = "${today.minusDays(5).format(firstBucketFormatter)}"
@@ -78,7 +78,7 @@ object EventsByTagSpec {
 
   val strictConfig = ConfigFactory.parseString(s"""
     cassandra-journal {
-      read.refresh-interval = 100ms
+      query.refresh-interval = 100ms
       events-by-tag {
         gap-timeout = 5s
         new-persistence-id-scan-timeout = 200s
@@ -89,7 +89,7 @@ object EventsByTagSpec {
 
   val strictConfigFirstOffset1001DaysAgo = ConfigFactory.parseString(s"""
     akka.loglevel = INFO # DEBUG is very verbose for this test so don't turn it on when debugging other tests
-    cassandra-journal.read.first-time-bucket = "${today.minusDays(1001).format(firstBucketFormatter)}"
+    cassandra-journal.query.first-time-bucket = "${today.minusDays(1001).format(firstBucketFormatter)}"
     """).withFallback(strictConfig)
 
   val persistenceIdCleanupConfig =
@@ -516,7 +516,7 @@ class EventsByTagSpec extends AbstractEventsByTagSpec(EventsByTagSpec.config) {
 
 class EventsByTagZeroEventualConsistencyDelaySpec
     extends AbstractEventsByTagSpec(ConfigFactory.parseString("""
-            cassandra-journal.read.eventual-consistency-delay = 0s
+            cassandra-journal.query.eventual-consistency-delay = 0s
           """).withFallback(EventsByTagSpec.strictConfig)) {
 
   "Cassandra query currentEventsByTag with zero eventual-consistency-delay" must {
@@ -807,7 +807,7 @@ class EventsByTagLongRefreshIntervalSpec
       ConfigFactory.parseString("""
      akka.loglevel = INFO 
      cassandra-journal {
-       read.refresh-interval = 10s # set large enough so that it will fail the test if a refresh is required to continue the stream
+       query.refresh-interval = 10s # set large enough so that it will fail the test if a refresh is required to continue the stream
        events-by-tag {
          gap-timeout = 30s
          offset-scanning-period = 0ms # do no scanning so each new persistence id triggers the search
@@ -1046,7 +1046,7 @@ class EventsByTagStrictBySeqMemoryIssueSpec extends AbstractEventsByTagSpec(Even
 class EventsByTagSpecBackTrackingLongRefreshInterval
     extends AbstractEventsByTagSpec(
       ConfigFactory.parseString("""
-    cassandra-journal.read.refresh-interval = 10s
+    cassandra-journal.query.refresh-interval = 10s
     cassandra-journal.events-by-tag {
      back-track {
         interval = 500ms
@@ -1091,7 +1091,7 @@ class EventsByTagSpecBackTracking
     extends AbstractEventsByTagSpec(
       ConfigFactory.parseString("""
 // this slows down the test too much for all the expectNexts
-//  cassandra-journal.read.refresh-interval = 4s
+//  cassandra-journal.query.refresh-interval = 4s
     cassandra-journal.events-by-tag {
      back-track {
         interval = 1s

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -45,40 +45,40 @@ object EventsByTagSpec {
     akka.actor.serialize-messages = off
     akka.actor.warn-about-java-serializer-usage = off
     cassandra-journal {
-      #write.target-partition-size = 5
+      write {
+        #target-partition-size = 5
 
-      event-adapters {
-        color-tagger  = akka.persistence.cassandra.query.ColorFruitTagger
-        metadata-tagger  = akka.persistence.cassandra.query.EventWithMetaDataTagger
+        event-adapters {
+          color-tagger  = akka.persistence.cassandra.query.ColorFruitTagger
+          metadata-tagger  = akka.persistence.cassandra.query.EventWithMetaDataTagger
+        }
+  
+        event-adapter-bindings = {
+          "java.lang.String" = color-tagger
+          "akka.persistence.cassandra.EventWithMetaData" = metadata-tagger
+        }
       }
-
-      event-adapter-bindings = {
-        "java.lang.String" = color-tagger
-        "akka.persistence.cassandra.EventWithMetaData" = metadata-tagger
+      
+      read {
+        refresh-interval = 500ms
+        max-buffer-size = 50
+        first-time-bucket = "${today.minusDays(5).format(firstBucketFormatter)}"
       }
 
       events-by-tag {
         flush-interval = 0ms
+        eventual-consistency-delay = 2s
         bucket-size = Day
         time-to-live = 1d
       }
 
       # coordinated-shutdown-on-error = on
     }
-
-    cassandra-query-journal {
-      refresh-interval = 500ms
-      max-buffer-size = 50
-      first-time-bucket = "${today.minusDays(5).format(firstBucketFormatter)}"
-      events-by-tag {
-        eventual-consistency-delay = 2s
-      }
-    }
     """).withFallback(CassandraLifecycle.config)
 
   val strictConfig = ConfigFactory.parseString(s"""
-    cassandra-query-journal {
-      refresh-interval = 100ms
+    cassandra-journal {
+      read.refresh-interval = 100ms
       events-by-tag {
         gap-timeout = 5s
         new-persistence-id-scan-timeout = 200s
@@ -89,12 +89,12 @@ object EventsByTagSpec {
 
   val strictConfigFirstOffset1001DaysAgo = ConfigFactory.parseString(s"""
     akka.loglevel = INFO # DEBUG is very verbose for this test so don't turn it on when debugging other tests
-    cassandra-query-journal.first-time-bucket = "${today.minusDays(1001).format(firstBucketFormatter)}"
+    cassandra-journal.read.first-time-bucket = "${today.minusDays(1001).format(firstBucketFormatter)}"
     """).withFallback(strictConfig)
 
   val persistenceIdCleanupConfig =
     ConfigFactory.parseString("""
-       cassandra-query-journal.events-by-tag {
+       cassandra-journal.events-by-tag {
           eventual-consistency-delay = 0s
           # will test by requiring a new persistence-id search every 2s
           new-persistence-id-scan-timeout = 500ms
@@ -516,7 +516,7 @@ class EventsByTagSpec extends AbstractEventsByTagSpec(EventsByTagSpec.config) {
 
 class EventsByTagZeroEventualConsistencyDelaySpec
     extends AbstractEventsByTagSpec(ConfigFactory.parseString("""
-            cassandra-query-journal.eventual-consistency-delay = 0s
+            cassandra-journal.read.eventual-consistency-delay = 0s
           """).withFallback(EventsByTagSpec.strictConfig)) {
 
   "Cassandra query currentEventsByTag with zero eventual-consistency-delay" must {
@@ -564,8 +564,8 @@ class EventsByTagFindDelayedEventsSpec
 # find delayed events from offset relies on this as it puts an event before the offset that will not
 # be found and one after that will be found for a new persistence id
 # have it at least 2x the interval so searching for missing tries trice
-cassandra-query-journal.events-by-tag.new-persistence-id-scan-timeout = 600ms
-cassandra-query-journal.events-by-tag.refresh-internal = 100ms
+cassandra-journal.events-by-tag.new-persistence-id-scan-timeout = 600ms
+cassandra-journal.events-by-tag.refresh-internal = 100ms
 
 """)
         .withFallback(EventsByTagSpec.strictConfig)) {
@@ -806,14 +806,14 @@ class EventsByTagLongRefreshIntervalSpec
     extends AbstractEventsByTagSpec(
       ConfigFactory.parseString("""
      akka.loglevel = INFO 
-     cassandra-query-journal {
-      refresh-interval = 10s # set large enough so that it will fail the test if a refresh is required to continue the stream
-      events-by-tag {
-        gap-timeout = 30s
-        offset-scanning-period = 0ms # do no scanning so each new persistence id triggers the search
-        eventual-consistency-delay = 0ms  # speed up the test
-      }
-    } 
+     cassandra-journal {
+       read.refresh-interval = 10s # set large enough so that it will fail the test if a refresh is required to continue the stream
+       events-by-tag {
+         gap-timeout = 30s
+         offset-scanning-period = 0ms # do no scanning so each new persistence id triggers the search
+         eventual-consistency-delay = 0ms  # speed up the test
+       }
+     } 
      """).withFallback(config)) {
 
   override protected val logCheck: PartialFunction[Any, Any] = {
@@ -1046,8 +1046,8 @@ class EventsByTagStrictBySeqMemoryIssueSpec extends AbstractEventsByTagSpec(Even
 class EventsByTagSpecBackTrackingLongRefreshInterval
     extends AbstractEventsByTagSpec(
       ConfigFactory.parseString("""
-    cassandra-query-journal.refresh-interval = 10s
-    cassandra-query-journal.events-by-tag {
+    cassandra-journal.read.refresh-interval = 10s
+    cassandra-journal.events-by-tag {
      back-track {
         interval = 500ms
         period = max
@@ -1091,8 +1091,8 @@ class EventsByTagSpecBackTracking
     extends AbstractEventsByTagSpec(
       ConfigFactory.parseString("""
 // this slows down the test too much for all the expectNexts
-//  cassandra-query-journal.refresh-interval = 4s
-    cassandra-query-journal.events-by-tag {
+//  cassandra-journal.read.refresh-interval = 4s
+    cassandra-journal.events-by-tag {
      back-track {
         interval = 1s
         period = 10m

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -37,18 +37,18 @@ object EventsByTagStageSpec {
 
         cassandra-journal {
           log-queries = off
-          events-by-tag {
-           flush-interval = 0ms
-           bucket-size = Minute
-          }
-        }
 
-        cassandra-query-journal {
-          first-time-bucket = "${today.minusMinutes(5).format(firstBucketFormatter)}"
-          max-result-size-query = $fetchSize
-          log-queries = on
-          refresh-interval = 200ms
+          read {
+            first-time-bucket = "${today.minusMinutes(5).format(firstBucketFormatter)}"
+            max-result-size-query = $fetchSize
+            log-queries = on
+            refresh-interval = 200ms
+          }
+          
           events-by-tag {
+            flush-interval = 0ms
+            bucket-size = Minute
+          
             # Speeds up tests
             eventual-consistency-delay = ${eventualConsistencyDelay.toMillis}ms
             gap-timeout = 5s

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -34,7 +34,7 @@ object EventsByTagStageSpec {
   val config = ConfigFactory.parseString(s"""
         akka.actor.serialize-messages=on
 
-        cassandra-journal {
+        cassandra-plugin {
           log-queries = off
 
           query {
@@ -66,7 +66,7 @@ class EventsByTagStageSpec
 
   import EventsByTagStageSpec._
 
-  val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+  val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
   val serialization: Serialization = SerializationExtension(system)
 
   private val bucketSize = Minute

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -26,7 +26,6 @@ import scala.annotation.tailrec
 import scala.concurrent.duration._
 
 object EventsByTagStageSpec {
-  val today = LocalDateTime.now(ZoneOffset.UTC)
   val fetchSize = 3L
   val eventualConsistencyDelay: FiniteDuration = 400.millis
   val waitTime: FiniteDuration = (eventualConsistencyDelay * 1.5).asInstanceOf[FiniteDuration] // bigger than the eventual consistency delay but less than the new pid timeout
@@ -39,7 +38,6 @@ object EventsByTagStageSpec {
           log-queries = off
 
           read {
-            first-time-bucket = "${today.minusMinutes(5).format(firstBucketFormatter)}"
             max-result-size-query = $fetchSize
             log-queries = on
             refresh-interval = 200ms

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagStageSpec.scala
@@ -37,7 +37,7 @@ object EventsByTagStageSpec {
         cassandra-journal {
           log-queries = off
 
-          read {
+          query {
             max-result-size-query = $fetchSize
             log-queries = on
             refresh-interval = 200ms

--- a/core/src/test/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScannerSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScannerSpec.scala
@@ -28,7 +28,7 @@ object TagViewSequenceNumberScannerSpec {
   val bucketSize = Hour
   val name = "EventsByTagSequenceNumberScanningSpec"
   val config = ConfigFactory.parseString(s"""
-      |cassandra-journal.events-by-tag.bucket-size = ${bucketSize.toString}
+      |cassandra-plugin.events-by-tag.bucket-size = ${bucketSize.toString}
     """.stripMargin).withFallback(CassandraLifecycle.config)
 }
 
@@ -38,7 +38,7 @@ class TagViewSequenceNumberScannerSpec extends CassandraSpec(config) with TestTa
 
   implicit override val patienceConfig = PatienceConfig(timeout = Span(5, Seconds), interval = Span(1, Seconds))
 
-  val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-journal"))
+  val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
   val serialization: Serialization = SerializationExtension(system)
 
   before {

--- a/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
@@ -13,7 +13,7 @@ import akka.persistence.cassandra.EventWithMetaData
 import akka.persistence.journal.Tagged
 
 object TestActor {
-  def props(persistenceId: String, journalId: String = "cassandra-journal.write"): Props =
+  def props(persistenceId: String, journalId: String = "cassandra-plugin.journal"): Props =
     Props(new TestActor(persistenceId, journalId))
 
   final case class PersistAll(events: immutable.Seq[String])

--- a/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
@@ -13,7 +13,7 @@ import akka.persistence.cassandra.EventWithMetaData
 import akka.persistence.journal.Tagged
 
 object TestActor {
-  def props(persistenceId: String, journalId: String = "cassandra-journal"): Props =
+  def props(persistenceId: String, journalId: String = "cassandra-journal.write"): Props =
     Props(new TestActor(persistenceId, journalId))
 
   final case class PersistAll(events: immutable.Seq[String])

--- a/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
@@ -16,12 +16,12 @@ import scala.concurrent.duration._
 object CassandraReadJournalSpec {
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-query-journal.max-buffer-size = 10
-    cassandra-query-journal.refresh-interval = 0.5s
-    cassandra-journal.event-adapters {
+    cassandra-journal.read.max-buffer-size = 10
+    cassandra-journal.read.refresh-interval = 0.5s
+    cassandra-journal.write.event-adapters {
       test-tagger = akka.persistence.cassandra.query.javadsl.TestTagger
     }
-    cassandra-journal.event-adapter-bindings = {
+    cassandra-journal.write.event-adapter-bindings = {
       "java.lang.String" = test-tagger
     }
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
@@ -16,12 +16,12 @@ import scala.concurrent.duration._
 object CassandraReadJournalSpec {
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-journal.query.max-buffer-size = 10
-    cassandra-journal.query.refresh-interval = 0.5s
-    cassandra-journal.write.event-adapters {
+    cassandra-plugin.query.max-buffer-size = 10
+    cassandra-plugin.query.refresh-interval = 0.5s
+    cassandra-plugin.journal.event-adapters {
       test-tagger = akka.persistence.cassandra.query.javadsl.TestTagger
     }
-    cassandra-journal.write.event-adapter-bindings = {
+    cassandra-plugin.journal.event-adapter-bindings = {
       "java.lang.String" = test-tagger
     }
     """).withFallback(CassandraLifecycle.config)

--- a/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/javadsl/CassandraReadJournalSpec.scala
@@ -16,8 +16,8 @@ import scala.concurrent.duration._
 object CassandraReadJournalSpec {
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-journal.read.max-buffer-size = 10
-    cassandra-journal.read.refresh-interval = 0.5s
+    cassandra-journal.query.max-buffer-size = 10
+    cassandra-journal.query.refresh-interval = 0.5s
     cassandra-journal.write.event-adapters {
       test-tagger = akka.persistence.cassandra.query.javadsl.TestTagger
     }

--- a/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -17,15 +17,15 @@ import scala.concurrent.duration._
 object CassandraReadJournalSpec {
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-journal.query.max-buffer-size = 10
-    cassandra-journal.query.refresh-interval = 0.5s
-    cassandra-journal.write.event-adapters {
+    cassandra-plugin.query.max-buffer-size = 10
+    cassandra-plugin.query.refresh-interval = 0.5s
+    cassandra-plugin.journal.event-adapters {
       test-tagger = akka.persistence.cassandra.query.scaladsl.TestTagger
     }
-    cassandra-journal.write.event-adapter-bindings = {
+    cassandra-plugin.journal.event-adapter-bindings = {
       "java.lang.String" = test-tagger
     }
-    cassandra-journal.log-queries = off
+    cassandra-plugin.log-queries = off
     """).withFallback(CassandraLifecycle.config)
 }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -17,12 +17,12 @@ import scala.concurrent.duration._
 object CassandraReadJournalSpec {
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-query-journal.max-buffer-size = 10
-    cassandra-query-journal.refresh-interval = 0.5s
-    cassandra-journal.event-adapters {
+    cassandra-journal.read.max-buffer-size = 10
+    cassandra-journal.read.refresh-interval = 0.5s
+    cassandra-journal.write.event-adapters {
       test-tagger = akka.persistence.cassandra.query.scaladsl.TestTagger
     }
-    cassandra-journal.event-adapter-bindings = {
+    cassandra-journal.write.event-adapter-bindings = {
       "java.lang.String" = test-tagger
     }
     cassandra-journal.log-queries = off

--- a/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -17,8 +17,8 @@ import scala.concurrent.duration._
 object CassandraReadJournalSpec {
   val config = ConfigFactory.parseString(s"""
     akka.actor.serialize-messages=off
-    cassandra-journal.read.max-buffer-size = 10
-    cassandra-journal.read.refresh-interval = 0.5s
+    cassandra-journal.query.max-buffer-size = 10
+    cassandra-journal.query.refresh-interval = 0.5s
     cassandra-journal.write.event-adapters {
       test-tagger = akka.persistence.cassandra.query.scaladsl.TestTagger
     }

--- a/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 object CassandraSessionSpec {
 
   lazy val config = ConfigFactory.parseString(s"""
-      cassandra-journal.keyspace=CassandraSessionSpec
+      cassandra-journal.write.keyspace=CassandraSessionSpec
     """).withFallback(CassandraLifecycle.config)
 
 }
@@ -45,7 +45,8 @@ class CassandraSessionSpec extends CassandraSpec(CassandraSessionSpec.config) {
       system.dispatcher,
       log,
       "CassandraSessionSpec-metrics",
-      (s: CqlSession) => s.executeAsync(s"USE ${cfg.getString("keyspace")};").toScala.map(_ => Done.getInstance).toJava)
+      (s: CqlSession) =>
+        s.executeAsync(s"USE ${cfg.getString("write.keyspace")};").toScala.map(_ => Done.getInstance).toJava)
   }
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration._
 object CassandraSessionSpec {
 
   lazy val config = ConfigFactory.parseString(s"""
-      cassandra-journal.write.keyspace=CassandraSessionSpec
+      cassandra-plugin.journal.keyspace=CassandraSessionSpec
     """).withFallback(CassandraLifecycle.config)
 
 }
@@ -38,7 +38,7 @@ class CassandraSessionSpec extends CassandraSpec(CassandraSessionSpec.config) {
   val log = Logging.getLogger(system, this.getClass)
 
   lazy val session: CassandraSession = {
-    val cfg = system.settings.config.withFallback(system.settings.config.getConfig("cassandra-journal"))
+    val cfg = system.settings.config.withFallback(system.settings.config.getConfig("cassandra-plugin"))
     new CassandraSession(
       system,
       new DefaultSessionProvider(system, cfg),
@@ -46,7 +46,7 @@ class CassandraSessionSpec extends CassandraSpec(CassandraSessionSpec.config) {
       log,
       "CassandraSessionSpec-metrics",
       (s: CqlSession) =>
-        s.executeAsync(s"USE ${cfg.getString("write.keyspace")};").toScala.map(_ => Done.getInstance).toJava)
+        s.executeAsync(s"USE ${cfg.getString("journal.keyspace")};").toScala.map(_ => Done.getInstance).toJava)
   }
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
@@ -18,7 +18,7 @@ class CassandraSnapshotCleanupSpec extends CassandraSpec {
   private val log = Logging(system, getClass)
   val snapshotCleanup = new CassandraSnapshotCleanup {
     override def snapshotConfig: CassandraSnapshotStoreConfig =
-      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-journal"))
+      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-plugin"))
     override val session: CassandraSession = new CassandraSession(
       system,
       snapshotConfig.sessionProvider,

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
@@ -18,7 +18,7 @@ class CassandraSnapshotCleanupSpec extends CassandraSpec {
   private val log = Logging(system, getClass)
   val snapshotCleanup = new CassandraSnapshotCleanup {
     override def snapshotConfig: CassandraSnapshotStoreConfig =
-      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-snapshot-store"))
+      new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-journal"))
     override val session: CassandraSession = new CassandraSession(
       system,
       snapshotConfig.sessionProvider,

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -22,7 +22,7 @@ import scala.collection.immutable.Seq
 
 object CassandraSnapshotStoreConfiguration {
   lazy val config = ConfigFactory.parseString(s"""
-       cassandra-journal.keyspace=CassandraSnapshotStoreSpec
+       cassandra-journal.write.keyspace=CassandraSnapshotStoreSpec
        cassandra-journal.snapshot.keyspace=CassandraSnapshotStoreSpecSnapshot
     """).withFallback(CassandraLifecycle.config)
 }

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -22,8 +22,8 @@ import scala.collection.immutable.Seq
 
 object CassandraSnapshotStoreConfiguration {
   lazy val config = ConfigFactory.parseString(s"""
-       cassandra-journal.write.keyspace=CassandraSnapshotStoreSpec
-       cassandra-journal.snapshot.keyspace=CassandraSnapshotStoreSpecSnapshot
+       cassandra-plugin.journal.keyspace=CassandraSnapshotStoreSpec
+       cassandra-plugin.snapshot.keyspace=CassandraSnapshotStoreSpecSnapshot
     """).withFallback(CassandraLifecycle.config)
 }
 
@@ -32,7 +32,7 @@ class CassandraSnapshotStoreSpec
     with CassandraLifecycle {
 
   val storeConfig =
-    new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-journal"))
+    new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-plugin"))
 
   val storeStatements = new CassandraStatements {
     def snapshotConfig = storeConfig

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -23,7 +23,7 @@ import scala.collection.immutable.Seq
 object CassandraSnapshotStoreConfiguration {
   lazy val config = ConfigFactory.parseString(s"""
        cassandra-journal.keyspace=CassandraSnapshotStoreSpec
-       cassandra-snapshot-store.keyspace=CassandraSnapshotStoreSpecSnapshot
+       cassandra-journal.snapshot.keyspace=CassandraSnapshotStoreSpecSnapshot
     """).withFallback(CassandraLifecycle.config)
 }
 
@@ -32,7 +32,7 @@ class CassandraSnapshotStoreSpec
     with CassandraLifecycle {
 
   val storeConfig =
-    new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-snapshot-store"))
+    new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-journal"))
 
   val storeStatements = new CassandraStatements {
     def snapshotConfig = storeConfig

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -36,7 +36,7 @@ To detect missed events without receiving another event for the same persistence
 to find events. Queries are run in the background to detect delayed events. A high frequency short back track is done
 for finding events delayed a small amount and a low frequency backtrack that scans further back. 
 
-These are configured with `cassandra-query-journal.events-by-tag.back-track`:
+These are configured with `cassandra-journal.query.events-by-tag.back-track`:
 
 @@snip [refernce.conf](/core/src/main/resources/reference.conf) { #backtrack }                                                                                                                                
 
@@ -66,14 +66,14 @@ Enable pub sub notifications so events by tag queries can execute a query right 
 query.
 ```
 cassandra-journal.pubsub-notification = on
-cassandra-query-journal.refresh-interval = 2s
+cassandra-journal.query.refresh-interval = 2s
 ```
 
 Reduce `eventual-consistency-delay`. You must test this has positive results for your use case. Setting this too low
 can decrease throughput and latency as more events will be missed initially and expensive searches carried out.
 
 ```
-cassandra-query-journal.events-by-tag.eventual-consistency-delay = 50ms
+cassandra-journal.events-by-tag.eventual-consistency-delay = 50ms
 ```
 
 ### Missing searches and gap detection

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -36,7 +36,7 @@ To detect missed events without receiving another event for the same persistence
 to find events. Queries are run in the background to detect delayed events. A high frequency short back track is done
 for finding events delayed a small amount and a low frequency backtrack that scans further back. 
 
-These are configured with `cassandra-journal.query.events-by-tag.back-track`:
+These are configured with `cassandra-plugin.query.events-by-tag.back-track`:
 
 @@snip [refernce.conf](/core/src/main/resources/reference.conf) { #backtrack }                                                                                                                                
 
@@ -55,7 +55,7 @@ depending on the load and performance of your Cassandra cluster.
 Flush the tag writes right away. By default they are batched and written as an unlogged back which increases throughput. To write each individually
 without delay use:
 ```
-cassandra-journal.events-by-tag.flush-interval = 0s
+cassandra-plugin.events-by-tag.flush-interval = 0s
 ```
 
 Alternatively set a very small value e.g. `25ms` so some batching is done. If your applicaion has a large number of tagged events per second
@@ -65,15 +65,15 @@ Enable pub sub notifications so events by tag queries can execute a query right 
 `refresh-interval`. Lower the `refresh-interval` for cases where the pub sub messages take a long time to arrive at the
 query.
 ```
-cassandra-journal.pubsub-notification = on
-cassandra-journal.query.refresh-interval = 2s
+cassandra-plugin.pubsub-notification = on
+cassandra-plugin.query.refresh-interval = 2s
 ```
 
 Reduce `eventual-consistency-delay`. You must test this has positive results for your use case. Setting this too low
 can decrease throughput and latency as more events will be missed initially and expensive searches carried out.
 
 ```
-cassandra-journal.events-by-tag.eventual-consistency-delay = 50ms
+cassandra-plugin.events-by-tag.eventual-consistency-delay = 50ms
 ```
 
 ### Missing searches and gap detection
@@ -113,7 +113,7 @@ getting to large.
 * 100,000s  of events per day per tag -- Hour
 * 1,000,000s of events per day per tag -- Minute
  
-The default is `Hour` and can be overridden by setting `cassandra-journal.events-by-tag.bucket-size`.
+The default is `Hour` and can be overridden by setting `cassandra-plugin.events-by-tag.bucket-size`.
 This setting can not be changed after data has been written.
  
 More billion per day per tag? You probably need a specialised schema rather than a general library like this.

--- a/docs/src/main/paradox/getting-started.md
+++ b/docs/src/main/paradox/getting-started.md
@@ -28,4 +28,4 @@ To include the latest release of the Cassandra plugins for **Akka 2.4.x** into y
 
 This version of `akka-persistence-cassandra` depends on Akka 2.4.20. It has been published for Scala 2.11 and 2.12.
 
-Those versions are compatible with Cassandra 3.0.0 or higher, and it is also compatible with Cassandra 2.1.6 or higher (versions < 2.1.6 have a static column bug) if you configure `cassandra-journal.cassandra-2x-compat=on` in your `application.conf`.
+Those versions are compatible with Cassandra 3.0.0 or higher, and it is also compatible with Cassandra 2.1.6 or higher (versions < 2.1.6 have a static column bug) if you configure `cassandra-plugin.cassandra-2x-compat=on` in your `application.conf`.

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -12,7 +12,7 @@
 
 To activate the journal plugin, add the following line to your Akka `application.conf`:
 
-    akka.persistence.journal.plugin = "cassandra-journal"
+    akka.persistence.journal.plugin = "cassandra-journal.write"
 
 This will run the journal with its default settings. The default settings can be changed with the configuration properties defined in [reference.conf](https://github.com/akka/akka-persistence-cassandra/blob/master/core/src/main/resources/reference.conf):
 

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -12,7 +12,7 @@
 
 To activate the journal plugin, add the following line to your Akka `application.conf`:
 
-    akka.persistence.journal.plugin = "cassandra-journal.write"
+    akka.persistence.journal.plugin = "cassandra-plugin.journal"
 
 This will run the journal with its default settings. The default settings can be changed with the configuration properties defined in [reference.conf](https://github.com/akka/akka-persistence-cassandra/blob/master/core/src/main/resources/reference.conf):
 

--- a/docs/src/main/paradox/migrations.md
+++ b/docs/src/main/paradox/migrations.md
@@ -14,7 +14,7 @@ All driver related configuration e.g. query consistency, query retries etc has b
 project's `reference.conf` and now each part of the plugin (journal, snapshot and query) specify a read and write 
 [execution profile](https://docs.datastax.com/en/developer/java-driver/4.3/manual/core/configuration/#execution-profiles) that gives
 fine grained control over consistencies and retires for each are. By default all read/write profiles are the same and under
-`datastax-java-driver.profile.cassandra-journal`. The only value in the profile provided by the plugin is setting the `basic.request.consistency`
+`datastax-java-driver.profile.cassandra-plugin`. The only value in the profile provided by the plugin is setting the `basic.request.consistency`
 to `QUORUM`.
 
 The new driver supports reconnection during initialization which was previously built into the plugin. It is recommended to turn this on with:
@@ -24,10 +24,10 @@ It can't be turned on by the plugin as it is in the driver's reference.conf and 
 #### Changed configuration structure
 
 In addition to the driver related configuration described above the overall configuration structure has been changed.
-It is now structured in four main sections within the top level `cassandra-journal` section:
+It is now structured in four main sections within the top level `cassandra-plugin` section:
 
-    cassandra-journal {
-      write {
+    cassandra-plugin {
+      journal {
       }
       query {
       }
@@ -42,8 +42,8 @@ for details and update your `application.conf` accordingly.
 
 This also means that the properties for enabling the plugin have changed to:
 
-    akka.persistence.journal.plugin = "cassandra-journal.write"
-    akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
+    akka.persistence.journal.plugin = "cassandra-plugin.journal"
+    akka.persistence.snapshot-store.plugin = "cassandra-plugin.snapshot"
 
 #### Removals
 
@@ -81,7 +81,7 @@ After complete roll out of 0.101 in step 1 the configuration can be changed so t
 at all.
 
 ```
-cassandra-journal.write-static-column-compat = off
+cassandra-plugin.journal-static-column-compat = off
 ```
 
 It can still run with an old schema where the column exists. 
@@ -195,7 +195,7 @@ It is also not required to add the materialized views, not even if the meta data
 If you don't alter existing messages table and still use `tables-autocreate=on` you have to set config:
 
 ```
-cassandra-journal.meta-in-events-by-tag-view = off
+cassandra-plugin.meta-in-events-by-tag-view = off
 ``` 
 
 When trying to create the materialized view (tables-autocreate=on) with the meta columns before corresponding columns have been added the messages table an exception "Undefined column name meta_ser_id" is raised, because Cassandra validates the ["CREATE MATERIALIZED VIEW IF NOT EXISTS"](https://docs.datastax.com/en/cql/3.3/cql/cql_reference/cqlCreateMaterializedView.html#cqlCreateMaterializedView__if-not-exists) even though the view already exists and will not be created. To work around that issue you can disable the meta columns in the materialized view by setting `meta-in-events-by-tag-view=off`.

--- a/docs/src/main/paradox/migrations.md
+++ b/docs/src/main/paradox/migrations.md
@@ -21,6 +21,30 @@ The new driver supports reconnection during initialization which was previously 
 `datastax-java-driver.advanced.reconnect-on-init = true`
 It can't be turned on by the plugin as it is in the driver's reference.conf and is not overridable in a profile.
 
+#### Changed configuration structure
+
+In addition to the driver related configuration described above the overall configuration structure has been changed.
+It is now structured in four main sections within the top level `cassandra-journal` section:
+
+    cassandra-journal {
+      write {
+      }
+      query {
+      }
+      events-by-tag {
+      }
+      snapshot {
+      }
+    }
+
+See [reference.conf](https://github.com/akka/akka-persistence-cassandra/blob/master/core/src/main/resources/reference.conf)
+for details and update your `application.conf` accordingly.
+
+This also means that the properties for enabling the plugin have changed to:
+
+    akka.persistence.journal.plugin = "cassandra-journal.write"
+    akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
+
 #### Removals
 
 Using DateTieredCompactionStrategy with automatic schema creation

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -8,7 +8,7 @@
 
 To activate the snapshot-store plugin, add the following line to your Akka `application.conf`:
 
-    akka.persistence.snapshot-store.plugin = "cassandra-snapshot-store"
+    akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
 
 This will run the snapshot store with its default settings. The default settings can be changed with the configuration properties defined in [reference.conf](https://github.com/akka/akka-persistence-cassandra/blob/master/core/src/main/resources/reference.conf):
 

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -8,7 +8,7 @@
 
 To activate the snapshot-store plugin, add the following line to your Akka `application.conf`:
 
-    akka.persistence.snapshot-store.plugin = "cassandra-journal.snapshot"
+    akka.persistence.snapshot-store.plugin = "cassandra-plugin.snapshot"
 
 This will run the snapshot store with its default settings. The default settings can be changed with the configuration properties defined in [reference.conf](https://github.com/akka/akka-persistence-cassandra/blob/master/core/src/main/resources/reference.conf):
 

--- a/dse-test/src/test/scala/akka/persistence/cassandra/JournalDseSpec.scala
+++ b/dse-test/src/test/scala/akka/persistence/cassandra/JournalDseSpec.scala
@@ -5,11 +5,11 @@ import com.typesafe.config.ConfigFactory
 
 object JournalDseSpec {
   val config = ConfigFactory.parseString(s"""
-   cassandra-journal.write.keyspace=JournalDseSpec
-   cassandra-journal.snapshot.keyspace=JournalDseSpec
+   cassandra-plugin.journal.keyspace=JournalDseSpec
+   cassandra-plugin.snapshot.keyspace=JournalDseSpec
                                  
    //# override-session-provider
-   cassandra-journal {
+   cassandra-plugin {
      session-provider = "your.pack.DseSessionProvider"
    }
    //# override-session-provider

--- a/dse-test/src/test/scala/akka/persistence/cassandra/JournalDseSpec.scala
+++ b/dse-test/src/test/scala/akka/persistence/cassandra/JournalDseSpec.scala
@@ -6,7 +6,7 @@ import com.typesafe.config.ConfigFactory
 object JournalDseSpec {
   val config = ConfigFactory.parseString(s"""
    cassandra-journal.keyspace=JournalDseSpec
-   cassandra-snapshot-store.keyspace=JournalDseSpec
+   cassandra-journal.snapshot.keyspace=JournalDseSpec
                                  
    //# override-session-provider
    cassandra-journal {

--- a/dse-test/src/test/scala/akka/persistence/cassandra/JournalDseSpec.scala
+++ b/dse-test/src/test/scala/akka/persistence/cassandra/JournalDseSpec.scala
@@ -5,7 +5,7 @@ import com.typesafe.config.ConfigFactory
 
 object JournalDseSpec {
   val config = ConfigFactory.parseString(s"""
-   cassandra-journal.keyspace=JournalDseSpec
+   cassandra-journal.write.keyspace=JournalDseSpec
    cassandra-journal.snapshot.keyspace=JournalDseSpec
                                  
    //# override-session-provider


### PR DESCRIPTION
Following the same structure as the Couchbase plugin
```
cassandra-journal {
  # common properties here
  write {
  }
  read {
  }
  events-by-tag {
  }
  snapshot {
  }
}
```

TODO:
- [x] A few fixmes
- [x] Docs and migration guide

Refs #81