### PR TITLE
CassandraFlow: make the session implicit

### DIFF
--- a/session/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/session/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -31,11 +31,8 @@ object CassandraFlow {
       cqlStatement: String,
       statementBinder: akka.japi.Function2[T, PreparedStatement, BoundStatement]): Flow[T, T, NotUsed] =
     scaladsl.CassandraFlow
-      .create(
-        session.delegate,
-        writeSettings,
-        cqlStatement,
-        (t, preparedStatement) => statementBinder.apply(t, preparedStatement))
+      .create(writeSettings, cqlStatement, (t, preparedStatement) => statementBinder.apply(t, preparedStatement))(
+        session.delegate)
       .asJava
 
   /**
@@ -56,11 +53,8 @@ object CassandraFlow {
       statementBinder: akka.japi.Function2[T, PreparedStatement, BoundStatement])
       : FlowWithContext[T, Ctx, T, Ctx, NotUsed] = {
     scaladsl.CassandraFlow
-      .withContext(
-        session.delegate,
-        writeSettings,
-        cqlStatement,
-        (t, preparedStatement) => statementBinder.apply(t, preparedStatement))
+      .withContext(writeSettings, cqlStatement, (t, preparedStatement) => statementBinder.apply(t, preparedStatement))(
+        session.delegate)
       .asJava
   }
 
@@ -86,11 +80,10 @@ object CassandraFlow {
       partitionKey: akka.japi.Function[T, K]): Flow[T, T, NotUsed] = {
     scaladsl.CassandraFlow
       .createUnloggedBatch(
-        session.delegate,
         writeSettings,
         cqlStatement,
         (t, preparedStatement) => statementBinder.apply(t, preparedStatement),
-        t => partitionKey.apply(t))
+        t => partitionKey.apply(t))(session.delegate)
       .asJava
   }
 

--- a/session/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
+++ b/session/src/main/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraFlow.scala
@@ -8,7 +8,7 @@ import akka.NotUsed
 import akka.dispatch.ExecutionContexts
 import akka.stream.alpakka.cassandra.CassandraWriteSettings
 import akka.stream.scaladsl.{ Flow, FlowWithContext }
-import com.datastax.oss.driver.api.core.cql.{ BatchStatement, BatchType, BoundStatement, PreparedStatement }
+import com.datastax.oss.driver.api.core.cql.{ BatchStatement, BatchType, BoundStatement, PreparedStatement, Row }
 
 import scala.collection.JavaConverters._
 import scala.concurrent.Future
@@ -22,17 +22,17 @@ object CassandraFlow {
    * A flow writing to Cassandra for every stream element.
    * The element is emitted unchanged.
    *
-   * @param session Cassandra session from `CassandraSessionRegistry`
    * @param writeSettings settings to configure the write operation
    * @param cqlStatement raw CQL statement
    * @param statementBinder function to bind data from the stream element to the prepared statement
+   * @param session implicit Cassandra session from `CassandraSessionRegistry`
    * @tparam T stream element type
    */
   def create[T](
-      session: CassandraSession,
       writeSettings: CassandraWriteSettings,
       cqlStatement: String,
-      statementBinder: (T, PreparedStatement) => BoundStatement): Flow[T, T, NotUsed] = {
+      statementBinder: (T, PreparedStatement) => BoundStatement)(
+      implicit session: CassandraSession): Flow[T, T, NotUsed] = {
     Flow
       .futureFlow {
         val prepare = session.prepare(cqlStatement)
@@ -51,18 +51,18 @@ object CassandraFlow {
    * A flow writing to Cassandra for every stream element, passing context along.
    * The element and context are emitted unchanged.
    *
-   * @param session Cassandra session from `CassandraSessionRegistry`
    * @param writeSettings settings to configure the write operation
    * @param cqlStatement raw CQL statement
    * @param statementBinder function to bind data from the stream element to the prepared statement
+   * @param session implicit Cassandra session from `CassandraSessionRegistry`
    * @tparam T stream element type
    * @tparam Ctx context type
    */
   def withContext[T, Ctx](
-      session: CassandraSession,
       writeSettings: CassandraWriteSettings,
       cqlStatement: String,
-      statementBinder: (T, PreparedStatement) => BoundStatement): FlowWithContext[T, Ctx, T, Ctx, NotUsed] = {
+      statementBinder: (T, PreparedStatement) => BoundStatement)(
+      implicit session: CassandraSession): FlowWithContext[T, Ctx, T, Ctx, NotUsed] = {
     FlowWithContext.fromTuples {
       Flow
         .futureFlow {
@@ -87,19 +87,18 @@ object CassandraFlow {
    *
    * Be aware that this stage does NOT preserve the upstream order.
    *
-   * @param session Cassandra session from `CassandraSessionRegistry`
-   * @param writeSettings settings to configure the write operation
+   * @param writeSettings settings to configure the batching and the write operation
    * @param cqlStatement raw CQL statement
    * @param statementBinder function to bind data from the stream element to the prepared statement
+   * @param session implicit Cassandra session from `CassandraSessionRegistry`
    * @tparam T stream element type
    * @tparam K extracted key type for grouping into batches
    */
   def createUnloggedBatch[T, K](
-      session: CassandraSession,
       writeSettings: CassandraWriteSettings,
       cqlStatement: String,
       statementBinder: (T, PreparedStatement) => BoundStatement,
-      partitionKey: T => K): Flow[T, T, NotUsed] = {
+      partitionKey: T => K)(implicit session: CassandraSession): Flow[T, T, NotUsed] = {
     Flow
       .futureFlow {
         val prepareStatement: Future[PreparedStatement] = session.prepare(cqlStatement)


### PR DESCRIPTION
Align the `scaladsl.CassandraFlow` with `CassandraSource` and expect the `CassandraSession` as implicit parameter.

The javadsl expect the session as the first parameter to all operations (as some would interfere with var-args if it was the last).

* Add a basic test for `createUnloggedBatch`