### PR TITLE
Cleanup utility, #720

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -793,3 +793,21 @@ cassandra-plugin-default-dispatcher {
   }
 }
 
+# Configuration of the Cleanup tool.
+akka.persistence.cassandra.cleanup {
+  # Full configuration path of the journal plugin to use. By default it will use
+  # the default plugin configured with `akka.persistence.journal.plugin`.
+  journal-plugin = ""
+
+  # Full configuration path of the snapshot plugin to use. By default it will use
+  # the default plugin configured with `akka.persistence.snapshot-store.plugin`.
+  snapshot-plugin = ""
+
+  # Timeout of individual delete operations. If it takes longer the whole job
+  # will be aborted with logging of how far it reached.
+  operation-timeout = 10s
+
+  # Log progress after this number of delete operations. Can be set to 1 to log
+  # progress of each operation.
+  log-progress-every = 100
+}

--- a/core/src/main/scala/akka/persistence/cassandra/cleanup/Cleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/cleanup/Cleanup.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.cleanup
+
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.collection.immutable
+
+import akka.Done
+import akka.actor.ActorSystem
+import akka.annotation.ApiMayChange
+import akka.pattern.ask
+import akka.persistence.Persistence
+import akka.persistence.cassandra.journal.CassandraJournal
+import akka.persistence.cassandra.snapshot.CassandraSnapshotStore
+import akka.util.Timeout
+
+@ApiMayChange
+final class Cleanup(system: ActorSystem) {
+
+  // FIXME in 1.0 we should support configurable pluginId
+  private val journal = Persistence(system).journalFor("")
+  // FIXME handle when default snapshot store isn't configured
+  private val snapshotStore = Persistence(system).snapshotStoreFor("")
+  private implicit val askTimeout: Timeout = 10.seconds
+  import system.dispatcher
+
+  def deleteAllEvents(persistenceIds: immutable.Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
+    Future.sequence(persistenceIds.map(pid => deleteAllEvents(pid, neverUsePersistenceIdAgain))).map(_ => Done)
+  }
+
+  def deleteAllEvents(persistenceId: String, neverUsePersistenceIdAgain: Boolean): Future[Done] = {
+    (journal ? CassandraJournal.DeleteAllEvents(persistenceId, neverUsePersistenceIdAgain)).mapTo[Done]
+  }
+
+  def deleteAllSnapshots(persistenceIds: immutable.Seq[String]): Future[Done] = {
+    Future.sequence(persistenceIds.map(pid => deleteAllSnapshots(pid))).map(_ => Done)
+  }
+
+  def deleteAllSnapshots(persistenceId: String): Future[Done] = {
+    (snapshotStore ? CassandraSnapshotStore.DeleteAllsnapshots(persistenceId)).mapTo[Done]
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/cassandra/cleanup/Cleanup.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/cleanup/Cleanup.scala
@@ -4,13 +4,16 @@
 
 package akka.persistence.cassandra.cleanup
 
+import scala.collection.immutable
 import scala.concurrent.Future
 import scala.concurrent.duration._
-import scala.collection.immutable
+import scala.util.Failure
+import scala.util.Success
 
 import akka.Done
 import akka.actor.ActorSystem
 import akka.annotation.ApiMayChange
+import akka.event.Logging
 import akka.pattern.ask
 import akka.persistence.Persistence
 import akka.persistence.cassandra.journal.CassandraJournal
@@ -20,15 +23,27 @@ import akka.util.Timeout
 @ApiMayChange
 final class Cleanup(system: ActorSystem) {
 
+  private val log = Logging(system, getClass)
+  private val logProgressEvery = 2
   // FIXME in 1.0 we should support configurable pluginId
   private val journal = Persistence(system).journalFor("")
-  // FIXME handle when default snapshot store isn't configured
-  private val snapshotStore = Persistence(system).snapshotStoreFor("")
+  private val snapshotStore =
+    if (system.settings.config.getString("akka.persistence.snapshot-store.plugin").nonEmpty)
+      Some(Persistence(system).snapshotStoreFor(""))
+    else None
   private implicit val askTimeout: Timeout = 10.seconds
   import system.dispatcher
 
+  def deleteAll(persistenceIds: immutable.Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
+    foreach(persistenceIds, "deleteAll", pid => deleteAll(pid, neverUsePersistenceIdAgain))
+  }
+
+  def deleteAll(persistenceId: String, neverUsePersistenceIdAgain: Boolean): Future[Done] = {
+    deleteAllEvents(persistenceId, neverUsePersistenceIdAgain).flatMap(_ => deleteAllSnapshots(persistenceId))
+  }
+
   def deleteAllEvents(persistenceIds: immutable.Seq[String], neverUsePersistenceIdAgain: Boolean): Future[Done] = {
-    Future.sequence(persistenceIds.map(pid => deleteAllEvents(pid, neverUsePersistenceIdAgain))).map(_ => Done)
+    foreach(persistenceIds, "deleteAllEvents", pid => deleteAllEvents(pid, neverUsePersistenceIdAgain))
   }
 
   def deleteAllEvents(persistenceId: String, neverUsePersistenceIdAgain: Boolean): Future[Done] = {
@@ -36,11 +51,49 @@ final class Cleanup(system: ActorSystem) {
   }
 
   def deleteAllSnapshots(persistenceIds: immutable.Seq[String]): Future[Done] = {
-    Future.sequence(persistenceIds.map(pid => deleteAllSnapshots(pid))).map(_ => Done)
+    if (snapshotStore.isDefined)
+      foreach(persistenceIds, "deleteAllSnapshots", pid => deleteAllSnapshots(pid))
+    else
+      Future.successful(Done)
   }
 
   def deleteAllSnapshots(persistenceId: String): Future[Done] = {
-    (snapshotStore ? CassandraSnapshotStore.DeleteAllsnapshots(persistenceId)).mapTo[Done]
+    snapshotStore match {
+      case Some(snapshotStoreRef) =>
+        (snapshotStoreRef ? CassandraSnapshotStore.DeleteAllsnapshots(persistenceId)).mapTo[Done]
+      case None => Future.successful(Done)
+    }
+  }
+
+  private def foreach(
+      persistenceIds: immutable.Seq[String],
+      operationName: String,
+      pidOperation: String => Future[Done]): Future[Done] = {
+    val size = persistenceIds.size
+    log.info("Cleanup started {} of [{}] persistenceId.", operationName, size)
+
+    def loop(remaining: List[String], n: Int): Future[Done] = {
+      remaining match {
+        case Nil => Future.successful(Done)
+        case pid :: tail =>
+          pidOperation(pid).flatMap { _ =>
+            if (n % logProgressEvery == 0)
+              log.info("Cleanup {} [{}] of [{}].", operationName, n, size)
+            loop(tail, n + 1)
+          }
+      }
+    }
+
+    val result = loop(persistenceIds.toList, n = 1)
+
+    result.onComplete {
+      case Success(_) =>
+        log.info("Cleanup completed {} of [{}] persistenceId.", operationName, size)
+      case Failure(e) =>
+        log.error(e, "Cleanup {} failed.")
+    }
+
+    result
   }
 
 }

--- a/core/src/main/scala/akka/persistence/cassandra/cleanup/CleanupSettings.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/cleanup/CleanupSettings.scala
@@ -1,0 +1,21 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.cleanup
+
+import scala.concurrent.duration._
+import java.util.concurrent.TimeUnit
+
+import scala.concurrent.duration.FiniteDuration
+
+import akka.annotation.ApiMayChange
+import com.typesafe.config.Config
+
+@ApiMayChange
+class CleanupSettings(config: Config) {
+  val journalPlugin: String = config.getString("journal-plugin")
+  val snapshotPlugin: String = config.getString("snapshot-plugin")
+  val operationTimeout: FiniteDuration = config.getDuration("operation-timeout", TimeUnit.MILLISECONDS).millis
+  val logProgressEvery: Int = config.getInt("log-progress-every")
+}

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraStatements.scala
@@ -281,6 +281,11 @@ trait CassandraStatements {
       VALUES ( ?, ? )
     """
 
+  private[akka] def deleteDeletedTo =
+    s"""
+      DELETE FROM ${metadataTableName} where persistence_id = ?
+    """
+
   private[akka] def writeInUse =
     s"""
        INSERT INTO ${tableName} (persistence_id, partition_nr, used)

--- a/core/src/test/scala/akka/persistence/cassandra/cleanup/CleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/cleanup/CleanupSpec.scala
@@ -15,6 +15,9 @@ import com.typesafe.config.ConfigFactory
 object CleanupSpec {
   val config = ConfigFactory.parseString(s"""
     akka.loglevel = INFO
+    akka.persistence.cassandra.cleanup {
+      log-progress-every = 2
+    }
   """)
 
   case object PersistEvent
@@ -204,7 +207,6 @@ class CleanupSpec extends CassandraSpec(CleanupSpec.config) {
       pC2 ! GetRecoveredState
       expectMsg(RecoveredState("", Nil, 0L))
     }
-
   }
 
 }

--- a/core/src/test/scala/akka/persistence/cassandra/cleanup/CleanupSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/cleanup/CleanupSpec.scala
@@ -1,0 +1,210 @@
+/*
+ * Copyright (C) 2016-2017 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.cleanup
+
+import akka.actor.ActorRef
+import akka.actor.Props
+import akka.persistence.PersistentActor
+import akka.persistence.SaveSnapshotSuccess
+import akka.persistence.SnapshotOffer
+import akka.persistence.cassandra.CassandraSpec
+import com.typesafe.config.ConfigFactory
+
+object CleanupSpec {
+  val config = ConfigFactory.parseString(s"""
+    akka.loglevel = INFO
+  """)
+
+  case object PersistEvent
+  final case class Ack(sequenceNr: Long)
+  case object GetRecoveredState
+  final case class RecoveredState(snap: String, events: Seq[String], sequenceNr: Long)
+  case object Snap
+
+  object TestActor {
+    def props(persistenceId: String): Props =
+      Props(new TestActor(persistenceId))
+  }
+
+  class TestActor(override val persistenceId: String) extends PersistentActor {
+
+    var recoveredSnap: String = ""
+    var replayedEvents: List[String] = List.empty
+    var lastSnapSender: ActorRef = context.system.deadLetters
+
+    override def receiveRecover: Receive = {
+      case SnapshotOffer(_, snap: String) =>
+        recoveredSnap = snap
+      case event: String =>
+        replayedEvents = event :: replayedEvents
+    }
+
+    override def receiveCommand: Receive = {
+      case PersistEvent =>
+        val seqNr = lastSequenceNr + 1
+        persist(s"evt-$seqNr") { _ =>
+          sender() ! Ack(seqNr)
+        }
+      case GetRecoveredState =>
+        sender() ! RecoveredState(recoveredSnap, replayedEvents.reverse, lastSequenceNr)
+      case Snap =>
+        lastSnapSender = sender()
+        saveSnapshot(s"snap-$lastSequenceNr")
+      case SaveSnapshotSuccess(meta) =>
+        lastSnapSender ! Ack(meta.sequenceNr)
+    }
+  }
+}
+
+class CleanupSpec extends CassandraSpec(CleanupSpec.config) {
+
+  import CleanupSpec._
+
+  "Cassandra cleanup" must {
+    "delete events for one persistenceId" in {
+      val pid = nextPid
+      val p = system.actorOf(TestActor.props(pid))
+      (1 to 10).foreach { _ =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+
+      system.stop(p)
+
+      val cleanup = new Cleanup(system)
+      cleanup.deleteAllEvents(pid, neverUsePersistenceIdAgain = true).futureValue
+
+      val p2 = system.actorOf(TestActor.props(pid))
+      p2 ! GetRecoveredState
+      expectMsg(RecoveredState("", Nil, 0L))
+    }
+
+    "delete events for one persistenceId, but keep seqNr" in {
+      val pid = nextPid
+      val p = system.actorOf(TestActor.props(pid))
+      (1 to 10).foreach { i =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+
+      system.stop(p)
+
+      val cleanup = new Cleanup(system)
+      cleanup.deleteAllEvents(pid, neverUsePersistenceIdAgain = false).futureValue
+
+      val p2 = system.actorOf(TestActor.props(pid))
+      p2 ! GetRecoveredState
+      expectMsg(RecoveredState("", Nil, 10L))
+    }
+
+    "delete snapshots for one persistenceId" in {
+      val pid = nextPid
+      val p = system.actorOf(TestActor.props(pid))
+      (1 to 3).foreach { i =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+      p ! Snap
+      expectMsgType[Ack]
+      (1 to 5).foreach { i =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+
+      system.stop(p)
+
+      val cleanup = new Cleanup(system)
+      cleanup.deleteAllSnapshots(pid).futureValue
+
+      val p2 = system.actorOf(TestActor.props(pid))
+      p2 ! GetRecoveredState
+      expectMsg(RecoveredState("", (1 to 8).map(n => s"evt-$n"), 8L))
+    }
+
+    "delete all for one persistenceId" in {
+      val pid = nextPid
+      val p = system.actorOf(TestActor.props(pid))
+      (1 to 3).foreach { i =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+      p ! Snap
+      expectMsgType[Ack]
+      (1 to 2).foreach { _ =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+      p ! Snap
+      expectMsgType[Ack]
+      (1 to 3).foreach { _ =>
+        p ! PersistEvent
+        expectMsgType[Ack]
+      }
+
+      system.stop(p)
+
+      val cleanup = new Cleanup(system)
+      cleanup.deleteAll(pid, neverUsePersistenceIdAgain = true).futureValue
+
+      val p2 = system.actorOf(TestActor.props(pid))
+      p2 ! GetRecoveredState
+      expectMsg(RecoveredState("", Nil, 0L))
+    }
+
+    "delete all for several persistenceId" in {
+      val pidA = nextPid
+      val pidB = nextPid
+      val pidC = nextPid
+      val pA = system.actorOf(TestActor.props(pidA))
+      val pB = system.actorOf(TestActor.props(pidB))
+      val pC = system.actorOf(TestActor.props(pidC))
+      (1 to 3).foreach { i =>
+        pA ! PersistEvent
+        expectMsgType[Ack]
+        pB ! PersistEvent
+        expectMsgType[Ack]
+        pC ! PersistEvent
+        expectMsgType[Ack]
+      }
+      pA ! Snap
+      expectMsgType[Ack]
+      pB ! Snap
+      expectMsgType[Ack]
+      (1 to 2).foreach { _ =>
+        pA ! PersistEvent
+        expectMsgType[Ack]
+        pB ! PersistEvent
+        expectMsgType[Ack]
+      }
+      pA ! Snap
+      expectMsgType[Ack]
+      (1 to 3).foreach { _ =>
+        pA ! PersistEvent
+        expectMsgType[Ack]
+        pC ! PersistEvent
+        expectMsgType[Ack]
+      }
+
+      system.stop(pA)
+
+      val cleanup = new Cleanup(system)
+      cleanup.deleteAll(List(pidA, pidB, pidC), neverUsePersistenceIdAgain = true).futureValue
+
+      val pA2 = system.actorOf(TestActor.props(pidA))
+      pA2 ! GetRecoveredState
+      expectMsg(RecoveredState("", Nil, 0L))
+
+      val pB2 = system.actorOf(TestActor.props(pidB))
+      pB2 ! GetRecoveredState
+      expectMsg(RecoveredState("", Nil, 0L))
+
+      val pC2 = system.actorOf(TestActor.props(pidC))
+      pC2 ! GetRecoveredState
+      expectMsg(RecoveredState("", Nil, 0L))
+    }
+
+  }
+
+}

--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -114,3 +114,9 @@ CREATE TABLE IF NOT EXISTS akka.metadata(
   deleted_to bigint,
   properties map<text,text>);
 ```
+
+### Delete all events
+
+The tool `akka.persistence.cassandra.cleanup.Cleanup` can be used for deleting all events and/or snapshots
+given list of `persistenceIds` without using persistent actors. It's important that the actors with corresponding
+`persistenceId` are not running at the same time as using the tool.

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -45,3 +45,8 @@ CREATE TABLE IF NOT EXISTS akka_snapshot.snapshots (
     };
 ```
 
+### Delete all snapshots
+
+The tool `akka.persistence.cassandra.cleanup.Cleanup` can be used for deleting all events and/or snapshots
+given list of `persistenceIds` without using persistent actors. It's important that the actors with corresponding
+`persistenceId` are not running at the same time as using the tool.


### PR DESCRIPTION
Tool for deleting for a persistenceId:

* all events
* the "deletedTo" seqNr
* all snapshots

Later it should also support delete of tagged events in tag view, but I'm thinking that can be 1.0 only, since it's already implemented in the reconciler tool.

Refs #720

TODO:
- [x] additional settings as constructor parameter
- [x] tests
- [x] docs