### PR TITLE
Sessions: deregister sessions on close

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -210,10 +210,6 @@ class CassandraJournal(cfg: Config, cfgPath: String)
       }
   }
 
-  override def postStop(): Unit = {
-    session.close()
-  }
-
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     // we need to preserve the order / size of this sequence even though we don't map
     // AtomicWrites 1:1 with a C* insert

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -185,10 +185,6 @@ class CassandraReadJournal(system: ExtendedActorSystem, cfg: Config, cfgPath: St
       byTagWithUpper <- preparedSelectFromTagViewWithUpperBound
     } yield EventByTagStatements(byTagWithUpper)
 
-  system.registerOnTermination {
-    session.close()
-  }
-
   /**
    * Use this as the UUID offset in `eventsByTag` queries when you want all
    * events from the beginning of time.

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -89,9 +89,6 @@ class CassandraSnapshotStore(cfg: Config, cfgPath: String)
       log.debug("Initialized")
   }
 
-  override def postStop(): Unit =
-    session.close()
-
   override def loadAsync(
       persistenceId: String,
       criteria: SnapshotSelectionCriteria): Future[Option[SelectedSnapshot]] = {

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraEventUpdateSpec.scala
@@ -44,7 +44,14 @@ class CassandraEventUpdateSpec extends CassandraSpec(CassandraEventUpdateSpec.co
         system.asInstanceOf[ExtendedActorSystem],
         system.settings.config.getConfig(PluginSettings.DefaultConfigPath))
     override private[akka] val session: CassandraSession =
-      new CassandraSession(system, sessionProvider, ec, log, systemName, init = _ => Future.successful(Done))
+      new CassandraSession(
+        system,
+        sessionProvider,
+        ec,
+        log,
+        systemName,
+        init = _ => Future.successful(Done),
+        onClose = () => ())
   }
 
   "CassandraEventUpdate" must {

--- a/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/session/javadsl/CassandraSessionSpec.scala
@@ -7,7 +7,7 @@ package akka.persistence.cassandra.session.javadsl
 import java.util.Optional
 
 import akka.Done
-import akka.cassandra.session.javadsl.CassandraSession
+import akka.cassandra.session.javadsl
 import akka.cassandra.session.DefaultSessionProvider
 import akka.event.Logging
 import akka.persistence.cassandra.{ CassandraLifecycle, CassandraSpec }
@@ -37,16 +37,20 @@ class CassandraSessionSpec extends CassandraSpec(CassandraSessionSpec.config) {
 
   val log = Logging.getLogger(system, this.getClass)
 
-  lazy val session: CassandraSession = {
+  // testing javadsl to prove delegation works
+  lazy val session: javadsl.CassandraSession = {
     val cfg = system.settings.config.withFallback(system.settings.config.getConfig("akka.persistence.cassandra"))
-    new CassandraSession(
+    new javadsl.CassandraSession(
       system,
       new DefaultSessionProvider(system, cfg),
       system.dispatcher,
       log,
       "CassandraSessionSpec-metrics",
       (s: CqlSession) =>
-        s.executeAsync(s"USE ${cfg.getString("journal.keyspace")};").toScala.map(_ => Done.getInstance).toJava)
+        s.executeAsync(s"USE ${cfg.getString("journal.keyspace")};").toScala.map(_ => Done.getInstance).toJava,
+      onClose = new Runnable {
+        override def run(): Unit = {}
+      })
   }
 
   override def beforeAll(): Unit = {

--- a/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotCleanupSpec.scala
@@ -32,7 +32,14 @@ class CassandraSnapshotCleanupSpec extends CassandraSpec {
     private val sessionProvider =
       CqlSessionProvider(system.asInstanceOf[ExtendedActorSystem], system.settings.config.getConfig(configPath))
     override val session: CassandraSession =
-      new CassandraSession(system, sessionProvider, ec, log, systemName, init = _ => Future.successful(Done))
+      new CassandraSession(
+        system,
+        sessionProvider,
+        ec,
+        log,
+        systemName,
+        init = _ => Future.successful(Done),
+        onClose = () => ())
 
   }
 

--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
@@ -6,7 +6,7 @@ package akka.cassandra.session.javadsl
 
 import java.util.{ List => JList }
 import java.util.Optional
-import java.util.concurrent.CompletionStage
+import java.util.concurrent.{ CompletionStage, Executor }
 import java.util.function.{ Function => JFunction }
 
 import scala.annotation.varargs
@@ -61,7 +61,11 @@ final class CassandraSession(delegate: akka.cassandra.session.scaladsl.Cassandra
 
   implicit private val ec = delegate.ec
 
-  def close(): CompletionStage[Done] = delegate.close().toJava
+  /**
+   * Closes the underlying Cassandra session.
+   * @param executor as this might be used after actor system termination, the actor systems dispatcher can't be used
+   */
+  def close(executor: Executor): CompletionStage[Done] = delegate.close(ExecutionContext.fromExecutor(executor)).toJava
 
   /**
    * The `Session` of the underlying

--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSession.scala
@@ -47,7 +47,8 @@ final class CassandraSession(delegate: akka.cassandra.session.scaladsl.Cassandra
       executionContext: ExecutionContext,
       log: LoggingAdapter,
       metricsCategory: String,
-      init: JFunction[CqlSession, CompletionStage[Done]]) =
+      init: JFunction[CqlSession, CompletionStage[Done]],
+      onClose: java.lang.Runnable) =
     this(
       new akka.cassandra.session.scaladsl.CassandraSession(
         system,
@@ -55,9 +56,12 @@ final class CassandraSession(delegate: akka.cassandra.session.scaladsl.Cassandra
         executionContext,
         log,
         metricsCategory,
-        session => init.apply(session).toScala))
+        session => init.apply(session).toScala,
+        () => onClose.run()))
 
   implicit private val ec = delegate.ec
+
+  def close(): CompletionStage[Done] = delegate.close().toJava
 
   /**
    * The `Session` of the underlying

--- a/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSessionRegistry.scala
+++ b/session/src/main/scala/akka/cassandra/session/javadsl/CassandraSessionRegistry.scala
@@ -37,8 +37,7 @@ final class CassandraSessionRegistry private (delegate: scaladsl.CassandraSessio
    * Get an existing session or start a new one with the given settings,
    * makes it possible to share one session across plugins.
    *
-   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
-   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   * Sessions in the session registry are closed after actor system termination.
    */
   def sessionFor(configPath: String, executionContext: ExecutionContext): CassandraSession =
     new CassandraSession(delegate.sessionFor(configPath, executionContext))
@@ -51,8 +50,7 @@ final class CassandraSessionRegistry private (delegate: scaladsl.CassandraSessio
    * if `sessionFor` is called from multiple places with different `init` it will
    * only execute the first.
    *
-   * Note that the session must not be stopped manually, it is shut down when the actor system is shutdown,
-   * if you need a more fine grained life cycle control, create the CassandraSession manually instead.
+   * Sessions in the session registry are closed after actor system termination.
    */
   def sessionFor(
       configPath: String,

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
@@ -73,7 +73,12 @@ final class CassandraSession(
    */
   def underlying(): Future[CqlSession] = _underlyingSession
 
-  def close(): Future[Done] = {
+  /**
+   * Closes the underlying Cassandra session.
+   * @param executionContext when used after actor system termination, the a different execution context must be provided
+   */
+  def close(executionContext: ExecutionContext): Future[Done] = {
+    implicit val ec: ExecutionContext = executionContext
     onClose()
     _underlyingSession.map(_.closeAsync().toScala).map(_ => Done)
   }

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSession.scala
@@ -65,15 +65,6 @@ final class CassandraSession(
     init(session).map(_ => session)
   }
 
-  def this(
-      system: ActorSystem,
-      sessionProvider: CqlSessionProvider,
-      executionContext: ExecutionContext,
-      log: LoggingAdapter,
-      metricsCategory: String,
-      init: CqlSession => Future[Done]) =
-    this(system, sessionProvider, executionContext, log, metricsCategory, init, onClose = () => ())
-
   /**
    * The `Session` of the underlying
    * <a href="http://datastax.github.io/java-driver/">Datastax Java Driver</a>.

--- a/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSessionRegistry.scala
+++ b/session/src/main/scala/akka/cassandra/session/scaladsl/CassandraSessionRegistry.scala
@@ -9,9 +9,9 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.collection.JavaConverters._
-
 import akka.Done
 import akka.actor.ActorSystem
+import akka.actor.CoordinatedShutdown
 import akka.actor.ExtendedActorSystem
 import akka.actor.Extension
 import akka.actor.ExtensionId
@@ -96,5 +96,6 @@ final class CassandraSessionRegistry(system: ExtendedActorSystem) extends Extens
     Future.sequence(closing).map(_ => Done)
   }
 
-  system.whenTerminated.foreach(_ => close())(system.dispatcher)
+  CoordinatedShutdown(system)
+    .addTask(CoordinatedShutdown.PhaseBeforeActorSystemTerminate, "Cassandra session registry close")(() => close())
 }


### PR DESCRIPTION
## Purpose

Make sessions deregister themselves from the registry on close and close all sessions in the session registry after actor system termination.

## Changes

- Change `session.close()` to use `closeAsync()` and return a `Future[Done]`
- Close all sessions in the session registry after actor system termination