### PR TITLE
Remove unused message column from createTable statement, #671

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraStatements.scala
@@ -12,6 +12,7 @@ import akka.annotation.InternalApi
 import akka.persistence.cassandra.journal.CassandraJournalStatements
 import akka.persistence.cassandra.snapshot.CassandraSnapshotStatements
 import com.datastax.oss.driver.api.core.CqlSession
+import com.datastax.oss.driver.api.core.cql.Row
 
 @InternalApi
 private[akka] class CassandraStatements(val settings: PluginSettings) {
@@ -27,4 +28,39 @@ private[akka] class CassandraStatements(val settings: PluginSettings) {
     } yield Done
   }
 
+}
+
+/**
+ * INTERNAL API: caching to avoid repeated check via ColumnDefinitions
+ */
+@InternalApi private[akka] class ColumnDefinitionCache {
+  private def hasColumn(column: String, row: Row, cached: Option[Boolean], updateCache: Boolean => Unit): Boolean = {
+    cached match {
+      case Some(b) => b
+      case None =>
+        val b = row.getColumnDefinitions.contains(column)
+        updateCache(b)
+        b
+    }
+  }
+
+  @volatile private var _hasMetaColumns: Option[Boolean] = None
+  private val updateMetaColumnsCache: Boolean => Unit = b => _hasMetaColumns = Some(b)
+  def hasMetaColumns(row: Row): Boolean =
+    hasColumn("meta", row, _hasMetaColumns, updateMetaColumnsCache)
+
+  @volatile private var _hasOldTagsColumns: Option[Boolean] = None
+  private val updateOldTagsColumnsCache: Boolean => Unit = b => _hasOldTagsColumns = Some(b)
+  def hasOldTagsColumns(row: Row): Boolean =
+    hasColumn("tag1", row, _hasOldTagsColumns, updateOldTagsColumnsCache)
+
+  @volatile private var _hasTagsColumn: Option[Boolean] = None
+  private val updateTagsColumnCache: Boolean => Unit = b => _hasTagsColumn = Some(b)
+  def hasTagsColumn(row: Row): Boolean =
+    hasColumn("tags", row, _hasTagsColumn, updateTagsColumnCache)
+
+  @volatile private var _hasMessageColumn: Option[Boolean] = None
+  private val updateMessageColumnCache: Boolean => Unit = b => _hasMessageColumn = Some(b)
+  def hasMessageColumn(row: Row): Boolean =
+    hasColumn("message", row, _hasMessageColumn, updateMessageColumnCache)
 }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -27,8 +27,6 @@ import com.datastax.oss.driver.api.core.CqlSession
      |WITH REPLICATION = { 'class' : ${journalSettings.replicationStrategy} }
     """.stripMargin.trim
 
-  // message is the serialized PersistentRepr that was used in v0.6 and earlier
-  // event is the serialized application event that is used in v0.7 and later
   // The event's serialization manifest is stored in ser_manifest and the
   // PersistentRepr.manifest is stored in event_manifest (sorry for naming confusion).
   // PersistentRepr.manifest is used by the event adapters (in akka-persistence).
@@ -49,7 +47,6 @@ import com.datastax.oss.driver.api.core.CqlSession
       |  meta_ser_id int,
       |  meta_ser_manifest text,
       |  meta blob,
-      |  message blob,
       |  tags set<text>,
       |  PRIMARY KEY ((persistence_id, partition_nr), sequence_nr, timestamp, timebucket))
       |  WITH gc_grace_seconds =${journalSettings.gcGraceSeconds}


### PR DESCRIPTION
* still reading from the old message column if it is defined and has data
* using same column definition caching as for some other things

References #671
