### PR TITLE
Remove timebucket from clustering column, #399

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -121,7 +121,6 @@ import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
       .setLong("partition_nr", partitionNr)
       .setLong("sequence_nr", s.sequenceNr)
       .setUuid("timestamp", s.timeUuid)
-      .setString("timebucket", s.timeBucket.key.toString)
       .setInt("ser_id", s.serId)
       .setString("ser_manifest", s.serManifest)
       .setString("event_manifest", s.eventAdapterManifest)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -50,7 +50,7 @@ import akka.persistence.cassandra.FutureDone
       |  meta_ser_manifest text,
       |  meta blob,
       |  tags set<text>,
-      |  PRIMARY KEY ((persistence_id, partition_nr), sequence_nr, timestamp, timebucket))
+      |  PRIMARY KEY ((persistence_id, partition_nr), sequence_nr, timestamp))
       |  WITH gc_grace_seconds =${journalSettings.gcGraceSeconds}
       |  AND compaction = ${indent(journalSettings.tableCompactionStrategy.asCQL, "    ")}
     """.stripMargin.trim

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -136,20 +136,7 @@ import akka.persistence.cassandra.FutureDone
         persistence_id = ? AND
         partition_nr = ? AND
         sequence_nr = ? AND
-        timestamp = ? AND
-        timebucket = ?
-     """
-
-  def addTagsToMessagesTable: String =
-    s"""
-       UPDATE $tableName
-       SET tags = tags + ?
-       WHERE
-        persistence_id = ? AND
-        partition_nr = ? AND
-        sequence_nr = ? AND
-        timestamp = ? AND
-        timebucket = ?
+        timestamp = ?
      """
 
   def writeTags(withMeta: Boolean): String =


### PR DESCRIPTION
* originally there because of the materialized view
* for old table definitions it must be set
* would be difficult to remove it entirely from the table
  because then we would have to maintain two different insert statements
  depending on if the table defined the column or not, meaning that we
  would have to do some fake query when starting up to check if the column
  is defined

References #399
