### PR TITLE
When used for recovery, pin query to journal dispatcher

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -14,10 +14,6 @@ import akka.persistence.cassandra.session.CassandraSessionSettings
 
 case class StorePathPasswordConfig(path: String, password: String)
 
-object CassandraDispatchers {
-  val nameOfDefaultDispatcher = "cassandra-plugin-default-dispatcher"
-}
-
 class CassandraPluginConfig(system: ActorSystem, config: Config) {
 
   import akka.persistence.cassandra.CassandraPluginConfig._

--- a/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/CassandraPluginConfig.scala
@@ -14,6 +14,10 @@ import akka.persistence.cassandra.session.CassandraSessionSettings
 
 case class StorePathPasswordConfig(path: String, password: String)
 
+object CassandraDispatchers {
+  val nameOfDefaultDispatcher = "cassandra-plugin-default-dispatcher"
+}
+
 class CassandraPluginConfig(system: ActorSystem, config: Config) {
 
   import akka.persistence.cassandra.CassandraPluginConfig._

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -29,7 +29,6 @@ import akka.persistence.cassandra.session.scaladsl.CassandraSession
 import akka.persistence.journal.{ AsyncWriteJournal, Tagged }
 import akka.persistence.query.PersistenceQuery
 import akka.serialization.{ AsyncSerializer, Serialization, SerializationExtension }
-import akka.stream.ActorAttributes
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import akka.util.OptionVal
@@ -638,9 +637,9 @@ class CassandraJournal(cfg: Config)
         "asyncReadLowestSequenceNr",
         readConsistency,
         retryPolicy,
-        extractor = Extractors.sequenceNumber(eventDeserializer, serialization))
-      // run the query on the journal dispatcher (not the queries dispatcher)
-      .withAttributes(ActorAttributes.dispatcher(sessionSettings.pluginDispatcher))
+        extractor = Extractors.sequenceNumber(eventDeserializer, serialization),
+        // run the query on the journal dispatcher (not the queries dispatcher)
+        dispatcher = sessionSettings.pluginDispatcher)
       .map(_.sequenceNr)
       .runWith(Sink.headOption)
       .map {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -22,13 +22,13 @@ import akka.pattern.pipe
 import akka.persistence._
 import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
 import akka.persistence.cassandra._
-import akka.persistence.cassandra.journal.TagWriters.{ TagWritersSession, TagWrite, BulkTagWrite }
+import akka.persistence.cassandra.journal.TagWriters.{ BulkTagWrite, TagWrite, TagWritersSession }
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
-import akka.persistence.journal.{ Tagged, AsyncWriteJournal }
+import akka.persistence.journal.{ AsyncWriteJournal, Tagged }
 import akka.persistence.query.PersistenceQuery
-import akka.serialization.{ Serialization, SerializationExtension, AsyncSerializer }
+import akka.serialization.{ AsyncSerializer, Serialization, SerializationExtension }
 import akka.stream.ActorAttributes
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
@@ -36,7 +36,7 @@ import akka.util.OptionVal
 import com.datastax.driver.core._
 import com.datastax.driver.core.exceptions.DriverException
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
-import com.datastax.driver.core.policies.{ RetryPolicy, LoggingRetryPolicy }
+import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
 import com.datastax.driver.core.utils.{ Bytes, UUIDs }
 import com.typesafe.config.Config
 
@@ -45,7 +45,7 @@ import scala.collection.immutable
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.util.control.NonFatal
-import scala.util.{ Try, Success, Failure }
+import scala.util.{ Failure, Success, Try }
 
 /**
  * Journal implementation of the cassandra plugin.

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -7,7 +7,6 @@ package akka.persistence.cassandra.journal
 import java.lang.{ Long => JLong }
 import java.nio.ByteBuffer
 import java.util.{ UUID, HashMap => JHMap, Map => JMap }
-
 import akka.Done
 import akka.actor.SupervisorStrategy.Stop
 import akka.actor.ActorRef
@@ -23,20 +22,21 @@ import akka.pattern.pipe
 import akka.persistence._
 import akka.persistence.cassandra.EventWithMetaData.UnknownMetaData
 import akka.persistence.cassandra._
-import akka.persistence.cassandra.journal.TagWriters.{ BulkTagWrite, TagWrite, TagWritersSession }
+import akka.persistence.cassandra.journal.TagWriters.{ TagWritersSession, TagWrite, BulkTagWrite }
 import akka.persistence.cassandra.query.EventsByPersistenceIdStage.Extractors
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.cassandra.session.scaladsl.CassandraSession
-import akka.persistence.journal.{ AsyncWriteJournal, Tagged }
+import akka.persistence.journal.{ Tagged, AsyncWriteJournal }
 import akka.persistence.query.PersistenceQuery
-import akka.serialization.{ AsyncSerializer, Serialization, SerializationExtension }
+import akka.serialization.{ Serialization, SerializationExtension, AsyncSerializer }
+import akka.stream.ActorAttributes
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.Sink
 import akka.util.OptionVal
 import com.datastax.driver.core._
 import com.datastax.driver.core.exceptions.DriverException
 import com.datastax.driver.core.policies.RetryPolicy.RetryDecision
-import com.datastax.driver.core.policies.{ LoggingRetryPolicy, RetryPolicy }
+import com.datastax.driver.core.policies.{ RetryPolicy, LoggingRetryPolicy }
 import com.datastax.driver.core.utils.{ Bytes, UUIDs }
 import com.typesafe.config.Config
 
@@ -45,7 +45,7 @@ import scala.collection.immutable
 import scala.collection.immutable.Seq
 import scala.concurrent._
 import scala.util.control.NonFatal
-import scala.util.{ Failure, Success, Try }
+import scala.util.{ Try, Success, Failure }
 
 /**
  * Journal implementation of the cassandra plugin.
@@ -639,6 +639,8 @@ class CassandraJournal(cfg: Config)
         readConsistency,
         retryPolicy,
         extractor = Extractors.sequenceNumber(eventDeserializer, serialization))
+      // run the query on the journal dispatcher (not the queries dispatcher)
+      .withAttributes(ActorAttributes.dispatcher(sessionSettings.pluginDispatcher))
       .map(_.sequenceNr)
       .runWith(Sink.headOption)
       .map {

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournalConfig.scala
@@ -70,6 +70,8 @@ class CassandraJournalConfig(system: ActorSystem, config: Config)
 
   val eventsByTagEnabled: Boolean = config.getBoolean("events-by-tag.enabled")
 
+  val pluginDispatcher: String = config.getString("plugin-dispatcher")
+
   val bucketSize: BucketSize =
     BucketSize.fromString(config.getString("events-by-tag.bucket-size"))
 

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -207,7 +207,8 @@ abstract class CassandraSpec(
         100,
         None,
         "test",
-        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
+        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)),
+        dispatcher = "cassandra-plugin-default-dispatcher")
       .toMat(Sink.seq)(Keep.right)
       .run()
       .futureValue
@@ -222,7 +223,8 @@ abstract class CassandraSpec(
         100,
         None,
         "test",
-        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
+        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)),
+        dispatcher = "cassandra-plugin-default-dispatcher")
       .map { tpr =>
         (tpr.pr.payload, tpr.tags)
       }


### PR DESCRIPTION
Recovering an entity should not be clogged by the load on the read-side.

When using a query for recovery, it should run on the journal dispatcher no the read dispatcher.