### PR TITLE
Akka Discovery-based session provider

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,6 +15,7 @@ object Dependencies {
   val akkaCassandraSessionDependencies = Seq(
     ("com.datastax.oss" % "java-driver-core" % DriverVersion).exclude("com.github.spotbugs", "spotbugs-annotations"),
     "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
+    "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided,
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
     "com.typesafe.akka" %% "akka-slf4j" % AkkaVersion % Test,
     "org.scalatest" %% "scalatest" % "3.1.0" % Test,

--- a/session/src/main/scala/akka/stream/alpakka/cassandra/AkkaDiscoverySessionProvider.scala
+++ b/session/src/main/scala/akka/stream/alpakka/cassandra/AkkaDiscoverySessionProvider.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.stream.alpakka.cassandra
+
+import akka.actor.ActorSystem
+import akka.discovery.Discovery
+import akka.dispatch.ExecutionContexts
+import akka.util.JavaDurationConverters._
+import com.datastax.oss.driver.api.core.CqlSession
+import com.typesafe.config.{ Config, ConfigFactory }
+
+import scala.collection.immutable
+import scala.compat.java8.FutureConverters._
+import scala.concurrent.duration.FiniteDuration
+import scala.concurrent.{ ExecutionContext, Future }
+
+/**
+ * A [[CqlSessionProvider]] implementation which builds a `CqlSession` from the given `config`
+ * with contact points provided via [[https://doc.akka.io/docs/akka/current/discovery/index.html Akka Discovery]].
+ *
+ * The configuration for the driver is typically the `datastax-java-driver` section of the ActorSystem's
+ * configuration, but it's possible to use other configuration. The configuration path of the
+ * driver's configuration can be defined with `datastax-java-driver-config` property in the
+ * given `config`.
+ *
+ * Akka Discovery overwrites the `basic.contact-points` from the configuration with addresses
+ * provided by the configured Akka Discovery mechanism.
+ *
+ * Example using config-based Akka Discovery:
+ * ```
+ * akka {
+ *   discovery.method = config
+ * }
+ * akka.discovery.config.services = {
+ *   cassandra-service = {
+ *     endpoints = [
+ *       {
+ *         host = "127.0.0.1"
+ *         port = 9042
+ *       },
+ *       {
+ *         host = "127.0.0.2"
+ *         port = 9042
+ *       }
+ *     ]
+ *   }
+ * }
+ * my-cassandra-session {
+ *   session-provider = "akka.cassandra.session.AkkaDiscoverySessionProvider"
+ *   service {
+ *     name = "cassandra-service"
+ *     lookup-timeout = 1 s
+ *   }
+ *   # Full config path to the Datastax Java driver's configuration section.
+ *   # When connecting to more than one Cassandra cluster different session configuration can be
+ *   # defined with this property.
+ *   datastax-java-driver-config = "datastax-java-driver"
+ * }
+ * ```
+ *
+ * Look up this  `CassandraSession` with
+ * ```
+ * CassandraSessionRegistry
+ *   .get(system)
+ *   .sessionFor(CassandraSessionSettings.create("my-cassandra-session"), system.dispatcher)
+ * ```
+ */
+class AkkaDiscoverySessionProvider(system: ActorSystem, config: Config) extends CqlSessionProvider {
+
+  /**
+   * Use Akka Discovery to read the addresses for `serviceName` within `lookupTimeout`.
+   */
+  private def readNodes(serviceName: String, lookupTimeout: FiniteDuration)(
+      implicit system: ActorSystem): Future[immutable.Seq[String]] = {
+    Discovery(system).discovery
+      .lookup(serviceName, lookupTimeout)
+      .map { resolved =>
+        resolved.addresses.map(target => target.host + ":" + target.port)
+      }(ExecutionContexts.sameThreadExecutionContext)
+  }
+
+  /**
+   * Expect a `service` section in Config and use Akka Discovery to read the addresses for `name` within `lookup-timeout`.
+   */
+  private def readNodes(config: Config)(implicit system: ActorSystem): Future[immutable.Seq[String]] = {
+    val serviceConfig = config.getConfig("service")
+    val serviceName = serviceConfig.getString("name")
+    val lookupTimeout = serviceConfig.getDuration("lookup-timeout").asScala
+    readNodes(serviceName, lookupTimeout)
+  }
+
+  override def connect()(implicit ec: ExecutionContext): Future[CqlSession] = {
+    val driverConfig = CqlSessionProvider.driverConfig(system, config)
+    val sessionName =
+      if (driverConfig.hasPath("basic.session-name")) driverConfig.getString("basic.session-name")
+      else ""
+    require(sessionName != null && sessionName.nonEmpty, s"driver config needs to set a non-empty `basic.session-name`")
+
+    readNodes(config)(system).flatMap { contactPoints =>
+      val driverConfigWithContactPoints = ConfigFactory.parseString(s"""
+        basic.contact-points = [${contactPoints.mkString("\"", "\", \"", "\"")}]
+        """).withFallback(driverConfig)
+
+      val driverConfigLoader = DriverConfigLoaderFromConfig.fromConfig(driverConfigWithContactPoints)
+      CqlSession.builder().withConfigLoader(driverConfigLoader).buildAsync().toScala
+    }
+  }
+
+}

--- a/session/src/main/scala/akka/stream/alpakka/cassandra/CqlSessionProvider.scala
+++ b/session/src/main/scala/akka/stream/alpakka/cassandra/CqlSessionProvider.scala
@@ -5,23 +5,13 @@
 package akka.stream.alpakka.cassandra
 
 import akka.actor.{ ActorSystem, ExtendedActorSystem }
-import akka.discovery.Discovery
-import akka.dispatch.ExecutionContexts
-import akka.util.unused
-import akka.util.JavaDurationConverters._
-import akka.event.Logging
 import com.datastax.oss.driver.api.core.CqlSession
-import com.typesafe.config.Config
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{ Config, ConfigFactory }
+
 import scala.collection.immutable
+import scala.compat.java8.FutureConverters._
 import scala.concurrent.{ ExecutionContext, Future }
 import scala.util.Failure
-import scala.compat.java8.FutureConverters._
-import scala.collection.JavaConverters._
-import com.datastax.oss.driver.api.core.CqlSession
-import com.datastax.oss.driver.api.core.config.{ DefaultDriverOption, DriverConfigLoader }
-
-import scala.concurrent.duration.FiniteDuration
 
 /**
  * The implementation of the `SessionProvider` is used for creating the
@@ -54,78 +44,6 @@ class DefaultSessionProvider(system: ActorSystem, config: Config) extends CqlSes
     val driverConfigLoader = DriverConfigLoaderFromConfig.fromConfig(driverConfig)
     builder.withConfigLoader(driverConfigLoader).buildAsync().toScala
   }
-}
-
-/**
- * ```
- * akka {
- *   discovery.method = config
- * }
- * akka.discovery.config.services = {
- *   cassandra-service = {
- *     endpoints = [
- *       {
- *         host = "127.0.0.1"
- *         port = 9042
- *       },
- *       {
- *         host = "127.0.0.2"
- *         port = 9042
- *       }
- *     ]
- *   }
- * }
- * my-cassandra-session {
- *   session-provider = "akka.cassandra.session.AkkaDiscoverySessionProvider"
- *   session-name = "my-session"
- *   service {
- *     name = "cassandra-service"
- *     lookup-timeout = 1 s
- *   }
- * }
- * ```
- */
-class AkkaDiscoverySessionProvider(system: ActorSystem, config: Config) extends CqlSessionProvider {
-
-  /**
-   * Use Akka Discovery to read the addresses for `serviceName` within `lookupTimeout`.
-   */
-  private def readNodes(serviceName: String, lookupTimeout: FiniteDuration)(
-      implicit system: ActorSystem): Future[immutable.Seq[String]] = {
-    Discovery(system).discovery
-      .lookup(serviceName, lookupTimeout)
-      .map { resolved =>
-        resolved.addresses.map(target => target.host + ":" + target.port)
-      }(ExecutionContexts.sameThreadExecutionContext)
-  }
-
-  /**
-   * Expect a `service` section in Config and use Akka Discovery to read the addresses for `name` within `lookup-timeout`.
-   */
-  private def readNodes(config: Config)(implicit system: ActorSystem): Future[immutable.Seq[String]] = {
-    val serviceConfig = config.getConfig("service")
-    val serviceName = serviceConfig.getString("name")
-    val lookupTimeout = serviceConfig.getDuration("lookup-timeout").asScala
-    readNodes(serviceName, lookupTimeout)
-  }
-
-  override def connect()(implicit ec: ExecutionContext): Future[CqlSession] = {
-    val driverConfig = CqlSessionProvider.driverConfig(system, config)
-    val sessionName =
-      if (driverConfig.hasPath("basic.session-name")) driverConfig.getString("basic.session-name")
-      else ""
-    require(sessionName != null && sessionName.nonEmpty, s"driver config needs to set a non-empty `basic.session-name`")
-
-    readNodes(config)(system).flatMap { contactPoints =>
-      val driverConfigWithContactPoints = ConfigFactory.parseString(s"""
-        basic.contact-points = [${contactPoints.mkString("\"", "\", \"", "\"")}]
-        """).withFallback(driverConfig)
-
-      val driverConfigLoader = DriverConfigLoaderFromConfig.fromConfig(driverConfigWithContactPoints)
-      CqlSession.builder().withConfigLoader(driverConfigLoader).buildAsync().toScala
-    }
-  }
-
 }
 
 object CqlSessionProvider {


### PR DESCRIPTION
## Purpose

Add a CQL session provider that reads Cassandra contact points via Akka Discovery.

## References

#653 
[Alpakka Couchbase with Akka Discovery](https://doc.akka.io/docs/alpakka/current/couchbase.html#using-akka-discovery)
[Alpakka Kafka with Akka Discovery](https://doc.akka.io/docs/alpakka-kafka/current/discovery.html)
[Akka Discovery](https://doc.akka.io/docs/akka/current/discovery/index.html)
