### PR TITLE
Build: verify code style in single Travis task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ before_script:
 
 jobs:
   include:
-    - script: sbt -jvm-opts .jvmopts-travis verifyCodeStyle
+    - stage: check
+      script: sbt -jvm-opts .jvmopts-travis verifyCodeStyle
       name: "Code style check. Run locally with: sbt verifyCodeStyle"
     - script: sbt -jvm-opts .jvmopts-travis ++2.13.1 Test/compile
       name: Compile all tests (with Scala 2.13)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,11 +20,8 @@ before_script:
 
 jobs:
   include:
-    - stage: check
-      script: sbt -jvm-opts .jvmopts-travis scalafmtCheckAll || { echo "[error] Unformatted code found. Please run 'scalafmtAll' and commit the reformatted code."; false; }
-      name: Code style check (fixed with `sbt scalafmtAll`)
-    - script: sbt -jvm-opts .jvmopts-travis scalafmtSbtCheck || { echo "[error] Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code."; false; }
-      name: Build code style check (fixed with `sbt scalafmtSbt`)
+    - script: sbt -jvm-opts .jvmopts-travis verifyCodeStyle
+      name: "Code style check. Run locally with: sbt verifyCodeStyle"
     - script: sbt -jvm-opts .jvmopts-travis ++2.13.1 Test/compile
       name: Compile all tests (with Scala 2.13)
     - script: sbt -jvm-opts .jvmopts-travis unidoc

--- a/build.sbt
+++ b/build.sbt
@@ -96,3 +96,16 @@ lazy val docs = project
     resolvers += Resolver.jcenterRepo,
     publishRsyncArtifact := makeSite.value -> "www/",
     publishRsyncHost := "akkarepo@gustav.akka.io")
+
+TaskKey[Unit]("verifyCodeFmt") := {
+  scalafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
+    throw new MessageOnlyException(
+      "Unformatted Scala code found. Please run 'scalafmtAll' and commit the reformatted code")
+  }
+  (Compile / scalafmtSbtCheck).result.value.toEither.left.foreach { _ =>
+    throw new MessageOnlyException(
+      "Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code")
+  }
+}
+
+addCommandAlias("verifyCodeStyle", "headerCheck; verifyCodeFmt")


### PR DESCRIPTION
Create an sbt command alias `verifyCodeStyle` to run all code style requirements and run that on Travis instead of separate jobs.