### PR TITLE
Replace jabba with SDKman on Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,10 @@ before_install:
   - git remote set-branches --add origin master && git fetch
   # fetch full history for correct current and previous version detection
   - git fetch --unshallow
-  # latest JDK 8 is installed by the super YAML (in https://github.com/scala/scala-dev/blob/scala-dev/travis/default.yml) 
-  # via `env:` below. We also manually install 11.0.10 manually.
-  - export JDK11=11.0.10.hs-adpt
+  - export JDK11=$(sdk list java | grep -o " 11\.[0-9\.]*hs-adpt" | head -1 | cut -c2-)
   - sdk install java $JDK11
-  # then, the variable $sdkJava, created in https://github.com/scala/scala-dev/blob/scala-dev/travis/default.yml, contains 
-  # the name of the JDK8 version we need.
-  - export JDK8=$sdkJava
+  - export JDK8=$(sdk list java | grep -o " 8\.[0-9\.]*hs-adpt" | head -1 | cut -c2-)
+  - sdk install java $JDK8
 
 before_script:
   - unset _JAVA_OPTIONS
@@ -75,15 +72,22 @@ stages:
 after_failure:
   - docker-compose logs
 
+
 before_cache:
-  - find $HOME/.ivy2/ -name "ivydata-*.properties" -print -delete
-  - find $HOME/.sbt   -name "*.lock"               -print -delete
+  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
+  - rm -fv $HOME/.sdkman/var/broadcast
+  - rm -fv $HOME/.sdkman/var/broadcast_id
+  - find $HOME/.ivy2/cache -name "ivydata-*.properties"     -print -delete
+  - find $HOME/.sbt        -name "*.lock"                   -print -delete
+  - find $HOME/.sbt        -name "*compiler-bridge_*-bin-*" -print -delete
 
 cache:
   directories:
     - $HOME/.ivy2/cache
-    - $HOME/.sbt/boot
-
+    - $HOME/.sbt
+    - $HOME/.sdkman
+    - $HOME/.cache/coursier
+    
 env:
   global:
     # encrypt with: travis encrypt WHITESOURCE_PASSWORD=...

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,9 +39,9 @@ jobs:
       name: Create site with Paradox
 
     - stage: test
-      script: sdk use java $JDK8 && java -version && docker-compose up -d cassandra && sbt +test
+      script: date && sdk use java $JDK8 && java -version && date && docker-compose up -d cassandra && date && sbt +test && date
       name: Run all tests with Jdk 8
-    - script: sdk use java $JDK11 && java -version && docker-compose up -d cassandra && sbt +test
+    - script: date && sdk use java $JDK11 && java -version && date && docker-compose up -d cassandra && date && sbt +test && date
       name: Run all tests with Jdk 11
 
     - stage: whitesource

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
-language: scala
-sudo: true
-dist: trusty
+version: ~> 1.0 # needed for imports
+
+import: scala/scala-dev:travis/default.yml
 
 services:
   - docker
@@ -10,13 +10,20 @@ before_install:
   - git remote set-branches --add origin master && git fetch
   # fetch full history for correct current and previous version detection
   - git fetch --unshallow
-  # using jabba for custom jdk management
-  - curl -sL https://raw.githubusercontent.com/shyiko/jabba/0.11.1/install.sh | bash && . ~/.jabba/jabba.sh
-  - jabba install adopt@~1.8-0
-  - jabba install adopt@~1.11-0
+  # latest JDK 8 is installed by the super YAML (in https://github.com/scala/scala-dev/blob/scala-dev/travis/default.yml) 
+  # via `env:` below. We also manually install 11.0.10 manually.
+  - export JDK11=11.0.10.hs-adpt
+  - sdk install java $JDK11
+  # then, the variable $sdkJava, created in https://github.com/scala/scala-dev/blob/scala-dev/travis/default.yml, contains 
+  # the name of the JDK8 version we need.
+  - export JDK8=$sdkJava
 
 before_script:
   - unset _JAVA_OPTIONS
+
+# latest JDK 8 will be installed by the super YAML (in https://github.com/scala/scala-dev/blob/scala-dev/travis/default.yml)
+env:
+  - ADOPTOPENJDK=8
 
 jobs:
   include:
@@ -35,9 +42,9 @@ jobs:
       name: Create site with Paradox
 
     - stage: test
-      script: jabba use adopt@~1.8-0 && java -version && docker-compose up -d cassandra && sbt +test
+      script: sdk use java $JDK8 && java -version && docker-compose up -d cassandra && sbt +test
       name: Run all tests with Jdk 8
-    - script: jabba use adopt@~1.11-0 && java -version && docker-compose up -d cassandra && sbt +test
+    - script: sdk use java $JDK11 && java -version && docker-compose up -d cassandra && sbt +test
       name: Run all tests with Jdk 11
 
     - stage: whitesource
@@ -76,7 +83,6 @@ cache:
   directories:
     - $HOME/.ivy2/cache
     - $HOME/.sbt/boot
-    - $HOME/.jabba/jdk
 
 env:
   global:


### PR DESCRIPTION
Replaces using Jabba with using SDKman inheriting the setup from https://github.com/scala/scala-dev/blob/scala-dev/travis/default.yml

Please squash-merge instead of merge