### PR TITLE
Uprade driver while not updating netty

### DIFF
--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -92,7 +92,7 @@ object CassandraSpec {
  * Picks a free port for Cassandra before starting the ActorSystem
  */
 abstract class CassandraSpec(
-    config: Config,
+    config: Config = CassandraLifecycle.config,
     val journalName: String = getCallerName(getClass),
     val snapshotName: String = getCallerName(getClass),
     dumpRowsOnFailure: Boolean = true)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
@@ -16,6 +16,7 @@ import akka.persistence.typed.scaladsl.Effect
 import akka.persistence.typed.scaladsl.EventSourcedBehavior
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
+import scala.concurrent.duration._
 
 object CassandraLoadTypedSpec {
 
@@ -105,7 +106,7 @@ object CassandraLoadTypedSpec {
 
 }
 
-class CassandraLoadTypedSpec extends CassandraSpec with AnyWordSpecLike with Matchers {
+class CassandraLoadTypedSpec extends CassandraSpec(dumpRowsOnFailure = false) with AnyWordSpecLike with Matchers {
 
   import CassandraLoadTypedSpec._
 
@@ -130,7 +131,7 @@ class CassandraLoadTypedSpec extends CassandraSpec with AnyWordSpecLike with Mat
     }
 
     processor ! "stats"
-    val throughput = probe.expectMessageType[String]
+    val throughput = probe.expectMessageType[String](5.seconds)
     println(throughput)
   }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,8 +9,12 @@ object Dependencies {
   val AkkaVersion = System.getProperty("override.akka.version", "2.6.3")
   val AkkaVersionInDocs = System.getProperty("override.akka.version", "2.6")
   val CassandraVersionInDocs = "4.0"
-  val DriverVersion = "4.3.0"
-  val DriverVersionInDocs = "4.3"
+  val DriverVersion = "4.5.0"
+  val DriverVersionInDocs = DriverVersion.take(3)
+
+  // Performance dropped by ~40% when the driver upgraded to latest netty version
+  // override for now
+  val OverrideNettyVersion = "4.1.39.Final"
 
   val AlpakkaVersion = "2.0.0-M3"
   val AlpakkaVersionInDocs = "2.0"
@@ -24,6 +28,10 @@ object Dependencies {
 
   val akkaCassandraSessionDependencies = Seq(
     ("com.datastax.oss" % "java-driver-core" % DriverVersion).exclude("com.github.spotbugs", "spotbugs-annotations"),
+    "io.netty" % "netty-handler" % OverrideNettyVersion,
+    "io.netty" % "netty-all" % OverrideNettyVersion,
+    // Specifying guava dependency because older transitive dependency has security vulnerability
+    "com.google.guava" % "guava" % "27.0.1-jre",
     "com.typesafe.akka" %% "akka-stream" % AkkaVersion,
     "com.typesafe.akka" %% "akka-discovery" % AkkaVersion % Provided,
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test,
@@ -34,7 +42,6 @@ object Dependencies {
     Logback % Test)
 
   val reconcilerDependencies = Seq(
-    ("com.datastax.oss" % "java-driver-core" % DriverVersion).exclude("com.github.spotbugs", "spotbugs-annotations"),
     "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,
     "com.typesafe.akka" %% "akka-stream-testkit" % AkkaVersion % Test)
 
@@ -50,9 +57,6 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-cluster-sharding")
 
   val akkaPersistenceCassandraDependencies = Seq(
-      ("com.datastax.oss" % "java-driver-core" % DriverVersion).exclude("com.github.spotbugs", "spotbugs-annotations"),
-      // Specifying guava dependency because older transitive dependency has security vulnerability
-      "com.google.guava" % "guava" % "27.0.1-jre",
       "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
       "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
       "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,


### PR DESCRIPTION
The 4.5.0 means we can use the reactive streams API but also dropped
throughput by 40%.

Bisected the changes in the driver to see it was due to a Netty upgrade.

Raised https://datastax-oss.atlassian.net/browse/JAVA-2676 to track it
with the Java driver team.

4.5

throughput = 370.03 persistent events per second
throughput = 393.23 persistent events per second
throughput = 411.08 persistent events per second

throughput = 337.94 persistent events per second
throughput = 385.06 persistent events per second
throughput = 398.53 persistent events per second

4.4

throughput = 456.26 persistent events per second
throughput = 678.01 persistent events per second
throughput = 740.82 persistent events per second

throughput = 570.46 persistent events per second
throughput = 677.72 persistent events per second
throughput = 676.27 persistent events per second

4.5 with the netty overridden matches 4.4


