### PR TITLE
disable new-persistence-id-scan-timeout config by default, #851

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -341,7 +341,9 @@ akka.persistence.cassandra {
     # The edge case is if events for a not previously seen persistenceId come out of order then if this is set to
     # 0s the newer event will be delivered and when the older event is found the stream will fail as events have
     # to be delivered in order.
-    new-persistence-id-scan-timeout = 100ms
+    # By default this is disabled, but for low (< 1 s) eventual-consistency-delay it can be set to something like
+    # 100ms for reduced risk of missing event for edge case when events are seen in "wrong" order.
+    new-persistence-id-scan-timeout = 0s
 
     # For offset queries that start in the current time bucket a period of scanning
     # takes place before deliverying events to look for the lowest sequence number

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -132,12 +132,11 @@ the query starts with a search to look for the lowest sequence number per persis
 before delivering any events.
  
 The above scanning only looks in the current time bucket. For persistence ids that aren't found in this initial scan because they 
-don't have any events in the current time bucket then the expected tag pid sequence number is not known. 
-In this case the eventsByTag query searches for `new-persistence-id-scan-timeout` before assuming this is the first
-event for that persistence id. 
-
-This adds a delay each time a new persistence id is found by an offset query when the first event doesn't have a sequenceNr of `1`. 
-If this is an issue it can be set to 0s. If events are found out of order due to this the stage will fail.  
+don't have any events in the current time bucket then the expected tag pid sequence number is not known.
+If events are found out of order due to this the stage will fail.
+It is possible to enable configuration `new-persistence-id-scan-timeout`, which will use an additional query to search
+for more events before assuming this is the first event for that persistence id.
+This adds a delay each time a new persistence id is found by an offset query when the first event doesn't have a sequenceNr of `1`.
 
 ## Events by tag reconciliation
 


### PR DESCRIPTION
* the delay can make the query very slow when there are many new persistenceIds,
  and this setting shouldn't add much more safetey for normal eventual-consistency-delay
  settings

References #851
