### PR TITLE
Docs: link directly to Akka 2.5 for migration

### DIFF
--- a/docs/src/main/paradox/journal.md
+++ b/docs/src/main/paradox/journal.md
@@ -2,11 +2,11 @@
 
 ### Features
 
-- All operations required by the Akka Persistence @extref:[journal plugin API](akka:scala/persistence.html#journal-plugin-api) are fully supported.
+- All operations required by the Akka Persistence @extref:[journal plugin API](akka:persistence.html#journal-plugin-api) are fully supported.
 - The plugin uses Cassandra in a pure log-oriented way i.e. data is only ever inserted but never updated (deletions are made on user request only).
-- Writes of messages are batched to optimize throughput for `persistAsync`. See @extref:[batch writes](akka:scala/persistence.html#batch-writes) for details how to configure batch sizes. The plugin was tested to work properly under high load.
+- Writes of messages are batched to optimize throughput for `persistAsync`. See @extref:[batch writes](akka:persistence.html#batch-writes) for details how to configure batch sizes. The plugin was tested to work properly under high load.
 - Messages written by a single persistent actor are partitioned across the cluster to achieve scalability with data volume by adding nodes.
-- @extref:[Persistence Query](akka:scala/persistence-query.html) support by `CassandraReadJournal`
+- @extref:[Persistence Query](akka:persistence-query.html) support by `CassandraReadJournal`
 
 ### Schema 
 

--- a/docs/src/main/paradox/migrations.md
+++ b/docs/src/main/paradox/migrations.md
@@ -226,7 +226,7 @@ CassandraLauncher.start(
 
 ## Migrations from 0.23 to 0.50
 
-The Persistence Query API changed slightly, see @extref:[migration guide for Akka 2.5](akka:scala/project/migration-guide-2.4.x-2.5.x.html#persistence-query).
+The Persistence Query API changed slightly, see [migration guide for Akka 2.5](https://doc.akka.io/docs/akka/2.5/project/migration-guide-2.4.x-2.5.x.html#persistence-query).
 
 ## Migrations from 0.11 to 0.12
 

--- a/docs/src/main/paradox/read-journal.md
+++ b/docs/src/main/paradox/read-journal.md
@@ -1,6 +1,6 @@
 # Query Plugin
 
-It implements the following @extref:[Persistence Queries](akka:scala/persistence-query.html):
+It implements the following @extref:[Persistence Queries](akka:persistence-query.html):
 
 * eventsByPersistenceId, currentEventsByPersistenceId
 * eventsByTag, currentEventsByTag

--- a/docs/src/main/paradox/snapshots.md
+++ b/docs/src/main/paradox/snapshots.md
@@ -2,7 +2,7 @@
 
 ### Features
 
-- Implements the Akka Persistence @extref:[snapshot store plugin API](akka:scala/persistence.html#snapshot-store-plugin-api).
+- Implements the Akka Persistence @extref:[snapshot store plugin API](akka:persistence.html#snapshot-store-plugin-api).
 
 ### Configuration
 


### PR DESCRIPTION
Link to Akka docs without redirects.