### PR TITLE
Initial testing with CosmosDB, #762

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -67,6 +67,11 @@ akka.persistence.cassandra {
   # won't function.
   coordinated-shutdown-on-error = off
 
+  compatibility {
+    # Enable this when using CosmosDB
+    cosmosdb = off
+  }
+
   //#shared
 
   //#journal

--- a/core/src/main/scala/akka/persistence/cassandra/PluginSettings.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/PluginSettings.scala
@@ -27,6 +27,8 @@ import com.typesafe.config.Config
   val snapshotSettings: SnapshotSettings = new SnapshotSettings(system, config)
 
   val healthCheckSettings: HealthCheckSettings = new HealthCheckSettings(system, config)
+
+  val cosmosDb: Boolean = config.getBoolean("compatibility.cosmosdb")
 }
 
 /**

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -131,7 +131,7 @@ import akka.stream.scaladsl.Source
   private def preparedDeleteMessages: Future[PreparedStatement] = {
     if (settings.journalSettings.supportDeletes) {
       session.serverMetaData.flatMap { meta =>
-        session.prepare(statements.journalStatements.deleteMessages(meta.isVersion2))
+        session.prepare(statements.journalStatements.deleteMessages(meta.isVersion2 || settings.cosmosDb))
       }
     } else
       deletesNotSupportedException
@@ -518,7 +518,7 @@ import akka.stream.scaladsl.Source
 
     def physicalDelete(lowestPartition: Long, highestPartition: Long, toSeqNr: Long): Future[Done] = {
       session.serverMetaData.flatMap { meta =>
-        if (meta.isVersion2) {
+        if (meta.isVersion2 || settings.cosmosDb) {
           physicalDelete2xCompat(lowestPartition, highestPartition, toSeqNr)
         } else {
           val deleteResult =

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/CassandraSnapshotStore.scala
@@ -219,6 +219,7 @@ import akka.stream.alpakka.cassandra.scaladsl.{ CassandraSession, CassandraSessi
   override def deleteAsync(persistenceId: String, criteria: SnapshotSelectionCriteria): Future[Unit] = {
     session.serverMetaData.flatMap { meta =>
       if (meta.isVersion2
+          || settings.cosmosDb
           || 0L < criteria.minTimestamp
           || criteria.maxTimestamp < SnapshotSelectionCriteria.latest().maxTimestamp) {
         preparedSelectSnapshotMetadata.flatMap { snapshotMetaPs =>

--- a/core/src/test/resources/logback-test.xml
+++ b/core/src/test/resources/logback-test.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-  <appender name="CONSOLE"
-  class="ch.qos.logback.core.ConsoleAppender">
-    <target>System.out</target>
+  <!-- Silence initial setup logging from Logback -->
+  <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+  <appender name="STDOUT" target="System.out" class="ch.qos.logback.core.ConsoleAppender">
     <encoder>
-      <pattern>%date{MM/dd HH:mm:ss} %-5level[%thread] %logger{1}
-      [%X{akkaSource}] - %m%n%xException</pattern>
+      <pattern>[%date{ISO8601}] [%level] [%logger] [%marker] [%thread] - %msg MDC: {%mdc}%n</pattern>
     </encoder>
   </appender>
   <logger name="org.apache.cassandra" level="ERROR" />

--- a/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/EventsByTagMigrationSpec.scala
@@ -411,7 +411,6 @@ abstract class AbstractEventsByTagMigrationSpec
   override protected def afterAll(): Unit = {
     try {
       externalCassandraCleanup()
-      cluster.close()
     } catch {
       case NonFatal(e) =>
         println("Failed to cleanup cassandra")

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
@@ -119,7 +119,7 @@ class CassandraLoadTypedSpec extends CassandraSpec(dumpRowsOnFailure = false) wi
 
   private def testThroughput(processor: ActorRef[Command], probe: TestProbe[String]): Unit = {
     val warmCycles = 100L
-    val loadCycles = 2000L
+    val loadCycles = 500L // increase for serious testing
 
     (1L to warmCycles).foreach { i =>
       processor ! "a"

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -182,6 +182,7 @@ class EventsByTagSpec extends AbstractEventsByTagSpec(EventsByTagSpec.config) {
 
   "Cassandra query currentEventsByTag" must {
     "set ttl on table" in {
+      cluster.refreshSchema()
       val options = cluster.getMetadata.getKeyspace(journalName).get.getTable("tag_views").get().getOptions
 
       options.get(CqlIdentifier.fromCql("default_time_to_live")) shouldEqual 86400
@@ -1394,10 +1395,12 @@ class EventsByTagDisabledSpec extends AbstractEventsByTagSpec(EventsByTagSpec.di
 
   "Events by tag disabled" must {
     "stop tag_views being created" in {
+      cluster.refreshSchema()
       cluster.getMetadata.getKeyspace(journalName).get.getTable("tag_views") shouldEqual Optional.empty()
     }
 
     "stop tag_progress being created" in {
+      cluster.refreshSchema()
       cluster.getMetadata.getKeyspace(journalName).get.getTable("tag_write_progress") shouldEqual Optional.empty()
     }
 

--- a/docs/src/main/paradox/cosmosdb.md
+++ b/docs/src/main/paradox/cosmosdb.md
@@ -1,0 +1,52 @@
+# CosmosDB
+
+@@@ warning
+
+**This project is not continuously tested against CosmosDB.**
+
+@@@
+
+[CosmosDB](https://docs.microsoft.com/en-us/azure/cosmos-db/) is a wire compatible replacement for Cassandra.
+
+Initial testing shows that most things are working. There is one issue related to deletes.
+Delete of events isn't supported because CosmosDB has a different behavior for clustering columns than Cassandra.
+This is probably will probably be fixed in CosmosDB.
+
+When using CosmosDB you need to configure:
+
+```
+akka.persistence.cassandra {
+  compatibility.cosmosdb = on
+  journal.gc-grace-seconds = 0
+  events-by-tag.gc-grace-seconds = 0
+}
+```
+
+The connection configuration can be defined with properties like the following example.
+
+```
+datastax-java-driver {
+  # using environment variables for the values
+  basic.contact-points = [${COSMOSDB_CONTACT_POINTS}]
+  basic.load-balancing-policy.local-datacenter = ${COSMOSDB_DATACENTER}
+  advanced.auth-provider {
+    class = PlainTextAuthProvider
+    username = ${COSMOSDB_USER}
+    password = ${COSMOSDB_PWD}
+  }
+  advanced.ssl-engine-factory {
+    class = DefaultSslEngineFactory
+  }
+  advanced.reconnect-on-init = true
+}
+```
+
+You need to define the variables `COSMOSDB_CONTACT_POINTS`, `COSMOSDB_DATACENTER`, `COSMOSDB_USER`,
+`COSMOSDB_PWD` as environment variables or system properties in the shell running the system.
+The connection details can be found in the Microsoft Azure CosmosDB portal. 
+
+If you don't know the datacenter you can first connect with `cqlsh` and query:
+```
+select * from system.local;
+```
+

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -16,6 +16,7 @@ The Akka Persistence Cassandra plugin allows for using [Apache Cassandra](https:
 * [CQRS](cqrs.md)
 * [Health check](healthcheck.md)
 * [Configuration](configuration.md)
+* [CosmosDB](cosmosdb.md)
 * [ScyllaDB](scylladb.md)
 * [Migrations](migrations.md)
 


### PR DESCRIPTION
* Most things seems to work fine.
* Delete of events isn't supported because CosmosDB has a different behavior for clustering columns than Cassandra.
  This is probably a bug in CosmosDB.
* Documented configuration for compat and connection

Apart from tests failing because of lack of support for delete events the
following tests are failing, were slow, or overloaded the quota of the "try" account.

Failing:
* akka.persistence.cassandra.query.EventsByTagFindDelayedEventsSpec - live eventsByTag delayed messages must find delayed events when many other events: got unexpected message
* akka.persistence.cassandra.query.EventsByTagPersistenceIdCleanupSpec - drop state and trigger new persistence id lookup peridodically: unexpected message

Very slow
* akka.persistence.cassandra.query.EventsByTagStrictBySeqNoEarlyFirstOffsetSpec - 354s, not failing
* akka.persistence.cassandra.query.EventsByTagZeroEventualConsistencyDelaySpec - hangs
* akka.persistence.cassandra.journal.RecoveryLoadSpec - not failing
* akka.persistence.cassandra.compaction.CassandraCompactionStrategySpec - not failing
* akka.persistence.cassandra.EventsByTagCrashSpec - never completes

Overloaded:
* akka.persistence.cassandra.journal.ManyActorsLoadSpec
* akka.persistence.cassandra.journal.StartupLoadSpec
* akka.persistence.cassandra.journal.CassandraLoadSpec
* akka.persistence.cassandra.journal.CassandraJournalPerfSpec
* akka.persistence.cassandra.EventsByTagStressSpec

truncate not supported:
* akka.persistence.cassandra.EventsByTagRecoverySpec
* akka.persistence.cassandra.reconciler.BuildTagViewForPersisetceIdSpec
* akka.persistence.cassandra.reconciler.TruncateAllSpec

Materialized view, not relevant:
* akka.persistence.cassandra.EventsByTagMigrationSpec
* akka.persistence.cassandra.EventsByTagMigrationProvidePersistenceIds


References #762
