### PR TITLE
CassandraFlow: default to logged batches; docs

### DIFF
--- a/session/src/main/scala/akka/stream/alpakka/cassandra/CassandraWriteSettings.scala
+++ b/session/src/main/scala/akka/stream/alpakka/cassandra/CassandraWriteSettings.scala
@@ -4,11 +4,16 @@
 
 package akka.stream.alpakka.cassandra
 
-import scala.concurrent.duration.FiniteDuration
 import akka.util.JavaDurationConverters._
-import scala.concurrent.duration._
+import com.datastax.oss.driver.api.core.cql.BatchType
 
-class CassandraWriteSettings private (val parallelism: Int, val maxBatchSize: Int, val maxBatchWait: FiniteDuration) {
+import scala.concurrent.duration.{ FiniteDuration, _ }
+
+class CassandraWriteSettings private (
+    val parallelism: Int,
+    val maxBatchSize: Int,
+    val maxBatchWait: FiniteDuration,
+    val batchType: BatchType) {
   require(parallelism > 0, s"Invalid value for parallelism: $parallelism. It should be > 0.")
   require(maxBatchSize > 0, s"Invalid value for maxBatchSize: $maxBatchSize. It should be > 0.")
 
@@ -35,22 +40,27 @@ class CassandraWriteSettings private (val parallelism: Int, val maxBatchSize: In
   def withMaxBatchWait(maxBatchWait: java.time.Duration): CassandraWriteSettings =
     copy(maxBatchWait = maxBatchWait.asScala)
 
+  def withBatchType(value: BatchType): CassandraWriteSettings =
+    copy(batchType = value)
+
   private def copy(
       parallelism: Int = parallelism,
       maxBatchSize: Int = maxBatchSize,
-      maxBatchWait: FiniteDuration = maxBatchWait) =
-    new CassandraWriteSettings(parallelism, maxBatchSize, maxBatchWait)
+      maxBatchWait: FiniteDuration = maxBatchWait,
+      batchType: BatchType = batchType) =
+    new CassandraWriteSettings(parallelism, maxBatchSize, maxBatchWait, batchType)
 
   override def toString: String =
     "CassandraWriteSettings(" +
     s"parallelism=$parallelism," +
     s"maxBatchSize=$maxBatchSize," +
-    s"maxBatchWait=$maxBatchWait)"
+    s"maxBatchWait=$maxBatchWait," +
+    s"batchType=$batchType)"
 
 }
 
 object CassandraWriteSettings {
-  val defaults: CassandraWriteSettings = new CassandraWriteSettings(1, 100, 500.millis)
+  val defaults: CassandraWriteSettings = new CassandraWriteSettings(1, 100, 500.millis, BatchType.LOGGED)
 
   def create(): CassandraWriteSettings = defaults
   def apply(): CassandraWriteSettings = defaults

--- a/session/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
+++ b/session/src/main/scala/akka/stream/alpakka/cassandra/javadsl/CassandraFlow.scala
@@ -59,16 +59,23 @@ object CassandraFlow {
   }
 
   /**
-   * Creates a flow that batches using an unlogged batch. Use this when most of the elements in the stream
-   * share the same partition key. Cassandra unlogged batches that share the same partition key will only
+   * Creates a flow that uses [[com.datastax.oss.driver.api.core.cql.BatchStatement]] and groups the
+   * elements internally into batches using the `writeSettings` and per `groupingKey`.
+   * Use this when most of the elements in the stream share the same partition key.
+   *
+   * Cassandra batches that share the same partition key will only
    * resolve to one write internally in Cassandra, boosting write performance.
+   *
+   * "A LOGGED batch to a single partition will be converted to an UNLOGGED batch as an optimization."
+   * ([[http://cassandra.apache.org/doc/latest/cql/dml.html#batch Batch CQL]])
    *
    * Be aware that this stage does NOT preserve the upstream order.
    *
-   * @param session Cassandra session from `CassandraSessionRegistry`
-   * @param writeSettings settings to configure the write operation
+   * @param writeSettings settings to configure the batching and the write operation
    * @param cqlStatement raw CQL statement
    * @param statementBinder function to bind data from the stream element to the prepared statement
+   * @param groupingKey groups the elements to go into the same batch
+   * @param session implicit Cassandra session from `CassandraSessionRegistry`
    * @tparam T stream element type
    * @tparam K extracted key type for grouping into batches
    */
@@ -77,13 +84,13 @@ object CassandraFlow {
       writeSettings: CassandraWriteSettings,
       cqlStatement: String,
       statementBinder: (T, PreparedStatement) => BoundStatement,
-      partitionKey: akka.japi.Function[T, K]): Flow[T, T, NotUsed] = {
+      groupingKey: akka.japi.Function[T, K]): Flow[T, T, NotUsed] = {
     scaladsl.CassandraFlow
-      .createUnloggedBatch(
+      .createBatch(
         writeSettings,
         cqlStatement,
         (t, preparedStatement) => statementBinder.apply(t, preparedStatement),
-        t => partitionKey.apply(t))(session.delegate)
+        t => groupingKey.apply(t))(session.delegate)
       .asJava
   }
 

--- a/session/src/test/scala/docs/scaladsl/CassandraFlowSpec.scala
+++ b/session/src/test/scala/docs/scaladsl/CassandraFlowSpec.scala
@@ -161,12 +161,12 @@ class CassandraFlowSpec extends CassandraSpecBase(ActorSystem("CassandraFlowSpec
       val persons =
         immutable.Seq(Person(12, "John", "London"), Person(43, "Umberto", "Roma"), Person(56, "James", "Chicago"))
       val written = Source(persons)
-        .via(CassandraFlow.createUnloggedBatch(
+        .via(CassandraFlow.createBatch(
           CassandraWriteSettings.defaults,
           s"INSERT INTO $table(id, name, city) VALUES (?, ?, ?)",
           statementBinder = (person, preparedStatement) =>
             preparedStatement.bind(Int.box(person.id), person.name, person.city),
-          partitionKey = person => person.id))
+          groupingKey = person => person.id))
         .runWith(Sink.ignore)
       written.futureValue mustBe Done
 


### PR DESCRIPTION
* Change `createUnloggedBatch` to `createBatch`
* Default to **logged** batches, which Cassandra will optimize to unlogged if they hit a single partition
