### PR TITLE
Set metadata on events by persisence id query

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -663,7 +663,13 @@ class CassandraReadJournal protected (
 
   private def toEventEnvelope(persistentRepr: PersistentRepr, offset: Offset): immutable.Iterable[EventEnvelope] =
     adaptFromJournal(persistentRepr).map { payload =>
-      EventEnvelope(offset, persistentRepr.persistenceId, persistentRepr.sequenceNr, payload, timestampFrom(offset))
+      EventEnvelope(
+        offset,
+        persistentRepr.persistenceId,
+        persistentRepr.sequenceNr,
+        payload,
+        timestampFrom(offset),
+        persistentRepr.metadata)
     }
 
   private def offsetToInternalOffset(offset: Offset): (UUID, Boolean) =

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByPersistenceIdSpec.scala
@@ -284,6 +284,14 @@ class EventsByPersistenceIdSpec extends CassandraSpec(EventsByPersistenceIdSpec.
         }
       }
     }
+
+    "return metadata" in {
+      val meta = "cats"
+      val pr1 = PersistentRepr("e1", 1L, "with-meta", "").withMetadata(meta)
+      writeTestEvent(pr1)
+      val src = queries.currentEventsByPersistenceId("with-meta", 0L, Long.MaxValue)
+      src.map(_.eventMetadata).runWith(TestSink.probe[Any]).request(2).expectNext(Some(meta)).expectComplete()
+    }
   }
 
   "Cassandra live query EventsByPersistenceId" must {


### PR DESCRIPTION
This went missing between closing https://github.com/akka/akka-persistence-cassandra/pull/797
and opening https://github.com/akka/akka-persistence-cassandra/pull/811/files