### PR TITLE
update scalaVersion, and nowarn

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
     - stage: check
       script: sbt -jvm-opts .jvmopts-travis verifyCodeStyle
       name: "Code style check. Run locally with: sbt verifyCodeStyle"
-    - script: sbt -jvm-opts .jvmopts-travis ++2.13.1 Test/compile
+    - script: sbt -jvm-opts .jvmopts-travis ++2.13.3 Test/compile
       name: Compile all tests (with Scala 2.13)
     - script: sbt -jvm-opts .jvmopts-travis unidoc
       name: Create all API docs

--- a/build.sbt
+++ b/build.sbt
@@ -22,7 +22,7 @@ lazy val core = (project in file("core"))
   .dependsOn(cassandraLauncher % Test)
   .settings(
     name := "akka-persistence-cassandra",
-    libraryDependencies ++= Dependencies.akkaPersistenceCassandraDependencies ++ Dependencies.silencer,
+    libraryDependencies ++= Dependencies.akkaPersistenceCassandraDependencies,
     Compile / packageBin / packageOptions += Package.ManifestAttributes(
         "Automatic-Module-Name" -> "akka.persistence.cassandra"))
   .configs(MultiJvm)

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -220,7 +220,7 @@ import akka.stream.scaladsl.Source
       result2.pipeTo(sender())
 
     case HealthCheckQuery =>
-      session.selectOne(healthCheckCql).map(_ => HealthCheckResponse)(ExecutionContexts.parasitic).pipeTo(sender)
+      session.selectOne(healthCheckCql).map(_ => HealthCheckResponse)(ExecutionContexts.parasitic).pipeTo(sender())
   }
 
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
@@ -254,7 +254,7 @@ import akka.stream.scaladsl.Source
     val writesWithUuids: Seq[Seq[(PersistentRepr, UUID)]] =
       messages.map(aw => aw.payload.map(pr => (pr, generateUUID(pr))))
 
-    val writeInProgressForPersistentId = Promise[Done]
+    val writeInProgressForPersistentId = Promise[Done]()
     val pid = messages.head.persistenceId
     writeInProgress.put(pid, writeInProgressForPersistentId.future)
 

--- a/core/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/PubSubThrottler.scala
@@ -35,7 +35,7 @@ import akka.annotation.InternalApi
 
     case msg =>
       if (seen.contains(msg)) {
-        repeated += (msg -> (repeated(msg) + sender))
+        repeated += (msg -> (repeated(msg) + sender()))
       } else {
         delegate.forward(msg)
         seen += msg

--- a/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/TagWriters.scala
@@ -330,7 +330,7 @@ import scala.util.Try
     case CancelPassivateTagWriter(tag) =>
       passivatingTagActors.get(tag).foreach { buffer =>
         passivatingTagActors = passivatingTagActors - tag
-        log.debug("Tag writer {} for tag [{}] canceled passivation.", sender, tag)
+        log.debug("Tag writer {} for tag [{}] canceled passivation.", sender(), tag)
         sendPassivateBuffer(tag, buffer)
       }
 

--- a/core/src/main/scala/akka/persistence/cassandra/query/AllPersistenceIdsStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/AllPersistenceIdsStage.scala
@@ -12,7 +12,7 @@ import akka.stream.{ Attributes, Outlet, SourceShape }
 import com.datastax.oss.driver.api.core.CqlSession
 import com.datastax.oss.driver.api.core.cql.AsyncResultSet
 import com.datastax.oss.driver.api.core.cql.PreparedStatement
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 
 import scala.collection.immutable.Queue
 import scala.concurrent.duration._
@@ -98,7 +98,7 @@ import scala.concurrent.duration._
         }
       }
 
-      @silent("deprecated") // keep compatible with akka 2.5
+      @nowarn("msg=deprecated") // keep compatible with akka 2.5
       override def preStart(): Unit = {
         query()
         refreshInterval.foreach { interval =>

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -18,7 +18,7 @@ import scala.concurrent.duration.{ FiniteDuration, _ }
 import scala.util.{ Failure, Success, Try }
 
 import com.datastax.oss.driver.api.core.CqlSession
-import com.github.ghik.silencer.silent
+import scala.annotation.nowarn
 import scala.compat.java8.FutureConverters._
 
 import akka.persistence.cassandra.PluginSettings
@@ -260,7 +260,7 @@ import akka.persistence.cassandra.PluginSettings
         }
       }
 
-      @silent("deprecated")
+      @nowarn("msg=deprecated")
       private def scheduleContinue(initial: FiniteDuration, interval: FiniteDuration): Unit = {
         schedulePeriodicallyWithInitialDelay(Continue, initial, interval)
       }

--- a/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/TagViewSequenceNumberScanner.scala
@@ -18,6 +18,7 @@ import akka.persistence.cassandra.query.TagViewSequenceNumberScanner.Session
 import akka.stream.Materializer
 import akka.stream.scaladsl.Source
 import com.datastax.oss.driver.api.core.cql.{ PreparedStatement, Row }
+import scala.annotation.nowarn
 import scala.concurrent.duration.{ Duration, FiniteDuration }
 import scala.concurrent.{ ExecutionContext, Future }
 
@@ -47,7 +48,7 @@ import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
  */
 @InternalApi private[akka] class TagViewSequenceNumberScanner(session: Session)(
     implicit materializer: Materializer,
-    ec: ExecutionContext) {
+    @nowarn("msg=never used") ec: ExecutionContext) {
   private val log = Logging(materializer.system, getClass)
 
   /**

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraEventsByTagLoadSpec.scala
@@ -72,7 +72,7 @@ class CassandraEventsByTagLoadSpec extends CassandraSpec(CassandraEventsByTagLoa
 
   private def validateTagStream(readJournal: CassandraReadJournal)(tag: String): Unit = {
     system.log.info(s"Validating tag $tag")
-    val probe = readJournal.eventsByTag("orange", NoOffset).toMat(TestSink.probe)(Keep.right).run
+    val probe = readJournal.eventsByTag("orange", NoOffset).toMat(TestSink.probe)(Keep.right).run()
     var sequenceNrsPerPid = Map[String, Long]()
     var allReceived: Map[String, List[Long]] = Map.empty.withDefaultValue(List.empty)
     probe.request(messagesPerPersistenceId * nrPersistenceIds)

--- a/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/CassandraLoadTypedSpec.scala
@@ -166,7 +166,7 @@ class CassandraLoadTypedSpec extends CassandraSpec(dumpRowsOnFailure = false) wi
 
   "Typed EventSourcedBehavior with Cassandra journal" must {
     "have some reasonable write throughput" in {
-      val probe = testKit.createTestProbe[String]
+      val probe = testKit.createTestProbe[String]()
       val processor =
         system.spawnAnonymous(
           Processor.behavior(PersistenceId.ofUniqueId("p1"), probe.ref, notifyProbeInEventHandler = false))
@@ -176,7 +176,7 @@ class CassandraLoadTypedSpec extends CassandraSpec(dumpRowsOnFailure = false) wi
     }
 
     "work properly under load" in {
-      val probe = testKit.createTestProbe[String]
+      val probe = testKit.createTestProbe[String]()
       def spawnProcessor() =
         system.spawnAnonymous(
           Processor.behavior(PersistenceId.ofUniqueId("p2"), probe.ref, notifyProbeInEventHandler = true))

--- a/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/journal/TagWriterSpec.scala
@@ -20,7 +20,6 @@ import akka.persistence.cassandra.journal.TagWriters.TagWritersSession
 import akka.testkit.{ TestKit, TestProbe }
 import com.datastax.oss.driver.api.core.cql.{ PreparedStatement, Statement }
 import com.datastax.oss.driver.api.core.uuid.Uuids
-import com.github.ghik.silencer.silent
 import com.typesafe.config.{ Config, ConfigFactory }
 import org.scalatest.{ BeforeAndAfterAll, BeforeAndAfterEach }
 import org.scalatest.wordspec.AnyWordSpecLike
@@ -56,7 +55,7 @@ object TagWriterSpec {
  * We have a lot of integration tests around eventsByTag queries so
  * writing this against a fake CassandraSession to test the batching
  */
-@silent // re-write to use lazy list
+// re-write to use lazy list
 class TagWriterSpec
     extends TestKit(ActorSystem("TagWriterSpec", TagWriterSpec.config))
     with AnyWordSpecLike

--- a/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/query/EventsByTagSpec.scala
@@ -1060,7 +1060,7 @@ class EventsByTagStrictBySeqMemoryIssueSpec extends AbstractEventsByTagSpec(Even
 
       probe.request(100)
       probe.expectNextN(30)
-      probe.expectComplete
+      probe.expectComplete()
     }
   }
 }

--- a/core/src/test/scala/akka/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/sharding/ClusterShardingQuickTerminationSpec.scala
@@ -80,7 +80,7 @@ class ClusterShardingQuickTerminationSpec extends CassandraSpec("""
       }
       ClusterSharding(system).start(
         typeName = "tagging",
-        entityProps = Props[Counter],
+        entityProps = Props[Counter](),
         settings = ClusterShardingSettings(system),
         extractEntityId = extractEntityId,
         extractShardId = extractShardId)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,8 +2,8 @@ import sbt._
 import Keys._
 
 object Dependencies {
-  val Scala212 = "2.12.10"
-  val Scala213 = "2.13.1"
+  val Scala212 = "2.12.13"
+  val Scala213 = "2.13.3"
   val ScalaVersions = Seq(Scala212, Scala213)
 
   val AkkaVersion = System.getProperty("override.akka.version", "2.6.9")
@@ -18,11 +18,6 @@ object Dependencies {
   val AkkaManagementVersion = "1.0.6"
 
   val Logback = "ch.qos.logback" % "logback-classic" % "1.2.3"
-
-  val silencerVersion = "1.5.0"
-  val silencer = Seq(
-    compilerPlugin(("com.github.ghik" %% "silencer-plugin" % silencerVersion).cross(CrossVersion.patch)),
-    ("com.github.ghik" %% "silencer-lib" % silencerVersion % Provided).cross(CrossVersion.patch))
 
   val reconcilerDependencies = Seq(
     "com.typesafe.akka" %% "akka-actor-testkit-typed" % AkkaVersion % Test,


### PR DESCRIPTION
Nightlies are failing: https://travis-ci.com/github/akka/akka-persistence-cassandra/jobs/482343227
See https://github.com/akka/akka/issues/30018

fixed warnings for 2.13 also, but didn't fix deprecation warnings
