### PR TITLE
use unique pubsub topic for each tag

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -274,7 +274,7 @@ import akka.util.UUIDComparator
 
   private def sendPubsubNotification(): Unit = {
     pubsub.foreach {
-      _ ! DistributedPubSubMediator.Publish("akka.persistence.cassandra.journal.tag", tag)
+      _ ! DistributedPubSubMediator.Publish(s"apc.tags.$tag", tag)
     }
   }
 

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByTagStage.scala
@@ -402,7 +402,7 @@ import scala.compat.java8.FutureConverters._
                 }
             }
             DistributedPubSub(system).mediator !
-            DistributedPubSubMediator.Subscribe("akka.persistence.cassandra.journal.tag", this.stageActor.ref)
+            DistributedPubSubMediator.Subscribe(s"apc.tags.${session.tag}", this.stageActor.ref)
           }
         }
         query()


### PR DESCRIPTION
* to avoid publishing messages to nodes where the query for the specific
  tag isn't running
* for example when using Projections with ShardedDaemonProcess
* because of the rename the notifications will not make it during a
  rolling update, but I think that is acceptable since it will start
  working again when the roll out is completed
