### PR TITLE
Document ways to test with Cassandra

### DIFF
--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -15,6 +15,7 @@ The Akka Persistence Cassandra plugin allows for using [Apache Cassandra](https:
 * [reconciliation](reconciliation.md)
 * [Snapshot Plugin](snapshots.md)
 * [Serialization](serialization.md)
+* [Testing](testing.md)
 * [CQRS](cqrs.md)
 * [scylladb](scylladb.md)
 * [migrations](migrations.md)

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,0 +1,22 @@
+# Testing
+
+There are numbers options for testing persistent actors when using the APC plugin.
+The two main methods are:
+
+* Testing using the inmem or Leveldb journals as shown in the [Akka docs](https://doc.akka.io/docs/akka/current/typed/persistence-testing.html).
+* Testing against a real Cassandra instance.
+
+For testing against Cassandra you can:
+
+* Use an existing cluster in your environment.
+* Install a local Cassandra cluster installed with your preferred method
+* Set up one locally with [Cassandra Cluster Manager](https://github.com/riptano/ccm)
+
+Then there are options with tighter unit test framework integration:
+
+* [Cassandra unit](https://github.com/jsevellec/cassandra-unit)
+* [Test Containers](https://www.testcontainers.org/modules/databases/cassandra/)
+
+
+
+

--- a/docs/src/main/paradox/testing.md
+++ b/docs/src/main/paradox/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-There are numbers options for testing persistent actors when using the APC plugin.
+There are a number of options for testing persistent actors when using the APC plugin.
 The two main methods are:
 
 * Testing using the inmem or Leveldb journals as shown in the [Akka docs](https://doc.akka.io/docs/akka/current/typed/persistence-testing.html).
@@ -17,6 +17,12 @@ Then there are options with tighter unit test framework integration:
 * [Cassandra unit](https://github.com/jsevellec/cassandra-unit)
 * [Test Containers](https://www.testcontainers.org/modules/databases/cassandra/)
 
+For testing it can be convenient to enable automatic creation of keyspace and tables with configuration:
 
-
+    akka.persistence.cassandra {
+      journal.keyspace-autocreate = on
+      journal.tables-autocreate = on
+      snapshot.keyspace-autocreate = on
+      snapshot.tables-autocreate = on
+    }
 


### PR DESCRIPTION
I didn't document CassandraLauncher. We aren't using it in tests any more
and CassandraLifecycle isn't public. Easier if users just use cassandra unit
or test containers.