### PR TITLE
Share CassandraSession between write, query, snapshot, #242

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -5,12 +5,9 @@
 package akka.persistence.cassandra
 
 import akka.actor.ActorSystem
-import akka.actor.ExtendedActorSystem
-import akka.cassandra.session.CqlSessionProvider
 import com.typesafe.config.Config
 
 class CassandraPluginConfig(system: ActorSystem, config: Config) {
-  val sessionProvider: CqlSessionProvider = CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], config)
 
   // TODO this is now only used when deciding how to delete, remove this config and just
   // query what version of cassandra we're connected to and do the right thing

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraStatements.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.annotation.InternalApi
+import akka.persistence.cassandra.journal.CassandraJournalConfig
+import akka.persistence.cassandra.journal.CassandraJournalStatements
+import akka.persistence.cassandra.snapshot.CassandraSnapshotStatements
+import akka.persistence.cassandra.snapshot.CassandraSnapshotStoreConfig
+import com.datastax.oss.driver.api.core.CqlSession
+
+@InternalApi
+private[akka] trait CassandraStatements {
+  def config: CassandraJournalConfig // FIXME rename to journalConfig, or create one single CassandraSettings holding everything
+  def snapshotConfig: CassandraSnapshotStoreConfig
+
+  val journalStatements: CassandraJournalStatements = new CassandraJournalStatements {
+    override def config: CassandraJournalConfig = CassandraStatements.this.config
+  }
+
+  val snapshotStatements: CassandraSnapshotStatements = new CassandraSnapshotStatements {
+    override def snapshotConfig: CassandraSnapshotStoreConfig = CassandraStatements.this.snapshotConfig
+  }
+
+  def executeAllCreateKeyspaceAndTables(session: CqlSession)(implicit ec: ExecutionContext): Future[Done] = {
+    for {
+      _ <- journalStatements.executeCreateKeyspaceAndTables(session)
+      _ <- snapshotStatements.executeCreateKeyspaceAndTables(session)
+    } yield Done
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -15,7 +15,7 @@ import scala.concurrent.{ ExecutionContext, Future }
 
 import java.lang.{ Long => JLong }
 
-private[akka] trait CassandraEventUpdate extends CassandraStatements {
+private[akka] trait CassandraEventUpdate extends CassandraJournalStatements {
 
   private[akka] val session: CassandraSession
   private[akka] def config: CassandraJournalConfig

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -171,8 +171,8 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
     createTablesStatements.asJava
   }
 
-  private def statements: CassandraStatements =
-    new CassandraStatements {
+  private def statements: CassandraJournalStatements =
+    new CassandraJournalStatements {
       override def config: CassandraJournalConfig = CassandraJournalConfig.this
     }
 }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TaggedPreparedStatements.scala
@@ -9,7 +9,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait TaggedPreparedStatements extends CassandraStatements {
+trait TaggedPreparedStatements extends CassandraJournalStatements {
   private[akka] val session: CassandraSession
   private[akka] implicit val ec: ExecutionContext
 

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanup.scala
@@ -13,7 +13,7 @@ import com.datastax.oss.driver.api.core.cql.PreparedStatement
 
 import scala.concurrent.{ ExecutionContext, Future }
 
-trait CassandraSnapshotCleanup extends CassandraStatements {
+trait CassandraSnapshotCleanup extends CassandraSnapshotStatements {
 
   def snapshotConfig: CassandraSnapshotStoreConfig
   def session: CassandraSession

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreConfig.scala
@@ -88,8 +88,8 @@ class CassandraSnapshotStoreConfig(system: ActorSystem, config: Config) extends 
     createTablesStatements.asJava
   }
 
-  private def statements: CassandraStatements =
-    new CassandraStatements {
+  private def statements: CassandraSnapshotStatements =
+    new CassandraSnapshotStatements {
       override def snapshotConfig: CassandraSnapshotStoreConfig =
         CassandraSnapshotStoreConfig.this
     }

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -9,7 +9,7 @@ import java.lang.{ Long => JLong }
 
 import akka.actor.{ ActorSystem, PoisonPill }
 import akka.persistence.cassandra.TestTaggingActor.Ack
-import akka.persistence.cassandra.journal.{ CassandraJournalConfig, CassandraStatements, Hour, TimeBucket }
+import akka.persistence.cassandra.journal.{ CassandraJournalConfig, CassandraJournalStatements, Hour, TimeBucket }
 import akka.persistence.cassandra.query.DirectWriting
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.{ EventEnvelope, NoOffset, PersistenceQuery }
@@ -352,7 +352,7 @@ abstract class AbstractEventsByTagMigrationSpec
        |CREATE KEYSPACE IF NOT EXISTS $journalName WITH replication = {'class': 'SimpleStrategy', 'replication_factor': 1 }
      """.stripMargin
 
-  val statements = new CassandraStatements {
+  val statements = new CassandraJournalStatements {
     override def config: CassandraJournalConfig =
       new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
   }

--- a/core/src/test/scala/akka/persistence/cassandra/query/DirectWriting.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/DirectWriting.scala
@@ -9,7 +9,7 @@ import java.nio.ByteBuffer
 import akka.actor.ActorSystem
 import akka.persistence.PersistentRepr
 import akka.persistence.cassandra.journal.CassandraJournalConfig
-import akka.persistence.cassandra.journal.CassandraStatements
+import akka.persistence.cassandra.journal.CassandraJournalStatements
 import akka.persistence.cassandra.journal.Hour
 import akka.persistence.cassandra.journal.TimeBucket
 import akka.serialization.SerializationExtension
@@ -29,7 +29,7 @@ trait DirectWriting extends BeforeAndAfterAll {
 
   def cluster: CqlSession
 
-  private lazy val writeStatements: CassandraStatements = new CassandraStatements {
+  private lazy val writeStatements: CassandraJournalStatements = new CassandraJournalStatements {
     def config: CassandraJournalConfig = writePluginConfig
   }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -11,7 +11,7 @@ import java.util.UUID
 
 import akka.actor.{ PoisonPill, Props }
 import akka.event.Logging.Warning
-import akka.persistence.cassandra.journal.{ CassandraJournalConfig, CassandraStatements, Day }
+import akka.persistence.cassandra.journal.{ CassandraJournalConfig, CassandraJournalStatements, Day }
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec, EventWithMetaData }
 import akka.persistence.journal.{ Tagged, WriteEventAdapter }
 import akka.persistence.query.scaladsl.{ CurrentEventsByTagQuery, EventsByTagQuery }
@@ -152,7 +152,7 @@ abstract class AbstractEventsByTagSpec(config: Config)
   val writePluginConfig = new CassandraJournalConfig(system, system.settings.config.getConfig("cassandra-plugin"))
 
   lazy val preparedWriteMessage = {
-    val writeStatements: CassandraStatements = new CassandraStatements {
+    val writeStatements: CassandraJournalStatements = new CassandraJournalStatements {
       def config: CassandraJournalConfig = writePluginConfig
     }
     cluster.prepare(writeStatements.writeMessage(withMeta = false))

--- a/core/src/test/scala/akka/persistence/cassandra/query/TestTagWriter.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/TestTagWriter.scala
@@ -24,7 +24,7 @@ private[akka] trait TestTagWriter {
   val writePluginConfig: CassandraJournalConfig
 
   lazy val (preparedWriteTagMessage, preparedWriteTagMessageWithMeta) = {
-    val writeStatements: CassandraStatements = new CassandraStatements {
+    val writeStatements: CassandraJournalStatements = new CassandraJournalStatements {
       def config: CassandraJournalConfig = writePluginConfig
     }
     (cluster.prepare(writeStatements.writeTags(false)), cluster.prepare(writeStatements.writeTags(true)))

--- a/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournalSpec.scala
@@ -79,8 +79,7 @@ class CassandraReadJournalSpec extends CassandraSpec(CassandraReadJournalSpec.co
 
     "insert Cassandra metrics to Cassandra Metrics Registry" in {
       val registry = CassandraMetricsRegistry(system).getRegistry
-      val snapshots =
-        registry.getNames.toArray().filter(value => value.toString.startsWith(s"${CassandraReadJournal.Identifier}"))
+      val snapshots = registry.getNames.toArray().filter(value => value.toString.startsWith("cassandra-plugin"))
       snapshots.length should be > 0
     }
   }

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStoreSpec.scala
@@ -34,7 +34,7 @@ class CassandraSnapshotStoreSpec
   val storeConfig =
     new CassandraSnapshotStoreConfig(system, system.settings.config.getConfig("cassandra-plugin"))
 
-  val storeStatements = new CassandraStatements {
+  val storeStatements = new CassandraSnapshotStatements {
     def snapshotConfig = storeConfig
   }
 

--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSessionRegistry.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSessionRegistry.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cassandra.session.javadsl
+
+import java.util.concurrent.CompletionStage
+import java.util.function.{ Function => JFunction }
+
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.ExecutionContext
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.cassandra.session.javadsl
+import akka.cassandra.session.scaladsl
+import com.datastax.oss.driver.api.core.CqlSession
+
+/**
+ * This Cassandra session registry makes it possible to share Cassandra sessions between multiple use sites
+ * in the same `ActorSystem` (important for the Cassandra Akka Persistence plugin where it is shared between journal,
+ * query plugin and snapshot plugin)
+ */
+object CassandraSessionRegistry {
+
+  /**
+   * Java API: get the session registry
+   */
+  def get(system: ActorSystem): CassandraSessionRegistry =
+    new javadsl.CassandraSessionRegistry(scaladsl.CassandraSessionRegistry(system))
+
+}
+
+final class CassandraSessionRegistry private (delegate: scaladsl.CassandraSessionRegistry) {
+
+  /**
+   * Get an existing session or start a new one with the given settings,
+   * makes it possible to share one session across plugins.
+   *
+   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
+   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   */
+  def sessionFor(configPath: String, executionContext: ExecutionContext): CassandraSession =
+    new CassandraSession(delegate.sessionFor(configPath, executionContext))
+
+  /**
+   * Get an existing session or start a new one with the given settings,
+   * makes it possible to share one session across plugins.
+   *
+   * The `init` function will be performed once when the session is created, i.e.
+   * if `sessionFor` is called from multiple places with different `init` it will
+   * only execute the first.
+   *
+   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
+   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   */
+  def sessionFor(
+      configPath: String,
+      executionContext: ExecutionContext,
+      init: JFunction[CqlSession, CompletionStage[Done]]): CassandraSession = {
+    new CassandraSession(delegate.sessionFor(configPath, executionContext, ses => init(ses).toScala))
+  }
+}

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
@@ -4,12 +4,9 @@
 
 package akka.cassandra.session.scaladsl
 
-import java.util.concurrent.atomic.AtomicReference
-
 import scala.collection.immutable
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
-import scala.concurrent.Promise
 import scala.util.Success
 import akka.Done
 import akka.NotUsed
@@ -338,31 +335,6 @@ final class CassandraSession(
             case _ =>
           }
       }
-  }
-
-}
-
-/**
- * INTERNAL API
- */
-@InternalApi private[akka] object CassandraSession {
-  private val serializedExecutionProgress =
-    new AtomicReference[Future[Done]](FutureDone)
-
-  def serializedExecution(recur: () => Future[Done], exec: () => Future[Done])(
-      implicit ec: ExecutionContext): Future[Done] = {
-    val progress = serializedExecutionProgress.get
-    val p = Promise[Done]()
-    progress.onComplete { _ =>
-      val result =
-        if (serializedExecutionProgress.compareAndSet(progress, p.future))
-          exec()
-        else
-          recur()
-      p.completeWith(result)
-      result
-    }
-    p.future
   }
 
 }

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSessionRegistry.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSessionRegistry.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.cassandra.session.scaladsl
+
+import java.util.concurrent.ConcurrentHashMap
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.Future
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.actor.ExtensionId
+import akka.actor.ExtensionIdProvider
+import akka.cassandra.session.CqlSessionProvider
+import akka.event.Logging
+import com.datastax.oss.driver.api.core.CqlSession
+
+/**
+ * This Cassandra session registry makes it possible to share Cassandra sessions between multiple use sites
+ * in the same `ActorSystem` (important for the Cassandra Akka Persistence plugin where it is shared between journal,
+ * query plugin and snapshot plugin)
+ */
+object CassandraSessionRegistry extends ExtensionId[CassandraSessionRegistry] with ExtensionIdProvider {
+
+  def createExtension(system: ExtendedActorSystem): CassandraSessionRegistry =
+    new CassandraSessionRegistry(system)
+
+  /**
+   * Java API: get the session registry
+   */
+  override def get(system: ActorSystem): CassandraSessionRegistry =
+    super.get(system)
+
+  override def lookup(): ExtensionId[CassandraSessionRegistry] = this
+
+  private case class SessionKey(configPath: String)
+}
+
+final class CassandraSessionRegistry(system: ExtendedActorSystem) extends Extension {
+
+  import CassandraSessionRegistry.SessionKey
+
+  private val sessions = new ConcurrentHashMap[SessionKey, CassandraSession]
+
+  /**
+   * Get an existing session or start a new one with the given settings,
+   * makes it possible to share one session across plugins.
+   *
+   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
+   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   */
+  def sessionFor(configPath: String, executionContext: ExecutionContext): CassandraSession =
+    sessionFor(configPath, executionContext, _ => Future.successful(Done))
+
+  /**
+   * Get an existing session or start a new one with the given settings,
+   * makes it possible to share one session across plugins.
+   *
+   * The `init` function will be performed once when the session is created, i.e.
+   * if `sessionFor` is called from multiple places with different `init` it will
+   * only execute the first.
+   *
+   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
+   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   */
+  def sessionFor(
+      configPath: String,
+      executionContext: ExecutionContext,
+      init: CqlSession => Future[Done]): CassandraSession = {
+    val key = SessionKey(configPath)
+    sessions.computeIfAbsent(key, _ => startSession(key, init, executionContext))
+  }
+
+  /**
+   * Java API: Get an existing session or start a new one with the given settings,
+   * makes it possible to share one session across plugins.
+   *
+   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
+   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   */
+  // FIXME in javadsl: def getSessionFor(configPath: String): CompletionStage[JCassandraSession] =
+
+  private def startSession(
+      key: SessionKey,
+      init: CqlSession => Future[Done],
+      executionContext: ExecutionContext): CassandraSession = {
+    val sessionProvider = CqlSessionProvider(system, system.settings.config.getConfig(key.configPath))
+    val log = Logging(system, classOf[CassandraSession])
+    new CassandraSession(system, sessionProvider, executionContext, log, metricsCategory = key.configPath, init)
+  }
+
+}

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSessionRegistry.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSessionRegistry.scala
@@ -75,15 +75,6 @@ final class CassandraSessionRegistry(system: ExtendedActorSystem) extends Extens
     sessions.computeIfAbsent(key, _ => startSession(key, init, executionContext))
   }
 
-  /**
-   * Java API: Get an existing session or start a new one with the given settings,
-   * makes it possible to share one session across plugins.
-   *
-   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
-   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
-   */
-  // FIXME in javadsl: def getSessionFor(configPath: String): CompletionStage[JCassandraSession] =
-
   private def startSession(
       key: SessionKey,
       init: CqlSession => Future[Done],


### PR DESCRIPTION
* share same connnection and thread pool
* same, and all, executeCreateKeyspaceAndTables, must be performed
  from all 3 places since the init is only performed once per CassandraSession
* serializedExecution not needed any more

Refs #242
