### PR TITLE
allEvents query, maybe alternative for Projections, #823

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -573,3 +573,22 @@ datastax-java-driver {
   }
 }
 //#profile
+
+// FIXME real config
+all-events-query {
+  low-throttle-delay = 100 ms
+  high-throttle-delay = 1000 ms
+
+  direct-replication.enabled = on
+
+  lru-cache {
+    enabled = on
+    time-to-live = 10 minutes
+    number-of-buckets = 100
+    max-entries = 100000
+  }
+
+  scan-all-initial-delay = 5 minutes
+  scan-all-interval = 30 minutes
+
+}

--- a/core/src/main/scala/akka/persistence/cassandra/query/AllEvents.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/AllEvents.scala
@@ -1,0 +1,355 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.query
+
+import java.util.concurrent.atomic.AtomicLong
+
+import scala.annotation.tailrec
+import scala.concurrent.ExecutionContext
+import scala.concurrent.duration._
+
+import akka.Done
+import akka.NotUsed
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.ExtendedActorSystem
+import akka.actor.PoisonPill
+import akka.actor.Props
+import akka.cluster.pubsub.DistributedPubSub
+import akka.cluster.pubsub.DistributedPubSubMediator
+import akka.dispatch.ExecutionContexts
+import akka.persistence.PersistentRepr
+import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
+import akka.persistence.query.AllEventsOffset
+import akka.persistence.query.EventEnvelope
+import akka.persistence.query.Offset
+import akka.stream.KillSwitches
+import akka.stream.scaladsl.Keep
+import akka.stream.scaladsl.Sink
+import akka.stream.scaladsl.Source
+import akka.util.Timeout
+
+// FIXME this can probably be implemented in akka-persistence-query
+// only needs `persistenceIds` and `currentEventsByPersistenceId`
+
+object AllEvents {
+  import PersistenceIdsState._
+
+  implicit val askTimeout: Timeout = 10.seconds
+
+  private val actorNameCounter = new AtomicLong()
+
+  def topicNameFromPersistenceId(pid: PersistenceId, numberOfSlices: Int): String = {
+    val entityName = {
+      val i = pid.indexOf('|')
+      if (i >= 0) pid.substring(0, i)
+      else "all"
+    }
+    val slice = math.abs(pid.hashCode % numberOfSlices)
+    topicName(entityName, slice)
+  }
+
+  def topicName(entityName: String, slice: Int): String =
+    s"apc.events.$entityName-$slice"
+
+  // FIXME haven't thought about the real API here yet
+  def allEvents(
+      system: ActorSystem,
+      queries: CassandraReadJournal,
+      offset: AllEventsOffset,
+      entityName: String,
+      slice: Int,
+      numberOfSlices: Int): Source[EventEnvelope, NotUsed] = {
+    allEvents(
+      queries,
+      matchingPersistenceId = pid => math.abs(pid.hashCode % numberOfSlices) == slice,
+      offset,
+      subscribeForDirectEvents = ref =>
+        DistributedPubSub(system).mediator ! DistributedPubSubMediator.Subscribe(topicName(entityName, slice), ref))
+  }
+
+  def allEvents(
+      queries: CassandraReadJournal,
+      matchingPersistenceId: PersistenceId => Boolean,
+      offset: AllEventsOffset,
+      subscribeForDirectEvents: ActorRef => Unit): Source[EventEnvelope, NotUsed] = {
+
+    def findAndEmitEvents(
+        persistenceIdsState: ActorRef,
+        pid: PersistenceId,
+        seqNr: SeqNr): Source[EventEnvelope, NotUsed] = {
+      queries
+        .currentEventsByPersistenceId(pid, seqNr + 1, Long.MaxValue)
+        .alsoTo(Sink.lastOption.mapMaterializedValue { lastFut =>
+          // when the persistenceIdsState actor has handed out a persistenceId it will not emit that again until
+          // it receives the updated seqNr
+          lastFut.map {
+            case None => persistenceIdsState ! UpdatePersistenceIdOffset(pid, seqNr, directEvents = false)
+            case Some(last) =>
+              persistenceIdsState ! UpdatePersistenceIdOffset(last.persistenceId, last.sequenceNr, directEvents = false)
+          }(ExecutionContexts.parasitic)
+          NotUsed
+        })
+    }
+
+    def emitEvents(persistenceIdsState: ActorRef, events: Vector[PersistentRepr]): Source[EventEnvelope, NotUsed] = {
+      val last = events.last
+      persistenceIdsState ! UpdatePersistenceIdOffset(last.persistenceId, last.sequenceNr, directEvents = true)
+      Source(
+        events.map(
+          repr =>
+            EventEnvelope(
+              Offset.sequence(repr.sequenceNr),
+              repr.persistenceId,
+              repr.sequenceNr,
+              repr.payload,
+              repr.timestamp)))
+    }
+
+    Source
+      .fromMaterializer { (mat, _) =>
+        val system = mat.system.asInstanceOf[ExtendedActorSystem]
+        implicit val ec: ExecutionContext = mat.executionContext
+
+        val persistenceIdsState: ActorRef = system.systemActorOf(
+          PersistenceIdsState.props(offset, matchingPersistenceId),
+          s"persistenceIdsState-${actorNameCounter.incrementAndGet()}")
+        subscribeForDirectEvents(persistenceIdsState)
+
+        val killSwitch = KillSwitches.shared(persistenceIdsState.path.name)
+
+        // FIXME handle failures, restart
+        // TODO we could maybe have a single ActorSystem global persistenceIds and merge with a currentPersistenceIds
+        queries
+          .persistenceIds()
+          .via(killSwitch.flow)
+          .filterNot(offset.offsets.contains) // already known
+          .filter(matchingPersistenceId)
+          .ask[Done](10)(persistenceIdsState)
+          .runWith(Sink.ignore)(mat)
+
+        Source
+          .repeat(GetNextPersistenceId)
+          .ask[NextPersistenceId](1)(persistenceIdsState)
+          .flatMapConcat {
+            case NextPersistenceId(pid, seqNr, events) =>
+              if (pid == "")
+                Source.empty
+              else if (events.isEmpty)
+                findAndEmitEvents(persistenceIdsState, pid, seqNr)
+              else
+                emitEvents(persistenceIdsState, events)
+          }
+          .watchTermination()(Keep.right)
+          .mapMaterializedValue { done =>
+            done.onComplete { _ =>
+              killSwitch.shutdown()
+              persistenceIdsState ! PoisonPill
+            }
+            NotUsed
+          }
+      }
+      .mapMaterializedValue(_ => NotUsed)
+
+  }
+
+}
+
+object PersistenceIdsState {
+  type PersistenceId = String
+  type SeqNr = Long
+
+  case object GetNextPersistenceId
+  final case class NextPersistenceId(pid: PersistenceId, seqNr: SeqNr, events: Vector[PersistentRepr])
+  final case class UpdatePersistenceIdOffset(pid: PersistenceId, seqNr: SeqNr, directEvents: Boolean)
+
+  private object PidState {
+    val empty: PidState = PidState(0L, Vector.empty, inFlight = false)
+  }
+  private case class PidState(seqNr: SeqNr, bufferedDirect: Vector[PersistentRepr], inFlight: Boolean)
+
+  def props(offset: AllEventsOffset, matchingPersistenceId: PersistenceIdsState.PersistenceId => Boolean): Props =
+    Props(new PersistenceIdsState(offset, matchingPersistenceId))
+
+}
+
+class PersistenceIdsState(offset: AllEventsOffset, matchingPersistenceId: PersistenceIdsState.PersistenceId => Boolean)
+    extends Actor
+    with ActorLogging {
+  import PersistenceIdsState._
+
+  private var pidState: Map[PersistenceId, PidState] = offset.offsets.iterator.map {
+    case (pid, seqNr) => pid -> PidState(seqNr, Vector.empty, inFlight = false)
+  }.toMap
+  // FIXME more efficient Queue?
+  private var pending: Vector[PersistenceId] = pidState.keysIterator.toVector.sorted
+  private var directPending: Vector[PersistenceId] = Vector.empty
+
+  private var throttleDelay: FiniteDuration = Duration.Zero
+  private var updateCount = 0
+
+  log.debug("Starting PersistenceIdsState [{}] with [{}] pids in offset.", self.path.name, offset.offsets.size)
+
+  private def scheduler = context.system.scheduler
+
+  private def nextDirectPending(): Option[(PersistenceId, PidState)] = {
+    if (directPending.isEmpty) {
+      None
+    } else {
+
+      val iter = directPending.iterator
+      @tailrec def findNext(): Option[(PersistenceId, PidState)] = {
+        if (iter.isEmpty) {
+          None
+        } else {
+          val pid = iter.next()
+          val state = pidState(pid)
+          if (state.inFlight || state.bufferedDirect.isEmpty) {
+            findNext()
+          } else {
+            // FIXME filterNot is not very efficient, better mutable collection for this purpose?
+            directPending = directPending.filterNot(_ == pid)
+            Some(pid -> state)
+          }
+        }
+      }
+
+      findNext()
+    }
+  }
+
+  private def nextPending(): Option[(PersistenceId, PidState)] = {
+    if (pending.isEmpty && pidState.nonEmpty) {
+      log.debug("Reset pending pids, size [{}]. Found events for [{}] pids.", pidState.size, updateCount)
+      if (updateCount == 0)
+        throttleDelay = 50.millis // FIXME config
+      updateCount = 0
+      pending = pidState.keysIterator.toVector.sorted
+    }
+
+    @tailrec def findNext(): Option[(PersistenceId, PidState)] = {
+      if (pending.isEmpty) {
+        None
+      } else {
+        val pid = pending.head
+        pending = pending.tail
+
+        val state = pidState(pid)
+        if (state.inFlight || state.bufferedDirect.nonEmpty)
+          findNext()
+        else
+          Some(pid -> state)
+      }
+    }
+    findNext()
+  }
+
+  override def receive: Receive = {
+    case pid: PersistenceId =>
+      if (!pidState.contains(pid)) {
+        log.debug("New pid [{}].", pid)
+        pidState = pidState.updated(pid, PidState.empty)
+        // add first to give new pid priority
+        pending = pid +: pending
+      }
+      sender() ! Done
+
+    case direct: PersistentRepr =>
+      val pid = direct.persistenceId
+      if (matchingPersistenceId(pid)) {
+        pidState.get(pid) match {
+          case Some(s @ PidState(seqNr, buffered, _)) =>
+            val expectedSeqNr =
+              if (buffered.isEmpty) seqNr + 1
+              else buffered.last.sequenceNr + 1
+            if (direct.sequenceNr == expectedSeqNr) {
+              log.debug("Received direct event pid [{}] seqNr [{}].", pid, direct.sequenceNr)
+              pidState = pidState.updated(pid, s.copy(bufferedDirect = buffered :+ direct))
+              directPending :+= pid
+            } else {
+              log.debug(
+                "Received direct event pid [{}] seqNr [{}], but expected seqNr [{}].",
+                pid,
+                direct.sequenceNr,
+                seqNr + 1)
+              // add first to give query for this pid priority
+              pending = pid +: pending
+            }
+          case None =>
+            if (direct.sequenceNr == 1L) {
+              log.debug("Received direct event new pid [{}] seqNr [{}]", pid, direct.sequenceNr)
+              pidState = pidState.updated(pid, PidState(0L, Vector(direct), inFlight = false))
+              directPending :+= pid
+            } else {
+              log.debug(
+                "Received direct event new pid [{}] seqNr [{}], but expected seqNr [{}].",
+                pid,
+                direct.sequenceNr,
+                1)
+              pidState = pidState.updated(pid, PidState.empty)
+              // add first to give query for this pid priority
+              pending = pid +: pending
+            }
+        }
+      } else {
+        log.debug("Received direct event pid [{}] seqNr [{}], but not with matching pid", pid, direct.sequenceNr)
+      }
+
+    case GetNextPersistenceId =>
+      // FIXME fairness between direct and other
+      // first look for buffered direct events
+      nextDirectPending() match {
+        case Some((pid, state)) =>
+          log.debug(
+            "Next pid [{}] via direct event, seqNr [{} - {}].",
+            pid,
+            state.bufferedDirect.head.sequenceNr,
+            state.bufferedDirect.last.sequenceNr)
+          // also update the seqNr so that new direct events are accepted and buffered while these are in flight
+          pidState = pidState.updated(
+            pid,
+            state.copy(seqNr = state.bufferedDirect.last.sequenceNr, bufferedDirect = Vector.empty, inFlight = true))
+          sender() ! NextPersistenceId(pid, state.seqNr, state.bufferedDirect)
+
+        case None =>
+          // then look for next in the order of the `pending`
+          nextPending() match {
+            case Some((pid, state)) =>
+              log.debug("Next pid [{}] from seqNr [{}].", pid, state.seqNr + 1)
+              pidState = pidState.updated(pid, state.copy(inFlight = true))
+              val reply = NextPersistenceId(pid, state.seqNr, Vector.empty)
+              if (throttleDelay == Duration.Zero)
+                sender() ! reply
+              else
+                scheduler.scheduleOnce(throttleDelay, sender(), reply)(context.dispatcher)
+            case None =>
+              log.debug("No pending pids.")
+              // slow down
+              scheduler.scheduleOnce(200.millis, sender(), NextPersistenceId("", 0, Vector.empty))(context.dispatcher)
+          }
+      }
+
+    case UpdatePersistenceIdOffset(pid, seqNr, directEvents) =>
+      val state = pidState(pid)
+      if (directEvents) {
+        log.debug("Delivered direct events pid [{}] to seqNr [{}].", pid, seqNr)
+      } else if (seqNr == state.seqNr) {
+        log.debug("No events found pid [{}] from seqNr [{}].", pid, seqNr + 1)
+      } else {
+        throttleDelay = Duration.Zero
+        updateCount += 1
+        log.debug("Updated pid [{}] with seqNr [{}]. Found events for [{}] pids.", pid, seqNr, updateCount)
+      }
+      val newBufferredDirrect =
+        if (state.bufferedDirect.isEmpty)
+          state.bufferedDirect
+        else
+          state.bufferedDirect.dropWhile(_.sequenceNr <= seqNr)
+      pidState =
+        pidState.updated(pid, state.copy(seqNr = seqNr, bufferedDirect = newBufferredDirrect, inFlight = false))
+  }
+}

--- a/core/src/main/scala/akka/persistence/cassandra/query/LruPersistenceIds.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/LruPersistenceIds.scala
@@ -1,0 +1,204 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.query
+
+import java.util.concurrent.ThreadLocalRandom
+
+import scala.concurrent.duration._
+
+import akka.actor.Actor
+import akka.actor.ActorLogging
+import akka.actor.ActorRef
+import akka.actor.ActorSystem
+import akka.actor.ClassicActorSystemProvider
+import akka.actor.ExtendedActorSystem
+import akka.actor.Extension
+import akka.actor.ExtensionId
+import akka.actor.ExtensionIdProvider
+import akka.actor.Props
+import akka.actor.Timers
+import akka.cluster.ddata.DistributedData
+import akka.cluster.ddata.LWWMap
+import akka.cluster.ddata.LWWMapKey
+import akka.cluster.ddata.Replicator
+import akka.cluster.ddata.SelfUniqueAddress
+import akka.util.JavaDurationConverters._
+
+object LruPersistenceIds extends ExtensionId[LruPersistenceIdsExt] with ExtensionIdProvider {
+  type PersistenceId = String
+  type Timestamp = Long
+
+  def props(subscriber: ActorRef, predicate: LruPersistenceIds.PersistenceId => Boolean): Props = {
+    Props(new LruPersistenceIds(subscriber, predicate))
+  }
+
+  final case class ActivePids(pids: Set[PersistenceId])
+  final case class InactivePids(pids: Set[PersistenceId])
+
+  private case object CleanupTick
+  private final case class Cleanup(bucketKey: LWWMapKey[PersistenceId, Timestamp])
+
+  val BucketKeyPrefix = "lruPids-"
+
+  override def get(system: ActorSystem): LruPersistenceIdsExt = super.get(system)
+  override def get(system: ClassicActorSystemProvider): LruPersistenceIdsExt = super.get(system)
+  override def lookup = LruPersistenceIds
+  override def createExtension(system: ExtendedActorSystem): LruPersistenceIdsExt =
+    new LruPersistenceIdsExt(system)
+
+  final case class Settings(numberOfBuckets: Int, maxEntriesPerBucket: Int, timeToLive: FiniteDuration) {
+    val timeToLiveMillis: Long = timeToLive.toMillis
+  }
+
+}
+
+class LruPersistenceIdsExt(system: ExtendedActorSystem) extends Extension {
+  import LruPersistenceIds._
+
+  implicit val node: SelfUniqueAddress = DistributedData(system).selfUniqueAddress
+
+  // TODO might be good to have own Replicator
+  val replicator: ActorRef = DistributedData(system).replicator
+
+  val settings: Settings = {
+    val cfg = system.settings.config.getConfig("all-events-query.lru-cache")
+    val numberOfBuckets = cfg.getInt("number-of-buckets")
+    val maxEntries = cfg.getInt("max-entries")
+    val maxEntriesPerBucket = math.max(1, maxEntries / numberOfBuckets)
+    val timeToLive = cfg.getDuration("time-to-live").asScala
+    Settings(numberOfBuckets, maxEntriesPerBucket, timeToLive)
+  }
+
+  def touch(persistenceId: PersistenceId): Unit = {
+    val i = math.abs(persistenceId.hashCode % settings.numberOfBuckets)
+    val bucketKey = LWWMapKey[PersistenceId, Timestamp](s"$BucketKeyPrefix$i")
+    replicator.tell(
+      Replicator.Update(bucketKey, LWWMap.empty[PersistenceId, Timestamp], Replicator.WriteLocal) { bucket =>
+        val now = System.currentTimeMillis()
+        val timestamp = bucket.get(persistenceId) match {
+          case None => now
+          case Some(t) =>
+            if (now > t) now
+            else t + 1
+        }
+        bucket :+ persistenceId -> timestamp
+      },
+      system.provider.ignoreRef)
+  }
+}
+
+class LruPersistenceIds(subscriber: ActorRef, predicate: LruPersistenceIds.PersistenceId => Boolean)
+    extends Actor
+    with Timers
+    with ActorLogging {
+  import LruPersistenceIds._
+
+  // TODO we could implement a more special purpose ddata type instead of LWWMap
+
+  private val lruPersistenceIdsExt = LruPersistenceIds(context.system)
+  private implicit val node: SelfUniqueAddress = lruPersistenceIdsExt.node
+  private val replicator = lruPersistenceIdsExt.replicator
+  import lruPersistenceIdsExt.settings._
+
+  private val cleanupInterval = timeToLive / 2
+
+  private val bucketKeys =
+    (0 until numberOfBuckets).map(i => LWWMapKey[PersistenceId, Timestamp](s"$BucketKeyPrefix$i")).toArray
+  private var subscriberState: Map[LWWMapKey[PersistenceId, Timestamp], Map[PersistenceId, Timestamp]] =
+    bucketKeys.map(_ -> Map.empty[PersistenceId, Timestamp]).toMap
+
+  override def preStart(): Unit = {
+    (0 until numberOfBuckets).foreach { i =>
+      replicator ! Replicator.Subscribe(bucketKeys(i), self)
+    }
+
+    timers.startSingleTimer(
+      CleanupTick,
+      CleanupTick,
+      timeToLive + ThreadLocalRandom.current().nextInt(cleanupInterval.toSeconds.toInt).seconds)
+  }
+
+  override def receive: Receive = {
+    case c @ Replicator.Changed(key: LWWMapKey[PersistenceId, Timestamp]) =>
+      val bucketEntries = c.get(key).entries
+      val state = subscriberState(key)
+      val updated = bucketEntries.filter {
+        case (pid, timestamp) =>
+          predicate(pid) && timestamp > state.getOrElse(pid, 0L)
+      }
+      val updatedState =
+        if (updated.nonEmpty) {
+          if (log.isDebugEnabled) // FIXME too much logging
+            log.debug(
+              "[{}] new active pids [{}] in bucket [{}]",
+              updated.size,
+              updated.keysIterator.mkString(", "),
+              key.id)
+          val s = state ++ updated
+          subscriber ! ActivePids(updated.iterator.map(_._1).toSet)
+          if (bucketEntries.size > maxEntriesPerBucket)
+            scheduleCleanup(key)
+          s
+        } else {
+          state
+        }
+
+      val removed = updatedState.keySet.diff(bucketEntries.keySet)
+      if (removed.nonEmpty) {
+        if (log.isDebugEnabled) // FIXME too much logging
+          log.debug("[{}] new inactive pids [{}] in bucket [{}]", removed.size, removed.mkString(", "), key.id)
+        subscriber ! InactivePids(removed)
+        subscriberState = subscriberState.updated(key, updatedState -- removed)
+      } else {
+        subscriberState = subscriberState.updated(key, updatedState)
+      }
+
+    case CleanupTick =>
+      bucketKeys.foreach { key =>
+        scheduleCleanup(key)
+      }
+      if (!timers.isTimerActive(CleanupTick))
+        timers.startTimerWithFixedDelay(CleanupTick, CleanupTick, cleanupInterval)
+
+    case Cleanup(bucketKey) =>
+      val now = System.currentTimeMillis()
+      replicator ! Replicator.Update(bucketKey, LWWMap.empty[PersistenceId, Timestamp], Replicator.WriteLocal) {
+        bucket =>
+          // first remove those that have exceeded TTL
+          val inactivePids = bucket.entries.collect {
+            case (pid, timestamp) if now - timestamp > timeToLiveMillis => pid
+          }
+          val stillActive =
+            if (inactivePids.isEmpty)
+              bucket
+            else {
+              if (log.isDebugEnabled)
+                log.debug("Evict [{}] inactive pids [{}]", inactivePids.size, inactivePids.mkString(","))
+              inactivePids.foldLeft(bucket) {
+                case (acc, pid) => acc.remove(node, pid)
+              }
+            }
+
+          // then if still too many remove the oldest
+          if (stillActive.size > maxEntriesPerBucket) {
+            val oldest = stillActive.entries.toVector.sortBy(_._2).takeRight(stillActive.size - maxEntriesPerBucket)
+            log.debug("Evict additional [{}] oldest pids [{}]", oldest.size, oldest.mkString(","))
+            oldest.foldLeft(stillActive) {
+              case (acc, (pid, _)) => acc.remove(node, pid)
+            }
+          } else {
+            stillActive
+          }
+      }
+
+  }
+
+  private def scheduleCleanup(bucketKey: LWWMapKey[PersistenceId, Timestamp]): Unit = {
+    val cleanupMsg = Cleanup(bucketKey)
+    if (!timers.isTimerActive(cleanupMsg))
+      timers.startSingleTimer(cleanupMsg, cleanupMsg, ThreadLocalRandom.current().nextInt(3).seconds)
+  }
+
+}

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -630,7 +630,7 @@ class CassandraReadJournal protected (
     val deserializeEventAsync = querySettings.deserializationParallelism > 1
 
     createFutureSource(combinedEventsByPersistenceIdStmts) { (s, c) =>
-      log.debug("Creating EventByPersistentIdState graph")
+      log.debug("Creating EventsByPersistenceIdStage pid [{}] from seqNr [{}]", persistenceId, fromSequenceNr)
       Source
         .fromGraph(
           new EventsByPersistenceIdStage(

--- a/core/src/main/scala/akka/persistence/query/AllEventsOffset.scala
+++ b/core/src/main/scala/akka/persistence/query/AllEventsOffset.scala
@@ -1,0 +1,13 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.query
+
+// FIXME this will be in akka-persistence-query
+
+object AllEventsOffset {
+  val empty: AllEventsOffset = AllEventsOffset(Map.empty)
+}
+
+final case class AllEventsOffset(offsets: Map[String, Long]) extends Offset

--- a/core/src/main/scala/akka/projection/internal/AllEventsOffsetAggregator.scala
+++ b/core/src/main/scala/akka/projection/internal/AllEventsOffsetAggregator.scala
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.projection.internal
+
+// FIXME this will be in akka-projection-core and used by the OffsetStore implementations
+
+import scala.collection.immutable
+
+case class AllEventsOffsetBucket(key: String, offsets: Map[String, Long])
+
+/**
+ * Used by Projections OffsetStore for `AllEventsOffset`.
+ * The `initial` corresponds to the read offsets when the projection is started.
+ * Each `AllEventsOffsetBucket` is stored as a row in the offset table.
+ *
+ * Several buckets (rows) are used because it can be many total number of pid/seqNr
+ * pairs in a `AllEventsOffset`. To reduce the amount of data that is updated
+ * when the offset changes it works with one primary bucket at a time. New
+ * pids are added to this primary bucket. Updated pids are moved to the primary
+ * bucket (removed from old bucket, added to primary).
+ *
+ * Assuming that recently used pids are "hot" and updated again.
+ *
+ * When the size of the primary bucket is 20% larger than next largest it selects
+ * the smallest bucket as the new primary.
+ */
+class AllEventsOffsetAggregator(initial: Vector[AllEventsOffsetBucket]) {
+  require(initial.size >= 2, "At least 2 buckets required.")
+  private var buckets: Array[AllEventsOffsetBucket] = initial.toArray
+  private var switchPrimarySize = 0
+
+  private def initBuckets(): Unit = {
+    val sorted = buckets.toVector.sortBy(_.offsets.size)
+    // Smallest first, then ordered from largest to smallest.
+    // It's most likely that updates are for pids that have been recently used.
+    // Then we only have to save one or two buckets.
+    buckets = (sorted.head +: sorted.tail.reverse).toArray
+    // switch the first bucket when it is 20% larger than currently largest
+    switchPrimarySize = math.max(100, (1.2 + buckets(1).offsets.size).toInt)
+  }
+
+  initBuckets()
+
+  /**
+   * Update the offset buckets.
+   * @return the changed buckets that should be saved
+   */
+  def add(offsets: Map[String, Long]): immutable.Seq[AllEventsOffsetBucket] = {
+    if (buckets(0).offsets.size >= switchPrimarySize)
+      initBuckets()
+
+    var dirty: Set[Int] = Set.empty
+    offsets.foreach {
+      case (pid, seqNr) =>
+        indexOfBucket(pid) match {
+          case -1 | 0 =>
+            // add or update in first bucket
+            val bucket0 = buckets(0)
+            buckets(0) = bucket0.copy(offsets = bucket0.offsets.updated(pid, seqNr))
+            dirty += 0
+          case i =>
+            // remove from old bucket
+            val oldBucket = buckets(i)
+            buckets(i) = oldBucket.copy(offsets = oldBucket.offsets - pid)
+            dirty += i
+            // add in first bucket
+            val bucket0 = buckets(0)
+            buckets(0) = bucket0.copy(offsets = bucket0.offsets.updated(pid, seqNr))
+            dirty += 0
+        }
+    }
+
+    dirty.toList.sorted.map(buckets(_))
+  }
+
+  private def indexOfBucket(pid: String): Int =
+    buckets.indexWhere(_.offsets.contains(pid))
+
+}

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllEventsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllEventsSpec.scala
@@ -72,7 +72,7 @@ class AllEventsSpec extends CassandraSpec(AllEventsSpec.config) with BeforeAndAf
       setup("b", 3)
       setup("c", 2)
 
-      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, _ => ())
+      val src = AllEvents.allEvents(queries, _.startsWith("pid-"), AllEventsOffset.empty, _ => ())
       val probe = src.runWith(TestSink.probe[EventEnvelope])
       probe.request(100)
       val received = probe.expectNextN(6)
@@ -221,9 +221,9 @@ class AllEventsSpec extends CassandraSpec(AllEventsSpec.config) with BeforeAndAf
         setup(s"pid-$N1", 3, await = true)
       }
 
-      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, _ => ())
+      val src = AllEvents.allEvents(queries, _.startsWith("pid-"), AllEventsOffset.empty, _ => ())
       val probe = src.runWith(TestSink.probe[EventEnvelope])
-      probe.request(100000)
+      probe.request(1000000)
 
       ((N1 + 1) to (N1 + N2)).foreach { n =>
         setup(s"pid-$n", 3, await = false)

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllEventsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllEventsSpec.scala
@@ -1,0 +1,281 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.query
+
+import java.util.concurrent.atomic.AtomicReference
+
+import scala.concurrent.duration._
+
+import akka.actor.ActorRef
+import akka.persistence.PersistentRepr
+import akka.persistence.cassandra.CassandraLifecycle
+import akka.persistence.cassandra.CassandraSpec
+import akka.persistence.cassandra.journal.JournalSettings
+import akka.persistence.query.AllEventsOffset
+import akka.persistence.query.EventEnvelope
+import akka.stream.testkit.scaladsl.TestSink
+import com.typesafe.config.ConfigFactory
+import org.scalatest.BeforeAndAfterEach
+
+object AllEventsSpec {
+  val config = ConfigFactory.parseString(s"""
+    akka.loglevel = DEBUG
+    akka.actor.provider = cluster
+    akka.remote.artery.canonical.port = 0
+    akka.remote.artery.canonical.hostname = "127.0.0.1"
+    akka.cluster.pub-sub.send-to-dead-letters-when-no-subscribers = off
+    akka.persistence.max-concurrent-recoveries = 50
+    akka.persistence.cassandra {
+      journal.target-partition-size = 15
+      query {
+        max-buffer-size = 10
+        refresh-interval = 0.5s
+        max-result-size-query = 10
+      }
+      events-by-tag.enabled = off
+    }  
+    """).withFallback(CassandraLifecycle.config)
+}
+
+class AllEventsSpec extends CassandraSpec(AllEventsSpec.config) with BeforeAndAfterEach {
+
+  val cfg = system.settings.config.getConfig("akka.persistence.cassandra")
+  val journalSettings = new JournalSettings(system, cfg)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    deleteAllEvents()
+  }
+
+  private def deleteAllEvents(): Unit = {
+    cluster.execute(s"TRUNCATE ${journalSettings.keyspace}.${journalSettings.table}")
+    cluster.execute(s"TRUNCATE ${journalSettings.keyspace}.${journalSettings.allPersistenceIdsTable}")
+  }
+
+  private def setup(persistenceId: String, n: Int, await: Boolean = true): ActorRef = {
+    val ref = system.actorOf(TestActor.props(persistenceId))
+    val replyTo = if (await) testActor else system.deadLetters
+    for (i <- 1 to n) {
+      ref.tell(s"$persistenceId-$i", replyTo)
+      if (await)
+        expectMsg(s"$persistenceId-$i-done")
+    }
+
+    ref
+  }
+
+  "Cassandra query allEvents" must {
+    "find existing events" in {
+      setup("a", 1)
+      setup("b", 3)
+      setup("c", 2)
+
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, _ => ())
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      probe.request(100)
+      val received = probe.expectNextN(6)
+
+      received.filter(_.persistenceId == "a").map(_.event) should ===(Vector("a-1"))
+      received.filter(_.persistenceId == "b").map(_.event) should ===(Vector("b-1", "b-2", "b-3"))
+      received.filter(_.persistenceId == "c").map(_.event) should ===(Vector("c-1", "c-2"))
+
+      probe.cancel()
+    }
+
+    "find new events" in {
+      val refA = setup("a", 1)
+
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, _ => ())
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      probe.request(100)
+
+      probe.expectNext().event should ===("a-1")
+      refA ! "a-2"
+      expectMsg("a-2-done")
+      refA ! "a-3"
+      expectMsg("a-3-done")
+      probe.expectNext().event should ===("a-2")
+      probe.expectNext().event should ===("a-3")
+
+      val refB = setup("b", 3)
+      probe.expectNext().event should ===("b-1")
+      probe.expectNext().event should ===("b-2")
+      probe.expectNext().event should ===("b-3")
+
+      refB ! "b-4"
+      expectMsg("b-4-done")
+      probe.expectNext().event should ===("b-4")
+
+      refA ! "a-4"
+      expectMsg("a-4-done")
+      probe.expectNext().event should ===("a-4")
+
+      probe.cancel()
+    }
+
+    "resume from offset" in {
+      setup("a", 2)
+      setup("b", 4)
+
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset(Map("a" -> 1L, "b" -> 2)), _ => ())
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      var received = Vector.empty[EventEnvelope]
+      probe.request(100)
+      received ++= probe.expectNextN(3)
+      probe.expectNoMessage()
+
+      received.filter(_.persistenceId == "a").map(_.event) should ===(Vector("a-2"))
+      received.filter(_.persistenceId == "b").map(_.event) should ===(Vector("b-3", "b-4"))
+
+      probe.cancel()
+    }
+
+    "deliver direct events without query" in {
+      val directRef = new AtomicReference[ActorRef]
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, ref => directRef.set(ref))
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      probe.request(100)
+
+      awaitCond(directRef.get != null)
+
+      val refA = setup("a", 2)
+      probe.expectNext().event should ===("a-1")
+      probe.expectNext().event should ===("a-2")
+      // might take some longer for PersistenceIdsState actor to see the update
+      probe.expectNoMessage(500.millis)
+
+      directRef.get ! PersistentRepr("a-3", 3, "a")
+      probe.expectNext().event should ===("a-3")
+      directRef.get ! PersistentRepr("a-4", 4, "a")
+      probe.expectNext().event should ===("a-4")
+
+      // missing a-5
+      directRef.get ! PersistentRepr("a-6", 6, "a")
+      probe.expectNoMessage()
+      refA ! "a-3"
+      refA ! "a-4"
+      refA ! "a-5"
+      refA ! "a-6"
+      expectMsg("a-3-done")
+      expectMsg("a-4-done")
+      expectMsg("a-5-done")
+      expectMsg("a-6-done")
+      probe.expectNext().event should ===("a-5")
+      probe.expectNext().event should ===("a-6")
+
+      // might take some longer for PersistenceIdsState actor to see the update
+      probe.expectNoMessage(500.millis)
+      directRef.get ! PersistentRepr("a-7", 7, "a")
+      directRef.get ! PersistentRepr("a-8", 8, "a")
+      probe.expectNext().event should ===("a-7")
+      probe.expectNext().event should ===("a-8")
+
+      probe.cancel()
+    }
+
+    "deliver direct events when first seqNr is expected" in {
+      val directRef = new AtomicReference[ActorRef]
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset(Map("c" -> 3)), ref => directRef.set(ref))
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      probe.request(100)
+
+      awaitCond(directRef.get != null)
+
+      directRef.get ! PersistentRepr("a-1", 1, "a")
+      probe.expectNext().event should ===("a-1")
+      directRef.get ! PersistentRepr("a-2", 2, "a")
+      probe.expectNext().event should ===("a-2")
+      directRef.get ! PersistentRepr("a-3", 3, "a")
+      directRef.get ! PersistentRepr("a-4", 4, "a")
+      directRef.get ! PersistentRepr("a-5", 5, "a")
+
+      probe.expectNext().event should ===("a-3")
+      probe.expectNext().event should ===("a-4")
+      probe.expectNext().event should ===("a-5")
+
+      // new pid must start at 1
+      directRef.get ! PersistentRepr("b-2", 2, "b")
+      probe.expectNoMessage()
+      directRef.get ! PersistentRepr("b-1", 1, "b")
+      probe.expectNext().event should ===("b-1")
+
+      // or new pid must start from offset
+      directRef.get ! PersistentRepr("c-5", 5, "c")
+      probe.expectNoMessage()
+      directRef.get ! PersistentRepr("c-4", 4, "c")
+      probe.expectNext().event should ===("c-4")
+
+      probe.cancel()
+    }
+
+    "handle many persistence ids, without pubsub" in {
+      val N1 = 100
+      val N2 = 2000
+
+      (1 until N1).foreach { n =>
+        setup(s"pid-$n", 3, await = false)
+      }
+      within(5.seconds + (3.millis * N1)) {
+        setup(s"pid-$N1", 3, await = true)
+      }
+
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, _ => ())
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      probe.request(100000)
+
+      ((N1 + 1) to (N1 + N2)).foreach { n =>
+        setup(s"pid-$n", 3, await = false)
+      }
+
+      val received =
+        probe.within(5.seconds + (3.millis * N2)) {
+          probe.expectNextN((N1 + N2) * 3)
+        }
+
+      received.filter(_.persistenceId == "pid-1").map(_.event) should ===(Vector("pid-1-1", "pid-1-2", "pid-1-3"))
+      received.filter(_.persistenceId == s"pid-$N1").map(_.event) should ===(
+        Vector(s"pid-$N1-1", s"pid-$N1-2", s"pid-$N1-3"))
+      received.filter(_.persistenceId == s"pid-${N1 + N2}").map(_.event) should ===(
+        Vector(s"pid-${N1 + N2}-1", s"pid-${N1 + N2}-2", s"pid-${N1 + N2}-3"))
+
+      probe.cancel()
+    }
+
+    "handle many persistence ids, with pubsub" in {
+      val N1 = 100
+      val N2 = 2000
+
+      (1 until N1).foreach { n =>
+        setup(s"TestEntity|pid-$n", 3, await = false)
+      }
+      within(5.seconds + (3.millis * N1)) {
+        setup(s"TestEntity|pid-$N1", 3, await = true)
+      }
+
+      val src = AllEvents.allEvents(system, queries, AllEventsOffset.empty, "TestEntity", 0, 1)
+      val probe = src.runWith(TestSink.probe[EventEnvelope])
+      probe.request(1000000)
+
+      ((N1 + 1) to (N1 + N2)).foreach { n =>
+        setup(s"TestEntity|pid-$n", 3, await = false)
+      }
+
+      val received =
+        probe.within(5.seconds + (3.millis * N2)) {
+          probe.expectNextN((N1 + N2) * 3)
+        }
+
+      received.filter(_.persistenceId == "TestEntity|pid-1").map(_.event) should ===(
+        Vector("TestEntity|pid-1-1", "TestEntity|pid-1-2", "TestEntity|pid-1-3"))
+      received.filter(_.persistenceId == s"TestEntity|pid-$N1").map(_.event) should ===(
+        Vector(s"TestEntity|pid-$N1-1", s"TestEntity|pid-$N1-2", s"TestEntity|pid-$N1-3"))
+      received.filter(_.persistenceId == s"TestEntity|pid-${N1 + N2}").map(_.event) should ===(
+        Vector(s"TestEntity|pid-${N1 + N2}-1", s"TestEntity|pid-${N1 + N2}-2", s"TestEntity|pid-${N1 + N2}-3"))
+
+      probe.cancel()
+    }
+
+  }
+}

--- a/core/src/test/scala/akka/persistence/cassandra/query/AllEventsSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/AllEventsSpec.scala
@@ -72,7 +72,7 @@ class AllEventsSpec extends CassandraSpec(AllEventsSpec.config) with BeforeAndAf
       setup("b", 3)
       setup("c", 2)
 
-      val src = AllEvents.allEvents(queries, _.startsWith("pid-"), AllEventsOffset.empty, _ => ())
+      val src = AllEvents.allEvents(queries, _ => true, AllEventsOffset.empty, _ => ())
       val probe = src.runWith(TestSink.probe[EventEnvelope])
       probe.request(100)
       val received = probe.expectNextN(6)
@@ -217,7 +217,7 @@ class AllEventsSpec extends CassandraSpec(AllEventsSpec.config) with BeforeAndAf
       (1 until N1).foreach { n =>
         setup(s"pid-$n", 3, await = false)
       }
-      within(5.seconds + (3.millis * N1)) {
+      within(5.seconds + (5.millis * N1)) {
         setup(s"pid-$N1", 3, await = true)
       }
 
@@ -230,7 +230,7 @@ class AllEventsSpec extends CassandraSpec(AllEventsSpec.config) with BeforeAndAf
       }
 
       val received =
-        probe.within(5.seconds + (3.millis * N2)) {
+        probe.within(5.seconds + (5.millis * N2)) {
           probe.expectNextN((N1 + N2) * 3)
         }
 

--- a/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/TestActor.scala
@@ -30,12 +30,14 @@ class TestActor(override val persistenceId: String, override val journalPluginId
   val receiveCommand: Receive = {
     case cmd: String =>
       persist(cmd) { evt =>
-        sender() ! evt + "-done"
+        if (sender() != context.system.deadLetters)
+          sender() ! evt + "-done"
       }
     case cmd: Tagged =>
       persist(cmd) { evt =>
         val msg = s"${evt.payload}-done"
-        sender() ! msg
+        if (sender() != context.system.deadLetters)
+          sender() ! msg
       }
 
     case TestActor.PersistAll(events) =>
@@ -44,7 +46,7 @@ class TestActor(override val persistenceId: String, override val journalPluginId
         var count = 0
         evt: String => {
           count += 1
-          if (count == size)
+          if (count == size && sender() != context.system.deadLetters)
             sender() ! "PersistAll-done"
         }
       }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -44,6 +44,7 @@ object Dependencies {
       "com.typesafe.akka" %% "akka-persistence" % AkkaVersion,
       "com.typesafe.akka" %% "akka-persistence-query" % AkkaVersion,
       "com.typesafe.akka" %% "akka-cluster-tools" % AkkaVersion,
+      "com.typesafe.akka" %% "akka-distributed-data" % AkkaVersion,
       Logback % Test,
       "org.scalatest" %% "scalatest" % "3.1.0" % Test,
       "org.pegdown" % "pegdown" % "1.6.0" % Test,


### PR DESCRIPTION
Early draft for discussion.

* look ma, no tags
* find all persistenceIds and scan each for new events with
  currentEventsByPersistenceId
* might be slow to scan through all persistenceIds
* pubsub of full events means that queries are not needed in
  happy case, simple to track expected seqNr
* the offset is large since it must contain seqNr for each
  persistenceId, but with some smart bucket management it
  might be alright

References #823
