### PR TITLE
A useless change to compare build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ jobs:
       name: Create site with Paradox
 
     - stage: test
-      script: jabba use adopt@~1.8-0 && java -version && docker-compose up -d cassandra && sbt +test
+      script: date &&jabba use adopt@~1.8-0 && java -version && docker-compose up -d cassandra && date && sbt +test && date
       name: Run all tests with Jdk 8
-    - script: jabba use adopt@~1.11-0 && java -version && docker-compose up -d cassandra && sbt +test
+    - script: date && jabba use adopt@~1.11-0 && java -version && docker-compose up -d cassandra && date && sbt +test && date
       name: Run all tests with Jdk 11
 
     - stage: whitesource


### PR DESCRIPTION
Do not merge.

In #881 I switched from Jabba to SDKman to install JDKs. Coincidentally (?) all builds since then seem to have degraded in performance and the test jobs in the build that used to run in about 30min now take 42-45 minutes.

It makes no sense.

