### PR TITLE
use write journal read-profile for recovery eventsByPersistenceId

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -237,6 +237,7 @@ class EventsByTagMigration(
                   Long.MaxValue,
                   Long.MaxValue,
                   None,
+                  config.readProfile,
                   s"migrateToTag-$pid",
                   extractor =
                     EventsByTagMigration.rawPayloadOldTagSchemaExtractor(config.bucketSize, eventDeserializer, system))

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -614,6 +614,7 @@ class CassandraJournal(cfg: Config, cfgPath: String)
         highestDeletedSequenceNumber,
         1,
         None,
+        config.readProfile,
         "asyncReadLowestSequenceNr",
         extractor = Extractors.sequenceNumber(eventDeserializer, serialization))
       .map(_.sequenceNr)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraRecovery.scala
@@ -65,6 +65,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
               toSequenceNr,
               max,
               None,
+              config.readProfile,
               "asyncReplayMessages",
               extractor = Extractors.taggedPersistentRepr(eventDeserializer, serialization))
             .mapAsync(1)(sendMissingTagWrite(tp, tagWrites.get))
@@ -81,6 +82,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
           toSequenceNr,
           max,
           None,
+          config.readProfile,
           "asyncReplayMessages",
           extractor = Extractors.persistentRepr(eventDeserializer, serialization))
         .map(p => queries.mapEvent(p.persistentRepr))
@@ -109,6 +111,7 @@ trait CassandraRecovery extends CassandraTagRecovery with TaggedPreparedStatemen
           scanTo,
           max,
           None,
+          config.readProfile,
           "asyncReplayMessagesPreSnapshot",
           Extractors.optionalTaggedPersistentRepr(eventDeserializer, serialization))
         .mapAsync(1) { t =>

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -245,6 +245,7 @@ abstract class CassandraSpec(
         Long.MaxValue,
         100,
         None,
+        readProfile = "cassandra-journal",
         "test",
         extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
       .toMat(Sink.seq)(Keep.right)
@@ -259,6 +260,7 @@ abstract class CassandraSpec(
         Long.MaxValue,
         100,
         None,
+        readProfile = "cassandra-journal",
         "test",
         extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
       .map { tpr =>


### PR DESCRIPTION
* read-profile of the queries may be configured differently, e.g. without quorum

