### PR TITLE
Log and recover errors from init function, #759

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -83,8 +83,9 @@ import akka.stream.scaladsl.Source
   // so fine to use an immutable list as the value
   private val pendingDeletes: JMap[String, List[PendingDelete]] = new JHMap
 
-  private val session: CassandraSession = CassandraSessionRegistry(context.system)
-    .sessionFor(sharedConfigPath, ses => statements.executeAllCreateKeyspaceAndTables(ses))
+  private val session: CassandraSession =
+    CassandraSessionRegistry(context.system)
+      .sessionFor(sharedConfigPath, ses => statements.executeAllCreateKeyspaceAndTables(ses, log))
 
   private val taggedPreparedStatements = new TaggedPreparedStatements(statements.journalStatements, session.prepare)
   private val tagWriterSession = TagWritersSession(

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -10,6 +10,7 @@ import scala.concurrent.Future
 
 import akka.Done
 import akka.annotation.InternalApi
+import akka.event.LoggingAdapter
 import akka.persistence.cassandra.PluginSettings
 import akka.persistence.cassandra.indent
 import com.datastax.oss.driver.api.core.CqlSession
@@ -338,8 +339,11 @@ import akka.persistence.cassandra.FutureDone
    * Execute creation of keyspace and tables if that is enabled in config.
    * Avoid calling this from several threads at the same time to
    * reduce the risk of (annoying) "Column family ID mismatch" exception.
+   *
+   * Exceptions will be logged but will not fail the returned Future.
    */
-  def executeCreateKeyspaceAndTables(session: CqlSession)(implicit ec: ExecutionContext): Future[Done] = {
+  def executeCreateKeyspaceAndTables(session: CqlSession, log: LoggingAdapter)(
+      implicit ec: ExecutionContext): Future[Done] = {
 
     def tagStatements: Future[Done] =
       if (eventsByTagSettings.eventsByTagEnabled) {
@@ -368,9 +372,19 @@ import akka.persistence.cassandra.FutureDone
         session.setSchemaMetadataEnabled(null)
         Done
       }
-      result.failed.foreach(_ => session.setSchemaMetadataEnabled(null))
-      result
-    } else keyspace
+      result.recoverWith {
+        case e =>
+          log.warning("Failed to create journal keyspace and tables: {}", e)
+          session.setSchemaMetadataEnabled(null)
+          FutureDone
+      }
+    } else {
+      keyspace.recoverWith {
+        case e =>
+          log.warning("Failed to create journal keyspace: {}", e)
+          FutureDone
+      }
+    }
 
     done
   }

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -149,7 +149,7 @@ class CassandraReadJournal protected (
    */
   val session: CassandraSession = {
     CassandraSessionRegistry(system).sessionFor(
-      CassandraSessionSettings(sharedConfigPath, ses => statements.executeAllCreateKeyspaceAndTables(ses)),
+      CassandraSessionSettings(sharedConfigPath, ses => statements.executeAllCreateKeyspaceAndTables(ses, log)),
       sharedConfig)
   }
 

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -62,7 +62,7 @@ import akka.stream.alpakka.cassandra.scaladsl.{ CassandraSession, CassandraSessi
 
   private val someMaxLoadAttempts = Some(snapshotSettings.maxLoadAttempts)
   private val session: CassandraSession = CassandraSessionRegistry(context.system)
-    .sessionFor(sharedConfigPath, ses => statements.executeAllCreateKeyspaceAndTables(ses))
+    .sessionFor(sharedConfigPath, ses => statements.executeAllCreateKeyspaceAndTables(ses, log))
 
   private def preparedWriteSnapshot =
     session.prepare(writeSnapshot(withMeta = false))


### PR DESCRIPTION
For example the infamous "Column family ID mismatch".

Refs #759