### PR TITLE
Synchronous write to tag views table

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -252,9 +252,10 @@ akka.persistence.cassandra {
     # Max time to buffer events for before writing.
     # Larger values will increase cassandra write efficiency but increase the delay before
     # seeing events in EventsByTag queries.
-    # Setting this to 0 means that tag writes will be written immediately but will still be asynchronous
-    # with respect to the PersistentActor's persist call.
-    flush-interval = 250ms
+    # Setting this to 0 means that tag writes will be written immediately. Batching will still happen
+    # as events are buffered while a write is in progress
+    # If the tag write fails for an event the actor's persist will be failed
+    flush-interval = 0ms
 
     # Update the tag_scanning table with this interval. Shouldn't be done too often to
     # avoid unecessary load. The tag_scanning table keeps track of a starting point for tag

--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -254,8 +254,16 @@ akka.persistence.cassandra {
     # seeing events in EventsByTag queries.
     # Setting this to 0 means that tag writes will be written immediately. Batching will still happen
     # as events are buffered while a write is in progress
-    # If the tag write fails for an event the actor's persist will be failed
     flush-interval = 0ms
+
+    # Tagged events are written to a separate table after the write to the messages table has completed.
+    # If the write to the tag_views table fails it is retried. If it hasn't succeeded within this timeout
+    # then the actor will be stopped and the write will be retried again to the tag_views table when the actor
+    # is restarted
+    # A default of 4 seconds as that is greater than a typical write timeout in C* (2 seconds) and less than
+    # the default eventual consistency delay
+    # This behavior is new in 1.0.4 where before the write to the tag_views was completely asynchronous.
+    tag-write-timeout = 4s
 
     # Update the tag_scanning table with this interval. Shouldn't be done too often to
     # avoid unecessary load. The tag_scanning table keeps track of a starting point for tag

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagSettings.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagSettings.scala
@@ -141,6 +141,8 @@ import com.typesafe.config.Config
       case _               => eventsByTagConfig.getDuration("pubsub-notification", TimeUnit.MILLISECONDS).millis
     }
 
+  val tagWriteTimeout = eventsByTagConfig.getDuration("tag-write-timeout", TimeUnit.MILLISECONDS).millis
+
   val tagWriterSettings = TagWriterSettings(
     eventsByTagConfig.getInt("max-message-batch-size"),
     eventsByTagConfig.getDuration("flush-interval", TimeUnit.MILLISECONDS).millis,

--- a/core/src/main/scala/akka/persistence/cassandra/journal/Buffer.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/Buffer.scala
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import akka.annotation.InternalApi
+import akka.persistence.cassandra.journal.TagWriter.{ timeUuidOrdering, AwaitingWrite }
+import akka.util.{ OptionVal, UUIDComparator }
+
+/**
+ * INTERNAL API
+ *
+ * Buffered events waiting to be written.
+ * The next batch is maintained in `nextBatch` and will never contain more than the `batchSize`
+ * or events from different time buckets.
+ *
+ * Events should be added and then call shouldWrite() to see if a batch is ready to be written.
+ * Once a write is complete call `writeComplete` to discard the events in `nextBatch` and take
+ * events from `pending` for the next batch.
+ */
+@InternalApi
+private[akka] case class Buffer(
+    batchSize: Int,
+    size: Int,
+    nextBatch: Vector[AwaitingWrite],
+    pending: Vector[AwaitingWrite],
+    writeRequired: Boolean) {
+  require(batchSize > 0)
+
+  def isEmpty: Boolean = nextBatch.isEmpty
+
+  def nonEmpty: Boolean = nextBatch.nonEmpty
+
+  def remove(pid: String): Buffer = {
+    val (toFilter, without) = nextBatch.partition(_.events.head._1.persistenceId == pid)
+    val filteredPending = pending.filterNot(_.events.head._1.persistenceId == pid)
+    val removed = toFilter.foldLeft(0)((acc, next) => acc + next.events.size)
+    copy(size = size - removed, nextBatch = without, pending = filteredPending)
+  }
+
+  /**
+   * Any time a new time bucket is received or the max batch size is reached then
+   * a write should happen
+   */
+  def shouldWrite(): Boolean = {
+    if (!writeRequired)
+      require(size <= batchSize)
+    writeRequired
+  }
+
+  final def add(write: AwaitingWrite): Buffer = {
+    val firstTimeBucket = write.events.head._1.timeBucket
+    val lastTimeBucket = write.events.last._1.timeBucket
+    if (firstTimeBucket != lastTimeBucket) {
+      // this write needs broken up as it spans multiple time buckets
+      val (first, rest) = write.events.partition {
+        case (serialized, _) => serialized.timeBucket == firstTimeBucket
+      }
+      add(AwaitingWrite(first, OptionVal.None)).add(AwaitingWrite(rest, write.ack))
+    } else {
+      // common case
+      val newSize = size + write.events.size
+      if (writeRequired) {
+        // add them to pending, any time bucket changes will be detected later
+        copy(size = newSize, pending = pending :+ write)
+      } else if (nextBatch.headOption.exists(oldestEvent =>
+                   UUIDComparator.comparator
+                     .compare(write.events.head._1.timeUuid, oldestEvent.events.head._1.timeUuid) < 0)) {
+        // rare case where events have been received out of order, just re-build the buffer
+        require(pending.isEmpty)
+        val allWrites = (nextBatch :+ write).sortBy(_.events.head._1.timeUuid)(timeUuidOrdering)
+        rebuild(allWrites)
+      } else if (nextBatch.headOption.exists(_.events.head._1.timeBucket != write.events.head._1.timeBucket)) {
+        // time bucket has changed
+        copy(size = newSize, pending = pending :+ write, writeRequired = true)
+      } else if (newSize >= batchSize) {
+        require(pending.isEmpty, "Pending should be empty if write not required")
+        // does the new write need broken up?
+        if (newSize > batchSize) {
+          val toAdd = batchSize - size
+          val (forNextWrite, forPending) = write.events.splitAt(toAdd)
+          copy(
+            size = newSize,
+            nextBatch = nextBatch :+ AwaitingWrite(forNextWrite, OptionVal.None),
+            pending = Vector(AwaitingWrite(forPending, write.ack)),
+            writeRequired = true)
+        } else {
+          copy(size = newSize, nextBatch = nextBatch :+ write, writeRequired = true)
+        }
+      } else {
+        copy(size = size + write.events.size, nextBatch = nextBatch :+ write)
+      }
+    }
+  }
+
+  private def rebuild(writes: Vector[AwaitingWrite]): Buffer = {
+    var buffer = Buffer.empty(batchSize)
+    var i = 0
+    while (!buffer.shouldWrite() && i < writes.size) {
+      buffer = buffer.add(writes(i))
+      i += 1
+    }
+    //       pending may have one in it as the last one may have been a time bucket change rather than bach full
+    val done = buffer.copy(pending = buffer.pending ++ writes.drop(i))
+    done
+  }
+
+  final def addPending(write: AwaitingWrite): Buffer = {
+    copy(size = size + write.events.size, pending = pending :+ write)
+  }
+
+  def writeComplete(): Buffer = {
+    // this could be more efficient by adding until a write is required but this is simpler and
+    // pending is expected to be small unless the database is falling behind
+    rebuild(pending)
+  }
+}
+
+/**
+ * INTERNAL API
+ */
+@InternalApi
+private[akka] object Buffer {
+  def empty(batchSize: Int): Buffer = {
+    require(batchSize > 0)
+    Buffer(batchSize, 0, Vector.empty, Vector.empty, writeRequired = false)
+  }
+}

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -282,10 +282,11 @@ import akka.stream.scaladsl.Source
 
         // The tag writer keeps retrying but will drop writes for a persistent actor when it restarts
         // due to this failing
-        implicit val timeout: Timeout = Timeout(settings.eventsByTagSettings.tagWriteTimeout)
         result.flatMap { _ =>
           tagWrites match {
-            case Some(t) => t.ask(extractTagWrites(serialized)).map(_ => Nil)(ExecutionContexts.parasitic)
+            case Some(t) =>
+              implicit val timeout: Timeout = Timeout(settings.eventsByTagSettings.tagWriteTimeout)
+              t.ask(extractTagWrites(serialized)).map(_ => Nil)(ExecutionContexts.parasitic)
             case None    => Future.successful(Nil)
           }
         }

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -287,7 +287,7 @@ import akka.stream.scaladsl.Source
             case Some(t) =>
               implicit val timeout: Timeout = Timeout(settings.eventsByTagSettings.tagWriteTimeout)
               t.ask(extractTagWrites(serialized)).map(_ => Nil)(ExecutionContexts.parasitic)
-            case None    => Future.successful(Nil)
+            case None => Future.successful(Nil)
           }
         }
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -251,7 +251,6 @@ import scala.util.{ Failure, Success, Try }
             context.become(idle(nextBuffer, tagPidSequenceNrs))
           }
         case None =>
-          log.debug("write finished, checking if a new flush is required")
           flushIfRequired(nextBuffer, tagPidSequenceNrs)
       }
       sendPubsubNotification()

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -112,11 +112,11 @@ import akka.util.{ OptionVal, UUIDComparator }
    * events from `pending` for the next batch.
    */
   case class Buffer(
-                     batchSize: Int,
-                     size: Int,
-                     nextBatch: Vector[AwaitingWrite],
-                     pending: Vector[AwaitingWrite],
-                     writeRequired: Boolean) {
+      batchSize: Int,
+      size: Int,
+      nextBatch: Vector[AwaitingWrite],
+      pending: Vector[AwaitingWrite],
+      writeRequired: Boolean) {
     require(batchSize > 0)
 
     def isEmpty: Boolean = nextBatch.isEmpty

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriter.scala
@@ -6,6 +6,7 @@ package akka.persistence.cassandra.journal
 
 import java.util.UUID
 
+import akka.Done
 import akka.actor.{ Actor, ActorLogging, ActorRef, NoSerializationVerificationNeeded, Props, Timers }
 import akka.annotation.InternalApi
 import akka.cluster.pubsub.{ DistributedPubSub, DistributedPubSubMediator }
@@ -20,7 +21,8 @@ import scala.util.control.NonFatal
 import scala.util.{ Failure, Success, Try }
 import scala.concurrent.duration._
 import akka.actor.ReceiveTimeout
-import akka.util.UUIDComparator
+import akka.event.LoggingAdapter
+import akka.util.{ OptionVal, UUIDComparator }
 
 /*
  * INTERNAL API
@@ -83,15 +85,127 @@ import akka.util.UUIDComparator
   private case object FlushKey
   sealed trait TagWriteFinished
   final case class TagWriteDone(summary: TagWriteSummary, doneNotify: Option[ActorRef]) extends TagWriteFinished
-  private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[(Serialized, TagPidSequenceNr)])
+  private final case class TagWriteFailed(reason: Throwable, failedEvents: Vector[AwaitingWrite])
       extends TagWriteFinished
 
   private[akka] case class DropState(pid: PersistenceId)
 
-  val timeUuidOrdering = new Ordering[UUID] {
+  val timeUuidOrdering: Ordering[UUID] = new Ordering[UUID] {
     override def compare(x: UUID, y: UUID) =
       UUIDComparator.comparator.compare(x, y)
   }
+
+  /**
+   * The only reason ack is None is if a TagWrite needed to be broken up because the events were
+   * from different time buckets or if a single write exceeds the batch size.
+   * In that case the later AwaitingWrite contains the ack.
+   */
+  case class AwaitingWrite(events: Seq[(Serialized, TagPidSequenceNr)], ack: OptionVal[ActorRef])
+
+  /**
+   * Buffered events waiting to be written.
+   * The next batch is maintained in `nextBatch` and will never contain more than the `batchSize`
+   * or events from different time buckets.
+   *
+   * Events should be added and then call shouldWrite() to see if a batch is ready to be written.
+   * Once a write is complete call `writeComplete` to discard the events in `nextBatch` and take
+   * events from `pending` for the next batch.
+   */
+  case class Buffer(
+                     batchSize: Int,
+                     size: Int,
+                     nextBatch: Vector[AwaitingWrite],
+                     pending: Vector[AwaitingWrite],
+                     writeRequired: Boolean) {
+    require(batchSize > 0)
+
+    def isEmpty: Boolean = nextBatch.isEmpty
+
+    def nonEmpty: Boolean = nextBatch.nonEmpty
+
+    def remove(pid: String): Buffer = {
+      val (toFilter, without) = nextBatch.partition(_.events.head._1.persistenceId == pid)
+      val filteredPending = pending.filterNot(_.events.head._1.persistenceId == pid)
+      val removed = toFilter.foldLeft(0)((acc, next) => acc + next.events.size)
+      copy(size = size - removed, nextBatch = without, pending = filteredPending)
+    }
+
+    /**
+     * Any time a new time bucket is received or the max batch size is reached then
+     * a write should happen
+     */
+    def shouldWrite(): Boolean = {
+      if (!writeRequired)
+        require(size <= batchSize)
+      writeRequired
+    }
+
+    final def add(write: AwaitingWrite): Buffer = {
+      val firstTimeBucket = write.events.head._1.timeBucket
+      val lastTimeBucket = write.events.last._1.timeBucket
+      if (firstTimeBucket != lastTimeBucket) {
+        // this write needs broken up as it spans multiple time buckets
+        val (first, rest) = write.events.partition {
+          case (serialized, _) => serialized.timeBucket == firstTimeBucket
+        }
+        add(AwaitingWrite(first, OptionVal.None)).add(AwaitingWrite(rest, write.ack))
+      } else {
+        // common case
+        val newSize = size + write.events.size
+        if (writeRequired) {
+          // add them to pending, any time bucket changes will be detected later
+          copy(size = newSize, pending = pending :+ write)
+        } else if (nextBatch.headOption.exists(oldestEvent =>
+                     UUIDComparator.comparator
+                       .compare(write.events.head._1.timeUuid, oldestEvent.events.last._1.timeUuid) < 0)) {
+          // rare case where events have been received out of order, just re-build the buffer
+          require(pending.isEmpty)
+          val allWrites = (nextBatch :+ write).sortBy(_.events.head._1.timeUuid)
+          rebuild(allWrites)
+        } else if (nextBatch.headOption.exists(_.events.head._1.timeBucket != write.events.head._1.timeBucket)) {
+          // time bucket has changed
+          copy(size = newSize, pending = pending :+ write, writeRequired = true)
+        } else if (newSize >= batchSize) {
+          require(pending.isEmpty, "Pending should be empty if write not required")
+          // does the new write need broken up?
+          if (newSize > batchSize) {
+            val toAdd = batchSize - size
+            val (forNextWrite, forPending) = write.events.splitAt(toAdd)
+            copy(
+              size = newSize,
+              nextBatch = nextBatch :+ AwaitingWrite(forNextWrite, OptionVal.None),
+              pending = Vector(AwaitingWrite(forPending, write.ack)),
+              writeRequired = true)
+          } else {
+            copy(size = newSize, nextBatch = nextBatch :+ write, writeRequired = true)
+          }
+        } else {
+          copy(size = size + write.events.size, nextBatch = nextBatch :+ write)
+        }
+      }
+    }
+
+    private def rebuild(writes: Vector[AwaitingWrite]): Buffer =
+      writes.foldLeft(Buffer.empty(batchSize)) { case (acc, next) => acc.add(next) }
+
+    final def addPending(write: AwaitingWrite): Buffer = {
+      copy(size = size + write.events.size, pending = pending :+ write)
+    }
+
+    def writeComplete(): Buffer = {
+      // this could be more efficient by adding until a write is required but this is simpler and
+      // pending is expected to be small unless the database is falling behind
+      rebuild(pending)
+    }
+  }
+
+  object Buffer {
+    def empty(batchSize: Int): Buffer = {
+      require(batchSize > 0)
+      Buffer(batchSize, 0, Vector.empty, Vector.empty, writeRequired = false)
+    }
+  }
+
 }
 
 /** INTERNAL API */
@@ -111,7 +225,7 @@ import akka.util.UUIDComparator
   import context.dispatcher
 
   // eager init and val because used from Future callbacks
-  override val log = super.log
+  override val log: LoggingAdapter = super.log
 
   private val pubsub: Option[ActorRef] = {
     settings.pubsubNotification match {
@@ -134,40 +248,39 @@ import akka.util.UUIDComparator
   }
 
   override def receive: Receive =
-    idle(Vector.empty[(Serialized, TagPidSequenceNr)], Map.empty[String, Long])
+    idle(Buffer.empty(settings.maxBatchSize), Map.empty[String, Long])
 
-  private def idle(
-      buffer: Vector[(Serialized, TagPidSequenceNr)],
-      tagPidSequenceNrs: Map[PersistenceId, TagPidSequenceNr]): Receive = {
+  private def idle(buffer: Buffer, tagPidSequenceNrs: Map[PersistenceId, TagPidSequenceNr]): Receive = {
     case DropState(pid) =>
       log.debug("Dropping state for pid: {}", pid)
       context.become(idle(buffer, tagPidSequenceNrs - pid))
     case InternalFlush =>
       log.debug("Flushing")
       if (buffer.nonEmpty) {
-        write(buffer.take(settings.maxBatchSize), buffer.drop(settings.maxBatchSize), tagPidSequenceNrs, None)
+        write(buffer, tagPidSequenceNrs, None)
       }
     case Flush =>
       if (buffer.nonEmpty) {
         // TODO this should br broken into batches https://github.com/akka/akka-persistence-cassandra/issues/405
         log.debug("External flush request from [{}]. Flushing.", sender())
-        write(buffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagPidSequenceNrs, Some(sender()))
+        write(buffer, tagPidSequenceNrs, Some(sender()))
       } else {
         log.debug("External flush request from [{}], buffer empty.", sender())
         sender() ! FlushComplete
       }
     case TagWrite(_, payload, _) =>
-      // TODO keeping this sorted is over kill. We only need to know if a new timebucket is
-      // reached to force a flush or that the batch size is met
-      val (newTagPidSequenceNrs, events) =
+      log.debug("Tag write {}", payload)
+      val (newTagPidSequenceNrs, events: Seq[(Serialized, TagPidSequenceNr)]) = {
         assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
-      val newBuffer = (buffer ++ events).sortBy(_._1.timeUuid)(timeUuidOrdering)
+      }
+      val newWrite = AwaitingWrite(events, OptionVal(sender()))
+      val newBuffer = buffer.add(newWrite)
       flushIfRequired(newBuffer, newTagPidSequenceNrs)
     case twd: TagWriteDone =>
       log.error("Received Done when in idle state. This is a bug. Please report with DEBUG logs: {}", twd)
     case ResetPersistenceId(_, tp @ TagProgress(pid, _, tagPidSequenceNr)) =>
       log.debug("Resetting pid {}. TagProgress {}", pid, tp)
-      become(idle(buffer.filterNot(_._1.persistenceId == pid), tagPidSequenceNrs + (pid -> tagPidSequenceNr)))
+      become(idle(buffer.remove(pid), tagPidSequenceNrs + (pid -> tagPidSequenceNr)))
       sender() ! ResetPersistenceIdComplete
 
     case ReceiveTimeout =>
@@ -182,11 +295,12 @@ import akka.util.UUIDComparator
   }
 
   private def writeInProgress(
-      buffer: Vector[(Serialized, TagPidSequenceNr)],
+      buffer: Buffer,
       tagPidSequenceNrs: Map[PersistenceId, TagPidSequenceNr],
       awaitingFlush: Option[ActorRef]): Receive = {
     case DropState(pid) =>
       log.debug("Dropping state for pid: [{}]", pid)
+      // FIXME remove anything from the buffer
       become(writeInProgress(buffer, tagPidSequenceNrs - pid, awaitingFlush))
     case InternalFlush =>
     // Ignore, we will check when the write is done
@@ -196,6 +310,7 @@ import akka.util.UUIDComparator
     case TagWrite(_, payload, _) =>
       val (updatedTagPidSequenceNrs, events) =
         assignTagPidSequenceNumbers(payload.toVector, tagPidSequenceNrs)
+      val awaitingWrite = AwaitingWrite(events, OptionVal(sender()))
       val now = System.nanoTime()
       if (buffer.size > (4 * settings.maxBatchSize) && now > (lastLoggedBufferNs + bufferWarningMinDurationNs)) {
         lastLoggedBufferNs = now
@@ -203,14 +318,22 @@ import akka.util.UUIDComparator
           "Buffer for tagged events is getting too large ({}), is Cassandra responsive? Are writes failing? " +
           "If events are buffered for longer than the eventual-consistency-delay they won't be picked up by live queries. The oldest event in the buffer is offset: {}",
           buffer.size,
-          formatOffset(buffer.head._1.timeUuid))
+          formatOffset(buffer.nextBatch.head.events.head._1.timeUuid))
       }
       // buffer until current query is finished
       // Don't sort until the write has finished
-      become(writeInProgress(buffer ++ events, updatedTagPidSequenceNrs, awaitingFlush))
+      val newBuffer = buffer.addPending(awaitingWrite)
+      log.debug("buffering write as write in progress. New buffer {}", newBuffer)
+      become(writeInProgress(newBuffer, updatedTagPidSequenceNrs, awaitingFlush))
     case TagWriteDone(summary, doneNotify) =>
-      val sortedBuffer = buffer.sortBy(_._1.timeUuid)(timeUuidOrdering)
       log.debug("Tag write done: {}", summary)
+      val nextBuffer = buffer.writeComplete()
+      buffer.nextBatch.foreach { write =>
+        write.ack match {
+          case OptionVal.None      =>
+          case OptionVal.Some(ref) => ref ! Done
+        }
+      }
       summary.foreach {
         case (id, PidProgress(_, seqNrTo, tagPidSequenceNr, offset)) =>
           // These writes do not block future writes. We don't read the tag progress again from C*
@@ -233,15 +356,16 @@ import akka.util.UUIDComparator
       awaitingFlush match {
         case Some(replyTo) =>
           log.debug("External flush request")
-          if (sortedBuffer.nonEmpty) {
-            // TODO break into batches
-            write(sortedBuffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagPidSequenceNrs, awaitingFlush)
+          if (buffer.pending.nonEmpty) {
+            // TODO break into batches - check, but this is now done as buffer always batches
+            write(nextBuffer, tagPidSequenceNrs, awaitingFlush)
           } else {
             replyTo ! FlushComplete
-            context.become(idle(sortedBuffer, tagPidSequenceNrs))
+            context.become(idle(nextBuffer, tagPidSequenceNrs))
           }
         case None =>
-          flushIfRequired(sortedBuffer, tagPidSequenceNrs)
+          log.debug("write finished, checking if a new flush is required")
+          flushIfRequired(nextBuffer, tagPidSequenceNrs)
       }
       sendPubsubNotification()
       doneNotify.foreach(_ ! FlushComplete)
@@ -253,15 +377,11 @@ import akka.util.UUIDComparator
         t)
       timers.startSingleTimer(FlushKey, InternalFlush, settings.flushInterval)
       parent ! TagWriters.TagWriteFailed(t)
-      context.become(idle(events ++ buffer, tagPidSequenceNrs))
+      context.become(idle(buffer, tagPidSequenceNrs))
 
     case ResetPersistenceId(_, tp @ TagProgress(pid, _, _)) =>
       log.debug("Resetting persistence id {}. TagProgress {}", pid, tp)
-      become(
-        writeInProgress(
-          buffer.filterNot(_._1.persistenceId == pid),
-          tagPidSequenceNrs + (pid -> tp.pidTagSequenceNr),
-          awaitingFlush))
+      become(writeInProgress(buffer.remove(pid), tagPidSequenceNrs + (pid -> tp.pidTagSequenceNr), awaitingFlush))
       sender() ! ResetPersistenceIdComplete
 
     case ReceiveTimeout =>
@@ -278,36 +398,17 @@ import akka.util.UUIDComparator
     }
   }
 
-  private def flushIfRequired(buffer: Vector[(Serialized, TagPidSequenceNr)], tagSequenceNrs: Map[String, Long]): Unit =
+  private def flushIfRequired(buffer: Buffer, tagSequenceNrs: Map[String, Long]): Unit = {
     if (buffer.isEmpty) {
       context.become(idle(buffer, tagSequenceNrs))
-    } else if (buffer.head._1.timeBucket < buffer.last._1.timeBucket) {
-      val (currentBucket, rest) =
-        buffer.span(_._1.timeBucket == buffer.head._1.timeBucket)
-      if (log.isDebugEnabled) {
-        log.debug(
-          "Switching time buckets: head: {} last: {}. Number in current bucket: {}",
-          buffer.head._1.timeBucket,
-          buffer.last._1.timeBucket,
-          currentBucket.size)
-      }
-
-      if (currentBucket.size > settings.maxBatchSize) {
-        write(buffer.take(settings.maxBatchSize), buffer.drop(settings.maxBatchSize), tagSequenceNrs, None)
-      } else {
-        write(currentBucket, rest, tagSequenceNrs, None)
-      }
-    } else if (buffer.size >= settings.maxBatchSize) {
-      log.debug("Batch size reached. Writing to Cassandra.")
-      write(buffer.take(settings.maxBatchSize), buffer.drop(settings.maxBatchSize), tagSequenceNrs, None)
-    } else if (settings.flushInterval == Duration.Zero) {
-      // Should always be a buffer of 1
-      write(buffer, Vector.empty[(Serialized, TagPidSequenceNr)], tagSequenceNrs, None)
+    } else if (buffer.shouldWrite() || settings.flushInterval == Duration.Zero) {
+      write(buffer, tagSequenceNrs, None)
     } else {
       if (!timers.isTimerActive(FlushKey))
         timers.startSingleTimer(FlushKey, InternalFlush, settings.flushInterval)
       context.become(idle(buffer, tagSequenceNrs))
     }
+  }
 
   /**
    * Defaults to 1 as if recovery for a persistent Actor based its recovery
@@ -329,42 +430,46 @@ import akka.util.UUIDComparator
    * Events should be ordered by sequence nr per pid
    */
   private def write(
-      events: Vector[(Serialized, TagPidSequenceNr)],
-      remainingBuffer: Vector[(Serialized, TagPidSequenceNr)],
+      buffer: Buffer,
       tagPidSequenceNrs: Map[String, TagPidSequenceNr],
       notifyWhenDone: Option[ActorRef]): Unit = {
-    val writeSummary = createTagWriteSummary(events)
-    log.debug("Starting tag write of {} events. Summary: {}", events.size, writeSummary)
-    val withFailure = session.writeBatch(tag, events).map(_ => TagWriteDone(writeSummary, notifyWhenDone)).recover {
+    val writeSummary = createTagWriteSummary(buffer)
+    log.debug("Starting tag write of {} events. Summary: {}", buffer.nextBatch.size, writeSummary)
+    val withFailure = session.writeBatch(tag, buffer).map(_ => TagWriteDone(writeSummary, notifyWhenDone)).recover {
       case NonFatal(t) =>
-        TagWriteFailed(t, events)
+        TagWriteFailed(t, buffer.nextBatch)
     }
 
     import context.dispatcher
     withFailure.pipeTo(self)
 
     // notifyWhenDone is cleared out as it is now in the TagWriteDone
-    context.become(writeInProgress(remainingBuffer, tagPidSequenceNrs, None))
+    context.become(writeInProgress(buffer, tagPidSequenceNrs, None))
   }
 
-  private def createTagWriteSummary(writes: Seq[(Serialized, TagPidSequenceNr)]): Map[PersistenceId, PidProgress] =
-    writes.foldLeft(Map.empty[PersistenceId, PidProgress])((acc, next) => {
-      val (event, tagPidSequenceNr) = next
-      acc.get(event.persistenceId) match {
-        case Some(PidProgress(from, to, _, _)) =>
-          if (event.sequenceNr <= to)
-            throw new IllegalStateException(
-              s"Expected events to be ordered by seqNr. ${event.persistenceId} " +
-              s"Events: ${writes.map(e => (e._1.persistenceId, e._1.sequenceNr, e._1.timeUuid))}")
-          acc + (event.persistenceId -> PidProgress(from, event.sequenceNr, tagPidSequenceNr, event.timeUuid))
-        case None =>
-          acc + (event.persistenceId -> PidProgress(
-            event.sequenceNr,
-            event.sequenceNr,
-            tagPidSequenceNr,
-            event.timeUuid))
-      }
-    })
+  private def createTagWriteSummary(writes: Buffer): Map[PersistenceId, PidProgress] = {
+    writes.nextBatch
+      .flatten(_.events)
+      .foldLeft(Map.empty[PersistenceId, PidProgress])((acc, next) => {
+        val (event, tagPidSequenceNr) = next
+        acc.get(event.persistenceId) match {
+          case Some(PidProgress(from, to, _, _)) =>
+            // FIXME make this log nicer
+            if (event.sequenceNr <= to)
+              throw new IllegalStateException(
+                s"Expected events to be ordered by seqNr. ${event.persistenceId} " +
+                s"Events: ${writes.nextBatch.map(e =>
+                  (e.events.head._1.persistenceId, e.events.head._1.sequenceNr, e.events.head._1.timeUuid))}")
+            acc + (event.persistenceId -> PidProgress(from, event.sequenceNr, tagPidSequenceNr, event.timeUuid))
+          case None =>
+            acc + (event.persistenceId -> PidProgress(
+              event.sequenceNr,
+              event.sequenceNr,
+              tagPidSequenceNr,
+              event.timeUuid))
+        }
+      })
+  }
 
   private def assignTagPidSequenceNumbers(
       events: Vector[Serialized],

--- a/core/src/test/scala/akka/persistence/cassandra/journal/BufferSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/BufferSpec.scala
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2016-2020 Lightbend Inc. <https://www.lightbend.com>
+ */
+
+package akka.persistence.cassandra.journal
+
+import java.nio.ByteBuffer
+import java.util.UUID
+
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.persistence.cassandra.Day
+import akka.persistence.cassandra.journal.CassandraJournal.{ Serialized, TagPidSequenceNr }
+import akka.persistence.cassandra.journal.TagWriter.{ AwaitingWrite, Buffer }
+import akka.testkit.{ TestKit, TestProbe }
+import akka.util.OptionVal
+import com.datastax.oss.driver.api.core.uuid.Uuids
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class BufferSpec extends AnyWordSpec with Matchers with BeforeAndAfterAll {
+  implicit val system = ActorSystem()
+
+  "Buffer" should {
+    "not write when empty" in {
+      Buffer.empty(2).shouldWrite() shouldEqual false
+    }
+    "write when batch size met (single AwaitingWrite)" in {
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket)
+
+      Buffer.empty(2).add(AwaitingWrite(List((e1, 1), (e2, 2)), OptionVal.None)).shouldWrite() shouldEqual true
+    }
+    "write when batch size met (multiple AwaitingWrites)" in {
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket)
+
+      val buffer = Buffer
+        .empty(2)
+        .add(AwaitingWrite(List((e1, 1)), OptionVal.None))
+        .add(AwaitingWrite(List((e2, 12)), OptionVal.None))
+
+      buffer.shouldWrite() shouldEqual true
+      buffer.nextBatch shouldEqual (List(
+        AwaitingWrite(List((e1, 1)), OptionVal.None),
+        AwaitingWrite(List((e2, 12)), OptionVal.None)))
+    }
+    "write when time bucket changes" in {
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket.next())
+
+      Buffer
+        .empty(10)
+        .add(AwaitingWrite(List((e1, 1)), OptionVal.None))
+        .add(AwaitingWrite(List((e2, 12)), OptionVal.None))
+        .shouldWrite() shouldEqual true
+    }
+
+    "write when time bucket changes in the same add" in {
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket.next())
+      val sender = TestProbe().ref
+
+      val buffer = Buffer.empty(3).add(aw(sender, (e1, 1), (e2, 2))) // same aw, spanning time buckets
+
+      buffer.writeRequired shouldEqual true
+      buffer.nextBatch shouldEqual Vector(awNoSender((e1, 1)))
+
+      val nextBuffer = buffer.writeComplete()
+      nextBuffer.writeRequired shouldEqual false
+      nextBuffer.nextBatch shouldEqual Vector(aw(sender, (e2, 2)))
+
+    }
+    "write when multiple time buckets" in {
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket.next())
+      val e3 = event("p1", 3L, "e-2", bucket.next().next())
+      val sender = TestProbe().ref
+
+      val buffer = Buffer.empty(3).add(aw(sender, (e1, 1), (e2, 2), (e3, 3))) // same aw, spanning time buckets
+
+      buffer.writeRequired shouldEqual true
+      buffer.nextBatch shouldEqual Vector(awNoSender((e1, 1)))
+
+      val nextBuffer = buffer.writeComplete()
+      nextBuffer.writeRequired shouldEqual true
+      nextBuffer.nextBatch shouldEqual Vector(awNoSender((e2, 2)))
+
+      val nextNextBuffer = nextBuffer.writeComplete()
+      nextNextBuffer.writeRequired shouldEqual false
+      nextNextBuffer.nextBatch shouldEqual Vector(aw(sender, (e3, 3)))
+    }
+
+    "break up writes based on batch" in {
+      val bucket = nowBucket()
+      val e1 = event("p1", 1L, "e-1", bucket)
+      val e2 = event("p1", 2L, "e-2", bucket)
+      val e3 = event("p1", 3L, "e-3", bucket)
+      val e4 = event("p1", 4L, "e-2", bucket)
+      val sender = TestProbe().ref
+
+      val buffer = Buffer.empty(2).add(aw(sender, (e1, 1), (e2, 2), (e3, 3), (e4, 4))) // same aw, greater than batch size
+
+      buffer.writeRequired shouldEqual true
+      buffer.nextBatch shouldEqual Vector(awNoSender((e1, 1), (e2, 2)))
+
+      val nextBuffer = buffer.writeComplete()
+      nextBuffer.nextBatch shouldEqual Vector(aw(sender, (e3, 3), (e4, 4)))
+      nextBuffer.writeRequired shouldEqual true
+
+      val nextNextBuffer = nextBuffer.writeComplete()
+      nextNextBuffer.writeRequired shouldEqual false
+    }
+
+    // there will never be events in the same add that are out of order  as they are from the same pid
+    // but there can be from different adds
+    "handle out of order writes" in {
+      val currentBucket = (0 to 2).map { _ =>
+        val uuid = Uuids.timeBased()
+        (uuid, TimeBucket(uuid, Day))
+      }
+      val sender1 = TestProbe().ref
+      val sender2 = TestProbe().ref
+      val sender3 = TestProbe().ref
+
+      val futureBucketMillis = Uuids.unixTimestamp(currentBucket(0)._1) + Day.durationMillis
+      val futureBucket = TimeBucket(futureBucketMillis, Day)
+
+      val p1e1 = event("p1", 1, "p1-e1", currentBucket(0)._2, uuid = currentBucket(0)._1)
+      val p2e1 = event("p2", 1, "p2-e1", futureBucket, uuid = Uuids.startOf(futureBucketMillis))
+      val p1e2 = event("p1", 2, "p1-e2", currentBucket(1)._2, uuid = currentBucket(1)._1)
+
+      val buffer = Buffer.empty(2).add(aw(sender1, (p1e1, 1))).add(aw(sender2, (p2e1, 1)))
+
+      buffer.shouldWrite() shouldEqual true
+      buffer.nextBatch shouldEqual Vector(aw(sender1, (p1e1, 1)))
+
+      val nextBuffer = buffer.writeComplete()
+      nextBuffer.shouldWrite() shouldEqual false
+      nextBuffer.nextBatch shouldEqual Vector(aw(sender2, (p2e1, 1)))
+
+      // this is from before what is currently in nextWrite, they should be switched around
+      val nextNextBuffer = nextBuffer.add(aw(sender3, (p1e2, 2)))
+      nextNextBuffer.shouldWrite() shouldEqual true
+      nextNextBuffer.nextBatch shouldEqual Vector(aw(sender3, (p1e2, 2)))
+
+      val finalBuffer = nextNextBuffer.writeComplete()
+      finalBuffer.shouldWrite() shouldEqual false
+      nextBuffer.nextBatch shouldEqual Vector(aw(sender2, (p2e1, 1)))
+
+    }
+  }
+
+  override protected def afterAll(): Unit = {
+    TestKit.shutdownActorSystem(system)
+  }
+
+  def awNoSender(events: (Serialized, TagPidSequenceNr)*): AwaitingWrite = {
+    AwaitingWrite(events.toList, OptionVal.None)
+  }
+
+  def aw(sender: ActorRef, events: (Serialized, TagPidSequenceNr)*): AwaitingWrite = {
+    AwaitingWrite(events.toList, OptionVal(sender))
+  }
+
+  private def event(
+      pId: String,
+      seqNr: Long,
+      payload: String,
+      bucket: TimeBucket,
+      tags: Set[String] = Set(),
+      uuid: UUID = Uuids.timeBased()): Serialized =
+    Serialized(pId, seqNr, ByteBuffer.wrap(payload.getBytes()), tags, "", "", 1, "", None, uuid, bucket)
+
+  private def nowBucket(): TimeBucket = {
+    val now = Uuids.timeBased()
+    TimeBucket(now, Day)
+  }
+
+}

--- a/core/src/test/scala/akka/persistence/cassandra/journal/BufferSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/BufferSpec.scala
@@ -10,7 +10,7 @@ import java.util.UUID
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.persistence.cassandra.Day
 import akka.persistence.cassandra.journal.CassandraJournal.{ Serialized, TagPidSequenceNr }
-import akka.persistence.cassandra.journal.TagWriter.{ AwaitingWrite, Buffer }
+import akka.persistence.cassandra.journal.TagWriter.AwaitingWrite
 import akka.testkit.{ TestKit, TestProbe }
 import akka.util.OptionVal
 import com.datastax.oss.driver.api.core.uuid.Uuids

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -19,6 +19,7 @@ import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
+// FIXME test for replies
 class TagWritersSpec
     extends TestKit(ActorSystem("TagWriterSpec"))
     with AnyWordSpecLike

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -68,7 +68,7 @@ class TagWritersSpec
 
   "Tag writers" must {
 
-    "replies when all tag writes are complete" in {
+    "reply when all tag writes are complete" in {
       val redProbe = TestProbe()
       val blueProbe = TestProbe()
       val probes = Map("red" -> redProbe, "blue" -> blueProbe)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWritersSpec.scala
@@ -6,6 +6,7 @@ package akka.persistence.cassandra.journal
 
 import java.nio.ByteBuffer
 
+import akka.Done
 import akka.actor.{ Actor, ActorRef, ActorSystem, PoisonPill, Props }
 import akka.persistence.cassandra.Hour
 import akka.persistence.cassandra.journal.CassandraJournal.Serialized
@@ -14,14 +15,26 @@ import akka.persistence.cassandra.journal.TagWriters._
 import akka.testkit.{ ImplicitSender, TestKit, TestProbe }
 import akka.util.Timeout
 import com.datastax.oss.driver.api.core.uuid.Uuids
+import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.BeforeAndAfterAll
 import org.scalatest.wordspec.AnyWordSpecLike
 import org.scalatest.matchers.should.Matchers
+
 import scala.concurrent.duration._
 
-// FIXME test for replies
+object TagWritersSpec {
+  val config: Config =
+    ConfigFactory.parseString("""
+      akka {
+        use-slf4j = off
+        loglevel = INFO
+      }
+    """)
+
+}
+
 class TagWritersSpec
-    extends TestKit(ActorSystem("TagWriterSpec"))
+    extends TestKit(ActorSystem("TagWriterSpec", TagWritersSpec.config))
     with AnyWordSpecLike
     with BeforeAndAfterAll
     with ImplicitSender
@@ -54,17 +67,28 @@ class TagWritersSpec
   }
 
   "Tag writers" must {
-    "forward flush requests" in {
-      val probe = TestProbe()
-      val tagWriters = system.actorOf(testProps(defaultSettings, tag => {
-        tag shouldEqual "blue"
-        probe.ref
-      }))
 
-      tagWriters ! TagFlush("blue")
-      probe.expectMsg(Flush)
-      probe.reply(FlushComplete)
-      expectMsg(FlushComplete) // should be forwarded
+    "replies when all tag writes are complete" in {
+      val redProbe = TestProbe()
+      val blueProbe = TestProbe()
+      val probes = Map("red" -> redProbe, "blue" -> blueProbe)
+      val tagWriters = system.actorOf(testProps(defaultSettings, tag => probes(tag).ref))
+      initializePid(tagWriters)
+
+      val blueTagWrite = TagWrite("blue", List(event(pid, 0, "cat", Set("red", "blue"))))
+      val redTagWrite = TagWrite("red", List(event(pid, 0, "dog", Set("red", "blue"))))
+
+      tagWriters ! BulkTagWrite(List(blueTagWrite, redTagWrite), Nil)
+
+      expectNoMessage()
+
+      redProbe.expectMsg(redTagWrite)
+      blueProbe.expectMsg(blueTagWrite)
+
+      redProbe.reply(Done)
+      expectNoMessage()
+      blueProbe.reply(Done)
+      expectMsg(Done)
     }
 
     "flush all tag writers" in {
@@ -147,8 +171,10 @@ class TagWritersSpec
       val tagWriters = system.actorOf(testProps(defaultSettings, _ => probe.ref))
       initializePid(tagWriters)
 
-      tagWriters ! TagFlush("blue")
-      probe.expectMsg(Flush)
+      // send a tag write so that it is created
+      val preWrite = TagWrite("blue", List(dummySerialized("blue")))
+      tagWriters ! preWrite
+      probe.expectMsg(preWrite)
 
       tagWriters.tell(PassivateTagWriter("blue"), probe.ref)
       probe.expectMsg(StopTagWriter)
@@ -168,6 +194,11 @@ class TagWritersSpec
 
       probe.expectMsg(blueTagWrite)
     }
+  }
+
+  private def event(pid: String, seqNr: Long, payload: String, tags: Set[String]): Serialized = {
+    val uuid = Uuids.timeBased()
+    Serialized(pid, seqNr, ByteBuffer.wrap(payload.getBytes()), tags, "", "", 1, "", None, uuid, TimeBucket(uuid, Hour))
   }
 
   override protected def afterAll(): Unit =


### PR DESCRIPTION
#259 

This changes the tag write to be part of the Future returned from asyncWriteMessages

It is still asynchronous with respect to the write to the messages table so it can still fail/timeout while the messages table write succeed however now the actor will be stopped. The tag_view will then be fixed when it is restarted.

Note that the TagWriter does keep retrying the write until the persistent actor stops, need to decide what to set that timeout to.



