### PR TITLE
Session: select performance test harness

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,8 @@ object Dependencies {
   val AkkaVersion = System.getProperty("override.akka.version", "2.6.3")
   val AkkaVersionInDocs = System.getProperty("override.akka.version", "2.6")
   val CassandraVersionInDocs = "4.0"
-  val DriverVersion = "4.3.0"
-  val DriverVersionInDocs = "4.3"
+  val DriverVersion = "4.5.0"
+  val DriverVersionInDocs = "4.5"
 
   val AlpakkaVersion = "2.0.0-M3"
   val AlpakkaVersionInDocs = "2.0"

--- a/session/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionPerformanceSpec.scala
+++ b/session/src/test/scala/akka/stream/alpakka/cassandra/scaladsl/CassandraSessionPerformanceSpec.scala
@@ -47,7 +47,7 @@ final class CassandraSessionPerformanceSpec extends CassandraSpecBase(ActorSyste
       .flatMap { _ =>
         Source(data)
           .via {
-            CassandraFlow.createUnloggedBatch(
+            CassandraFlow.createBatch(
               CassandraWriteSettings.create().withMaxBatchSize(10000),
               s"INSERT INTO $dataTable(partition_id, id, value, seq_nr) VALUES (?, ?, ?, ?)",
               (d: Int, ps) => ps.bind(Long.box(partitionId), id, Long.box(d), Long.box(d)),

--- a/session/src/test/scala/docs/javadsl/CassandraSessionPerformanceSpec.scala
+++ b/session/src/test/scala/docs/javadsl/CassandraSessionPerformanceSpec.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package docs.javadsl
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.event.Logging
+import akka.stream.alpakka.cassandra.CassandraSessionSettings
+import akka.stream.alpakka.cassandra.scaladsl.{ CassandraSession, CassandraSpecBase }
+import akka.stream.scaladsl.Sink
+import akka.stream.testkit.scaladsl.StreamTestKit.assertAllStagesStopped
+import com.datastax.oss.driver.api.core.cql.{ BatchStatement, BatchType }
+
+import scala.collection.JavaConverters._
+import scala.concurrent.Await
+import scala.concurrent.duration._
+
+final class CassandraSessionPerformanceSpec extends CassandraSpecBase(ActorSystem("CassandraSessionPerformanceSpec")) {
+
+  val log = Logging(system, this.getClass)
+
+  val data = 1 until 1000 * 100
+
+  override implicit def patienceConfig: PatienceConfig = PatienceConfig(1.minute)
+
+  private val dataTableName = "largerData"
+  lazy val dataTable = s"$keyspaceName.$dataTableName"
+
+  val sessionSettings: CassandraSessionSettings = CassandraSessionSettings()
+  override val lifecycleSession: CassandraSession =
+    sessionRegistry.sessionFor(sessionSettings, system.dispatcher)
+
+  lazy val session: CassandraSession = sessionRegistry.sessionFor(sessionSettings, system.dispatcher)
+
+  def insertDataTable() = {
+    lifecycleSession
+      .executeDDL(s"""CREATE TABLE IF NOT EXISTS $dataTable (
+                     |    id int PRIMARY KEY
+                     |);""".stripMargin)
+      .flatMap { _ =>
+        lifecycleSession.prepare(s"INSERT INTO $dataTable(id) VALUES (?)")
+      }
+      .map { prepareStatement =>
+        data.sliding(10000, 10000).foreach { d =>
+          val boundStatements = d.map { i =>
+            prepareStatement.bind(Int.box(i))
+          }
+          val batchStatement = BatchStatement.newInstance(BatchType.LOGGED).addAll(boundStatements.asJava)
+          Await.result(lifecycleSession.executeWrite(batchStatement), 4.seconds)
+        }
+        Done
+      }
+      .futureValue
+  }
+
+  override def beforeAll(): Unit = {
+    super.beforeAll()
+    insertDataTable()
+  }
+
+  "session" must {
+    "stream the result of a Cassandra statement with one page" ignore assertAllStagesStopped {
+      val rows =
+        session
+          .select(s"SELECT * FROM $dataTable")
+          .map(_.getInt("id"))
+          .runWith(Sink.fold(0)((u, _) => u + 1))
+          .futureValue
+      rows mustBe data.last
+    }
+  }
+}


### PR DESCRIPTION
A "select many rows" test to try to compare performance between master and #696 (the test is ignored for now).

Upgrades the Cassandra driver to 4.5.0.