### PR TITLE
Include information for Cassandra-as-a-Service

### DIFF
--- a/docs/src/main/paradox/astra.md
+++ b/docs/src/main/paradox/astra.md
@@ -1,0 +1,23 @@
+# DataStax Astra
+
+You can spin up a free Apache Cassandra cluster in the cloud using [DataStax
+Astra](https://www.datastax.com/products/datastax-astra). To use a Cassandra-as-a-Service cluster as Akka persistence,
+specify your secure connect bundle and credentials in your configuration instead of the contact points:
+
+```
+datastax-java-driver {
+  basic {
+    session-keyspace = my_keyspace
+    cloud {
+      secure-connect-bundle = /path/to/secure-connect-database_name.zip
+    }
+  }
+  advanced {
+    auth-provider {
+      class = PlainTextAuthProvider
+      username = <user name> 
+      password = <password>
+    }
+  }
+}
+```

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -49,3 +49,27 @@ Alternatively, Akka Discovery can be used for finding the Cassandra server conta
 in the @extref:[Alpakka Cassandra documentation](alpakka:cassandra.html#using-akka-discovery).
 
 Without any configuration it will use `localhost:9042` as default.
+
+## Using Cassandra-as-a-Service
+
+You can spin up a free Apache Cassandra cluster in the cloud using [DataStax
+Astra](https://www.datastax.com/products/datastax-astra). To use a Cassandra-as-a-Service cluster as Akka persistence,
+specify your secure connect bundle and credentials in your configuration instead of the contact points:
+
+```
+datastax-java-driver {
+  basic {
+    session-keyspace = my_keyspace
+    cloud {
+      secure-connect-bundle = /path/to/secure-connect-database_name.zip
+    }
+  }
+  advanced {
+    auth-provider {
+      class = PlainTextAuthProvider
+      username = user_name 
+      password = p@ssword1
+    }
+  }
+}
+```

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -49,27 +49,3 @@ Alternatively, Akka Discovery can be used for finding the Cassandra server conta
 in the @extref:[Alpakka Cassandra documentation](alpakka:cassandra.html#using-akka-discovery).
 
 Without any configuration it will use `localhost:9042` as default.
-
-## Using Cassandra-as-a-Service
-
-You can spin up a free Apache Cassandra cluster in the cloud using [DataStax
-Astra](https://www.datastax.com/products/datastax-astra). To use a Cassandra-as-a-Service cluster as Akka persistence,
-specify your secure connect bundle and credentials in your configuration instead of the contact points:
-
-```
-datastax-java-driver {
-  basic {
-    session-keyspace = my_keyspace
-    cloud {
-      secure-connect-bundle = /path/to/secure-connect-database_name.zip
-    }
-  }
-  advanced {
-    auth-provider {
-      class = PlainTextAuthProvider
-      username = <user name> 
-      password = <password>
-    }
-  }
-}
-```

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -67,8 +67,8 @@ datastax-java-driver {
   advanced {
     auth-provider {
       class = PlainTextAuthProvider
-      username = user_name 
-      password = p@ssword1
+      username = <user name> 
+      password = <password>
     }
   }
 }

--- a/docs/src/main/paradox/index.md
+++ b/docs/src/main/paradox/index.md
@@ -17,6 +17,7 @@ The Akka Persistence Cassandra plugin allows for using [Apache Cassandra](https:
 * [Health check](healthcheck.md)
 * [Configuration](configuration.md)
 * [CosmosDB](cosmosdb.md)
+* [DataStax Astra](astra.md)
 * [ScyllaDB](scylladb.md)
 * [Migrations](migrations.md)
 


### PR DESCRIPTION
I've added a section in the docs for the configuration settings required to use Cassandra as a service.