### PR TITLE
Akka Discovery: integrate into CqlSessionProvider

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -33,6 +33,12 @@ akka.persistence.cassandra {
   # See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/#quick-overview
   session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
 
+  # Configure Akka Discovery by setting a serice name
+  service-discovery {
+    name = ""
+    lookup-timeout = 1 s
+  }
+
   # Full config path to the Datastax Java driver's configuration section.
   # When connecting to more than one Cassandra cluster different session configuration can be
   # defined with this property. Different plugins can thereby connect to different Cassandra

--- a/session/src/main/resources/reference.conf
+++ b/session/src/main/resources/reference.conf
@@ -9,6 +9,12 @@ alpakka.cassandra {
   # See https://docs.datastax.com/en/developer/java-driver/latest/manual/core/configuration/#quick-overview
   session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
 
+  # Configure Akka Discovery by setting a serice name
+  service-discovery {
+    name = ""
+    lookup-timeout = 1 s
+  }
+
   # Full config path to the Datastax Java driver's configuration section.
   # When connecting to more than one Cassandra cluster different session configuration can be
   # defined with this property.

--- a/session/src/test/resources/application.conf
+++ b/session/src/test/resources/application.conf
@@ -10,3 +10,41 @@ datastax-java-driver {
     load-balancing-policy.local-datacenter = datacenter1
   }
 }
+
+akka {
+  discovery.method = config
+}
+akka.discovery.config.services = {
+  cassandra-service = {
+    endpoints = [
+      {
+        host = "127.0.0.1"
+        port = 9042
+      }
+    ]
+  }
+}
+
+with-akka-discovery {
+  session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
+  service-discovery {
+    name = "cassandra-service"
+    lookup-timeout = 1 s
+  }
+  datastax-java-driver-config = datastax-java-driver-illegal-contact-point
+}
+datastax-java-driver-illegal-contact-point {
+  basic {
+    contact-points = [ "127.0.0.1:8088" ]
+    load-balancing-policy.local-datacenter = datacenter1
+  }
+}
+
+without-akka-discovery {
+  session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
+  service-discovery {
+    name = ""
+    lookup-timeout = 1 s
+  }
+  datastax-java-driver-config = datastax-java-driver-illegal-contact-point
+}

--- a/session/src/test/resources/application.conf
+++ b/session/src/test/resources/application.conf
@@ -23,6 +23,13 @@ akka.discovery.config.services = {
       }
     ]
   }
+  cassandra-service-no-port = {
+    endpoints = [
+      {
+        host = "127.0.0.1"
+      }
+    ]
+  }
 }
 
 with-akka-discovery {
@@ -44,6 +51,15 @@ without-akka-discovery {
   session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
   service-discovery {
     name = ""
+    lookup-timeout = 1 s
+  }
+  datastax-java-driver-config = datastax-java-driver-illegal-contact-point
+}
+
+with-akka-discovery-no-port {
+  session-provider = "akka.stream.alpakka.cassandra.DefaultSessionProvider"
+  service-discovery {
+    name = "cassandra-service-no-port"
     lookup-timeout = 1 s
   }
   datastax-java-driver-config = datastax-java-driver-illegal-contact-point

--- a/session/src/test/scala/docs/scaladsl/AkkaDiscoverySpec.scala
+++ b/session/src/test/scala/docs/scaladsl/AkkaDiscoverySpec.scala
@@ -49,5 +49,13 @@ class AkkaDiscoverySpec extends CassandraSpecBase(ActorSystem("AkkaDiscoverySpec
       exception.getCause mustBe a[com.datastax.oss.driver.api.core.AllNodesFailedException]
     }
 
+    "fail when the port is missing" in assertAllStagesStopped {
+      val sessionSettings = CassandraSessionSettings("with-akka-discovery-no-port")
+      val session = sessionRegistry.sessionFor(sessionSettings, system.dispatcher)
+      val result = session.select(s"SELECT * FROM fsdfsd").runWith(Sink.head)
+      val exception = result.failed.futureValue
+      exception mustBe a[akka.ConfigurationException]
+    }
+
   }
 }

--- a/session/src/test/scala/docs/scaladsl/AkkaDiscoverySpec.scala
+++ b/session/src/test/scala/docs/scaladsl/AkkaDiscoverySpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.scaladsl
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.stream.alpakka.cassandra.CassandraSessionSettings
+import akka.stream.alpakka.cassandra.scaladsl.{ CassandraSession, CassandraSpecBase }
+import akka.stream.scaladsl.Sink
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+
+import scala.concurrent.Future
+
+class AkkaDiscoverySpec extends CassandraSpecBase(ActorSystem("AkkaDiscoverySpec")) {
+
+  val sessionSettings = CassandraSessionSettings("with-akka-discovery")
+  val data = 1 until 103
+
+  override val lifecycleSession: CassandraSession = sessionRegistry.sessionFor(sessionSettings, system.dispatcher)
+
+  "Service discovery" must {
+
+    "connect to Cassandra" in assertAllStagesStopped {
+      val session = sessionRegistry.sessionFor(sessionSettings, system.dispatcher)
+      val table = createTableName()
+      withSchemaMetadataDisabled {
+        for {
+          _ <- lifecycleSession.executeDDL(s"""
+                                              |CREATE TABLE IF NOT EXISTS $table (
+                                              |    id int PRIMARY KEY
+                                              |);""".stripMargin)
+          _ <- Future.sequence(data.map { i =>
+            lifecycleSession.executeWrite(s"INSERT INTO $table(id) VALUES ($i)")
+          })
+        } yield Done
+      }.futureValue mustBe Done
+      val rows = session.select(s"SELECT * FROM $table").map(_.getInt("id")).runWith(Sink.seq).futureValue
+      rows must contain theSameElementsAs data
+    }
+
+    "fail when the contact point address is invalid" in assertAllStagesStopped {
+      val sessionSettings = CassandraSessionSettings("without-akka-discovery")
+      val session = sessionRegistry.sessionFor(sessionSettings, system.dispatcher)
+      val result = session.select(s"SELECT * FROM fsdfsd").runWith(Sink.head)
+      val exception = result.failed.futureValue
+      exception mustBe a[java.util.concurrent.CompletionException]
+      exception.getCause mustBe a[com.datastax.oss.driver.api.core.AllNodesFailedException]
+    }
+
+  }
+}


### PR DESCRIPTION
Align the option to rely on Akka Discovery for contact point lookup with the solution in Alpakka Kafka.
When the user specifies a non-empty `service-discovery.name` the session provider will use that name to look up contact points via Akka Discovery.