### PR TITLE
Replicated Event Sourcing support

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/Extractors.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/Extractors.scala
@@ -188,7 +188,7 @@ import akka.persistence.typed.internal.ReplicatedEventMetadata
 
         payload match {
           case EventWithMetaData(p, m: ReplicatedEventMetadata) => repr.withMetadata(m).withPayload(p)
-          case _ => repr
+          case _                                                => repr
         }
       }
     }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -42,6 +42,7 @@ import scala.util.{ Failure, Success, Try }
 import scala.compat.java8.FutureConverters._
 import akka.annotation.DoNotInherit
 import akka.annotation.InternalStableApi
+import akka.persistence.typed.internal.ReplicatedEventMetadata
 import akka.stream.scaladsl.Source
 
 /**

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -655,7 +655,12 @@ class CassandraReadJournal protected (
 
   private def toEventEnvelope(persistentRepr: PersistentRepr, offset: Offset): immutable.Iterable[EventEnvelope] =
     adaptFromJournal(persistentRepr).map { payload =>
-      EventEnvelope(offset, persistentRepr.persistenceId, persistentRepr.sequenceNr, payload, timestampFrom(offset))
+      val env =
+        EventEnvelope(offset, persistentRepr.persistenceId, persistentRepr.sequenceNr, payload, timestampFrom(offset))
+      persistentRepr.metadata match {
+        case Some(replicatedMeta) => env.withMetadata(replicatedMeta)
+        case None                 => env
+      }
     }
 
   private def offsetToInternalOffset(offset: Offset): (UUID, Boolean) =

--- a/core/src/test/resources/application.conf
+++ b/core/src/test/resources/application.conf
@@ -12,3 +12,10 @@ datastax-java-driver {
   }
 
 }
+akka {
+  actor {
+    serialization-bindings {
+      "akka.persistence.cassandra.CborSerializable" = jackson-cbor
+    }
+  }
+}

--- a/core/src/test/scala/akka/persistence/cassandra/ActiveActiveSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/ActiveActiveSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+import akka.actor.typed.ActorRef
+import akka.actor.typed.Behavior
+import akka.persistence.cassandra.ActiveActiveSpec.MyActiveActiveStringSet
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.typed.ReplicaId
+import akka.persistence.typed.scaladsl.ActiveActiveEventSourcing
+import akka.persistence.typed.scaladsl.Effect
+import akka.persistence.typed.scaladsl.EventSourcedBehavior
+import akka.testkit.TestProbe
+
+object ActiveActiveSpec {
+
+  object MyActiveActiveStringSet {
+    trait Command extends CborSerializable
+    case class Add(text: String) extends Command
+    case class GetTexts(replyTo: ActorRef[Texts]) extends Command
+    case object Stop extends Command
+    case class Texts(texts: Set[String]) extends CborSerializable
+
+    def apply(entityId: String, replicaId: ReplicaId, allReplicas: Set[ReplicaId]): Behavior[Command] =
+      ActiveActiveEventSourcing.withSharedJournal(entityId, replicaId, allReplicas, CassandraReadJournal.Identifier) {
+        aaContext =>
+          EventSourcedBehavior[Command, String, Set[String]](
+            aaContext.persistenceId,
+            Set.empty[String],
+            (state, command) =>
+              command match {
+                case Add(text) =>
+                  Effect.persist(text)
+                case GetTexts(replyTo) =>
+                  replyTo ! Texts(state)
+                  Effect.none
+              },
+            (state, event) => state + event).withJournalPluginId("akka.persistence.cassandra.journal")
+      }
+  }
+
+}
+
+class ActiveActiveSpec extends CassandraSpec {
+
+  "Active active" must {
+    "work with Cassandra as journal" in {
+      import akka.actor.typed.scaladsl.adapter._
+      val allReplicas = Set(ReplicaId("DC-A"), ReplicaId("DC-B"))
+      val aProps = PropsAdapter(MyActiveActiveStringSet("id-1", ReplicaId("DC-A"), allReplicas))
+      val replicaA = system.actorOf(aProps)
+      val replicaB = system.actorOf(PropsAdapter(MyActiveActiveStringSet("id-1", ReplicaId("DC-B"), allReplicas)))
+
+      replicaA ! MyActiveActiveStringSet.Add("added to a")
+      replicaB ! MyActiveActiveStringSet.Add("added to b")
+      val stopProbe = TestProbe()
+      stopProbe.watch(replicaA)
+      replicaA ! MyActiveActiveStringSet.Stop
+      stopProbe.expectTerminated(replicaA)
+
+      val restartedReplicaA = system.actorOf(aProps)
+      awaitAssert {
+        val probe = TestProbe()
+        restartedReplicaA ! MyActiveActiveStringSet.GetTexts(probe.ref.toTyped)
+        probe.expectMsgType[MyActiveActiveStringSet.Texts].texts should ===(Set("added to a", "added to b"))
+      }
+    }
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/cassandra/ActiveActiveSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/ActiveActiveSpec.scala
@@ -36,6 +36,8 @@ object ActiveActiveSpec {
                 case GetTexts(replyTo) =>
                   replyTo ! Texts(state)
                   Effect.none
+                case Stop =>
+                  Effect.stop()
               },
             (state, event) => state + event).withJournalPluginId("akka.persistence.cassandra.journal")
       }

--- a/core/src/test/scala/akka/persistence/cassandra/CborSerializable.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CborSerializable.scala
@@ -1,0 +1,7 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra
+
+trait CborSerializable

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraJournalSpec.scala
@@ -42,6 +42,10 @@ class CassandraJournalSpec extends JournalSpec(CassandraJournalConfiguration.con
 
   override def supportsRejectingNonSerializableObjects = false
 
+  // we cannot enable this because we need to discern legacy metadata format from multidc support
+  // from active active by the actual type of the metadata
+  // override def supportsMetadata = CapabilityFlag.on()
+
   "A Cassandra Journal" must {
     "insert Cassandra metrics to Cassandra Metrics Registry" in {
       val registry = CassandraMetricsRegistry(system).getRegistry

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -6,7 +6,8 @@ object Dependencies {
   val Scala213 = "2.13.1"
   val ScalaVersions = Seq(Scala212, Scala213)
 
-  val AkkaVersion = System.getProperty("override.akka.version", "2.6.4")
+  // FIXME actual patch release with active active metadata
+  val AkkaVersion = System.getProperty("override.akka.version", "2.6.8+31-a9efe189+20200723-1641")
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val CassandraVersionInDocs = "4.0"
   val DriverVersionInDocs = "4.5"
@@ -41,6 +42,7 @@ object Dependencies {
   val akkaPersistenceCassandraDependencies = Seq(
       "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % AlpakkaVersion,
       "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-persistence-typed" % AkkaVersion % Optional,
       "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
       "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
       Logback % Test,

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,8 @@ object Dependencies {
     "com.typesafe.akka" %% "akka-persistence-tck",
     "com.typesafe.akka" %% "akka-stream-testkit",
     "com.typesafe.akka" %% "akka-multi-node-testkit",
-    "com.typesafe.akka" %% "akka-cluster-sharding")
+    "com.typesafe.akka" %% "akka-cluster-sharding",
+    "com.typesafe.akka" %% "akka-serialization-jackson")
 
   val akkaPersistenceCassandraDependencies = Seq(
       "com.lightbend.akka" %% "akka-stream-alpakka-cassandra" % AlpakkaVersion,


### PR DESCRIPTION
This won't work until we have released an Akka version with Active Active.

A bit messier than necessary because I kept support for MultiDC but maybe we should throw that away?