### PR TITLE
WriteMessagesFailed changed in Akka master

### DIFF
--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -66,7 +66,7 @@ class CassandraJournalSpec extends JournalSpec(CassandraJournalConfiguration.con
 
       journal ! WriteMessages(List(AtomicWrite(msg)), probe.ref, actorInstanceId)
       val err = probe.expectMsgPF() {
-        case WriteMessagesFailed(cause) => cause
+        case fail: WriteMessagesFailed => fail.cause
       }
       probe.expectMsg(WriteMessageFailure(msg, err, actorInstanceId))
 


### PR DESCRIPTION
Snapshot build failed: https://travis-ci.org/github/akka/akka-persistence-cassandra/jobs/665509918

CassandraJournalSpec is using internal WriteMessagesFailed.