### PR TITLE
Use the tag table name from the configuration in read statement.

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/CassandraReadStatements.scala
@@ -14,9 +14,10 @@ import akka.persistence.cassandra.PluginSettings
 
   def settings: PluginSettings
   private def journalSettings = settings.journalSettings
+  private def eventsByTagSettings = settings.eventsByTagSettings
 
   private def tableName = s"${journalSettings.keyspace}.${journalSettings.table}"
-  private def tagViewTableName = s"${journalSettings.keyspace}.tag_views"
+  private def tagViewTableName = s"${journalSettings.keyspace}.${eventsByTagSettings.tagTable.name}"
 
   def selectDistinctPersistenceIds =
     s"""


### PR DESCRIPTION
<!--
# Pull Request Checklist

* [x] Have you read through the [contributor guidelines](./CONTRIBUTING.md)?
* [x] Have you signed the [Lightbend CLA](https://www.lightbend.com/contribute/cla)?
* [x] Have you updated the documentation?
* [x] Have you added tests for any changed functionality?
-->
## Purpose

<!-- What does this PR do? -->
I found that is impossible to change default name for tag table because it is hardcoded in `CassandraReadStatements`. I use the table name from the configuration.

## Changes

<!-- Bullets for important changes in this PR -->
* Building read statements plugin is using tag view table name from the configuration

