### PR TITLE
logging of retries eventsByTag

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/Retries.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/Retries.scala
@@ -47,8 +47,9 @@ private[cassandra] object Retries {
 
     if (maxAttempts == -1 || maxAttempts - attempted != 1) {
       tryAttempt().recoverWith {
-        case NonFatal(_) =>
+        case NonFatal(exc) =>
           val nextDelay = BackoffSupervisor.calculateDelay(attempted, minBackoff, maxBackoff, randomFactor)
+          onFailure(attempted + 1, exc, nextDelay)
           after(nextDelay, scheduler) {
             retry(attempt, maxAttempts, onFailure, minBackoff, maxBackoff, randomFactor, attempted + 1)
           }


### PR DESCRIPTION
The logging was missing, but the backoff works as expected. (I did some ad-hoc testing with EventsByTagSpec)

See #847
