### PR TITLE
Reverse sort fix

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -280,11 +280,9 @@ import akka.persistence.cassandra.FutureDone
 
   def selectHighestSequenceNr =
     s"""
-     SELECT sequence_nr FROM $tableName WHERE
+     SELECT max(sequence_nr) FROM $tableName WHERE
        persistence_id = ? AND
        partition_nr = ?
-       ORDER BY sequence_nr
-       DESC LIMIT 1
    """
 
   def selectDeletedTo =

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalStatements.scala
@@ -280,7 +280,7 @@ import akka.persistence.cassandra.FutureDone
 
   def selectHighestSequenceNr =
     s"""
-     SELECT max(sequence_nr) FROM $tableName WHERE
+     SELECT max(sequence_nr) as sequence_nr FROM $tableName WHERE
        persistence_id = ? AND
        partition_nr = ?
    """


### PR DESCRIPTION
Issue: https://github.com/akka/akka-persistence-cassandra/issues/801 

Tests passing, except one test unrelated to this fix (issue with loading snapshots). Failed test:-

```[info] - must give up after 3 snapshot loading attempts *** FAILED *** (19 milliseconds)
[info]   java.lang.AssertionError: assertion failed: expected:  but got unexpected message LoadSnapshotFailed(java.io.NotSerializableException: Cannot find manifest class [] for serializer with id [0].)
[info]   at scala.Predef$.assert(Predef.scala:223)
[info]   at akka.testkit.TestKitBase.expectMsgPF(TestKit.scala:478)
[info]   at akka.testkit.TestKitBase.expectMsgPF$(TestKit.scala:474)
[info]   at akka.testkit.TestKit.expectMsgPF(TestKit.scala:969)
[info]   at akka.persistence.cassandra.snapshot.CassandraSnapshotStoreSpec.$anonfun$new$4(CassandraSnapshotStoreSpec.scala:110)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike$$anon$3.apply(AnyWordSpecLike.scala:1076)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]   at akka.persistence.PluginSpec.withFixture(PluginSpec.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.invokeWithFixture$1(AnyWordSpecLike.scala:1074)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTest$1(AnyWordSpecLike.scala:1086)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest(AnyWordSpecLike.scala:1086)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTest$(AnyWordSpecLike.scala:1068)
[info]   at akka.persistence.PluginSpec.org$scalatest$BeforeAndAfterEach$$super$runTest(PluginSpec.scala:20)
[info]   at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
[info]   at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
[info]   at akka.persistence.PluginSpec.runTest(PluginSpec.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$runTests$1(AnyWordSpecLike.scala:1145)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]   at scala.collection.immutable.List.foreach(List.scala:392)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:390)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:427)
[info]   at scala.collection.immutable.List.foreach(List.scala:392)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests(AnyWordSpecLike.scala:1145)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.runTests$(AnyWordSpecLike.scala:1144)
[info]   at akka.persistence.PluginSpec.runTests(PluginSpec.scala:20)
[info]   at org.scalatest.Suite.run(Suite.scala:1112)
[info]   at org.scalatest.Suite.run$(Suite.scala:1094)
[info]   at akka.persistence.PluginSpec.org$scalatest$wordspec$AnyWordSpecLike$$super$run(PluginSpec.scala:20)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.$anonfun$run$1(AnyWordSpecLike.scala:1190)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run(AnyWordSpecLike.scala:1190)
[info]   at org.scalatest.wordspec.AnyWordSpecLike.run$(AnyWordSpecLike.scala:1188)
[info]   at akka.persistence.PluginSpec.org$scalatest$BeforeAndAfterAll$$super$run(PluginSpec.scala:20)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at akka.persistence.PluginSpec.run(PluginSpec.scala:20)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:318)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:513)
[info]   at sbt.TestRunner.runTest$1(TestFramework.scala:139)
[info]   at sbt.TestRunner.run(TestFramework.scala:154)
[info]   at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.$anonfun$apply$1(TestFramework.scala:317)
[info]   at sbt.TestFramework$.sbt$TestFramework$$withContextLoader(TestFramework.scala:277)
[info]   at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:317)
[info]   at sbt.TestFramework$$anon$3$$anonfun$$lessinit$greater$1.apply(TestFramework.scala:317)
[info]   at sbt.TestFunction.apply(TestFramework.scala:329)
[info]   at sbt.Tests$.processRunnable$1(Tests.scala:350)
[info]   at sbt.Tests$.$anonfun$makeSerial$1(Tests.scala:356)
[info]   at sbt.std.Transform$$anon$3.$anonfun$apply$2(Transform.scala:46)
[info]   at sbt.std.Transform$$anon$4.work(Transform.scala:67)
[info]   at sbt.Execute.$anonfun$submit$2(Execute.scala:281)
[info]   at sbt.internal.util.ErrorHandling$.wideConvert(ErrorHandling.scala:19)
[info]   at sbt.Execute.work(Execute.scala:290)
[info]   at sbt.Execute.$anonfun$submit$1(Execute.scala:281)
[info]   at sbt.ConcurrentRestrictions$$anon$4.$anonfun$submitValid$1(ConcurrentRestrictions.scala:178)
[info]   at sbt.CompletionService$$anon$2.call(CompletionService.scala:37)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[info]   at java.base/java.lang.Thread.run(Thread.java:834)
```

Need to test on Scylla as this should now pass on scylla also. 


