### PR TITLE
Use journal plugin-dispatcher for eventsByPersistenceId recovery

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -26,6 +26,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration._
 
 import akka.actor.ClassicActorSystemProvider
+import akka.stream.ActorAttributes
 
 object EventsByTagMigration {
   def apply(systemProvider: ClassicActorSystemProvider): EventsByTagMigration =
@@ -79,10 +80,9 @@ class EventsByTagMigration(
   private lazy val queries = PersistenceQuery(system).readJournalFor[CassandraReadJournal](pluginConfigPath + ".query")
   private implicit val sys: ActorSystem = system
 
-  implicit val ec =
-    system.dispatchers.lookup(system.settings.config.getString(s"$pluginConfigPath.journal.plugin-dispatcher"))
   private val settings: PluginSettings =
     new PluginSettings(system, system.settings.config.getConfig(pluginConfigPath))
+  implicit val ec = system.dispatchers.lookup(settings.journalSettings.pluginDispatcher)
   private val journalStatements = new CassandraJournalStatements(settings)
   private val taggedPreparedStatements = new TaggedPreparedStatements(journalStatements, session.prepare)
   private val tagWriterSession =
@@ -211,6 +211,7 @@ class EventsByTagMigration(
                 .map(tagRecovery.sendMissingTagWriteRaw(tp, actorRunning = false))
                 .grouped(periodicFlush)
                 .mapAsync(1)(_ => tagRecovery.flush(timeout))
+                .withAttributes(ActorAttributes.dispatcher(settings.journalSettings.pluginDispatcher))
             }
           }
         }

--- a/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/EventsByTagMigration.scala
@@ -207,7 +207,8 @@ class EventsByTagMigration(
                   settings.querySettings.readProfile,
                   s"migrateToTag-$pid",
                   extractor =
-                    EventsByTagMigration.rawPayloadOldTagSchemaExtractor(eventsByTagSettings.bucketSize, system))
+                    EventsByTagMigration.rawPayloadOldTagSchemaExtractor(eventsByTagSettings.bucketSize, system),
+                  ec)
                 .map(tagRecovery.sendMissingTagWriteRaw(tp, actorRunning = false))
                 .grouped(periodicFlush)
                 .mapAsync(1)(_ => tagRecovery.flush(timeout))

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -747,7 +747,8 @@ import akka.stream.scaladsl.Source
                 None,
                 settings.journalSettings.readProfile,
                 "asyncReplayMessages",
-                extractor = Extractors.taggedPersistentRepr(eventDeserializer, serialization))
+                extractor = Extractors.taggedPersistentRepr(eventDeserializer, serialization),
+                ec)
               .mapAsync(1)(tr.sendMissingTagWrite(tp))
           }))
           .map(te => queries.mapEvent(te.pr))
@@ -767,7 +768,8 @@ import akka.stream.scaladsl.Source
             None,
             settings.journalSettings.readProfile,
             "asyncReplayMessages",
-            extractor = Extractors.persistentRepr(eventDeserializer, serialization))
+            extractor = Extractors.persistentRepr(eventDeserializer, serialization),
+            ec)
           .map(queries.mapEvent)
           .map(replayCallback)
           .toMat(Sink.ignore)(Keep.right)
@@ -800,7 +802,8 @@ import akka.stream.scaladsl.Source
           None,
           settings.journalSettings.readProfile,
           "asyncReplayMessagesPreSnapshot",
-          Extractors.optionalTaggedPersistentRepr(eventDeserializer, serialization))
+          Extractors.optionalTaggedPersistentRepr(eventDeserializer, serialization),
+          ec)
         .mapAsync(1) { t =>
           t.tagged match {
             case OptionVal.Some(tpr) =>

--- a/core/src/main/scala/akka/persistence/cassandra/journal/JournalSettings.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/JournalSettings.scala
@@ -53,4 +53,6 @@ import com.typesafe.config.Config
 
   val coordinatedShutdownOnError: Boolean = config.getBoolean("coordinated-shutdown-on-error")
 
+  val pluginDispatcher: String = journalConfig.getString("plugin-dispatcher")
+
 }

--- a/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/EventsByPersistenceIdStage.scala
@@ -110,6 +110,7 @@ import akka.persistence.cassandra.PluginSettings
     refreshInterval: Option[FiniteDuration],
     session: EventsByPersistenceIdStage.EventsByPersistenceIdSession,
     settings: PluginSettings,
+    executionContext: ExecutionContext,
     fastForwardEnabled: Boolean = false)
     extends GraphStageWithMaterializedValue[SourceShape[Row], EventsByPersistenceIdStage.Control] {
 
@@ -123,10 +124,10 @@ import akka.persistence.cassandra.PluginSettings
   override def createLogicAndMaterializedValue(inheritedAttributes: Attributes): (GraphStageLogic, Control) = {
     val logic = new TimerGraphStageLogic(shape) with OutHandler with StageLogging with Control {
 
+      implicit def ec: ExecutionContext = executionContext
+
       override protected def logSource: Class[_] =
         classOf[EventsByPersistenceIdStage]
-
-      implicit def ec = materializer.executionContext
 
       val donePromise = Promise[Done]()
 

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -332,7 +332,8 @@ class CassandraReadJournal protected (
                 eventsByTagSettings.bucketSize,
                 usingOffset,
                 initialTagPidSequenceNrs,
-                scanner))
+                scanner,
+                ec))
         }.via(deserializeEventsByTagRow)
           .withAttributes(ActorAttributes.dispatcher(querySettings.pluginDispatcher))
           .mapMaterializedValue(_ => NotUsed)
@@ -515,7 +516,8 @@ class CassandraReadJournal protected (
                 eventsByTagSettings.bucketSize,
                 usingOffset,
                 initialTagPidSequenceNrs,
-                scanner))
+                scanner,
+                ec))
         }.via(deserializeEventsByTagRow)
           .withAttributes(ActorAttributes.dispatcher(querySettings.pluginDispatcher))
           .mapMaterializedValue(_ => NotUsed)

--- a/core/src/main/scala/akka/persistence/cassandra/reconciler/BuildTagViewForPersistenceId.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/reconciler/BuildTagViewForPersistenceId.scala
@@ -10,6 +10,7 @@ import akka.Done
 import akka.persistence.cassandra.journal.TagWriter._
 import scala.concurrent.duration._
 import scala.concurrent.Future
+
 import akka.stream.scaladsl.Source
 import akka.actor.ExtendedActorSystem
 import akka.persistence.query.PersistenceQuery
@@ -22,6 +23,7 @@ import akka.stream.OverflowStrategy
 import akka.stream.scaladsl.Sink
 import akka.annotation.InternalApi
 import akka.serialization.SerializationExtension
+import akka.stream.ActorAttributes
 
 /**
  * INTERNAL API
@@ -68,6 +70,7 @@ private[akka] final class BuildTagViewForPersisetceId(
           .map(recovery.sendMissingTagWriteRaw(tp, actorRunning = false))
           .buffer(flushEvery, OverflowStrategy.backpressure)
           .mapAsync(1)(_ => recovery.flush(flushTimeout))
+          .withAttributes(ActorAttributes.dispatcher(settings.journalSettings.pluginDispatcher))
       }))
       .runWith(Sink.ignore)
 

--- a/core/src/main/scala/akka/persistence/cassandra/reconciler/BuildTagViewForPersistenceId.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/reconciler/BuildTagViewForPersistenceId.scala
@@ -66,7 +66,8 @@ private[akka] final class BuildTagViewForPersisetceId(
             None,
             settings.journalSettings.readProfile,
             "BuildTagViewForPersistenceId",
-            extractor = Extractors.rawEvent(settings.eventsByTagSettings.bucketSize, serialization, system))
+            extractor = Extractors.rawEvent(settings.eventsByTagSettings.bucketSize, serialization, system),
+            system.dispatcher)
           .map(recovery.sendMissingTagWriteRaw(tp, actorRunning = false))
           .buffer(flushEvery, OverflowStrategy.backpressure)
           .mapAsync(1)(_ => recovery.flush(flushTimeout))

--- a/core/src/main/scala/akka/persistence/cassandra/snapshot/SnapshotSettings.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/snapshot/SnapshotSettings.scala
@@ -37,4 +37,6 @@ import com.typesafe.config.Config
 
   val maxLoadAttempts: Int = snapshotConfig.getInt("max-load-attempts")
 
+  val pluginDispatcher: String = snapshotConfig.getString("plugin-dispatcher")
+
 }

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -255,12 +255,7 @@ abstract class CassandraSpec(
   }
 
   def eventsPayloads(pid: String): Seq[Any] =
-    queries
-      .currentEventsByPersistenceId(pid, 0, Long.MaxValue)
-      .map(e => e.event)
-      .toMat(Sink.seq)(Keep.right)
-      .run()
-      .futureValue
+    queries.currentEventsByPersistenceId(pid, 0, Long.MaxValue).map(e => e.event).runWith(Sink.seq).futureValue
 
   def events(pid: String): immutable.Seq[Extractors.TaggedPersistentRepr] =
     queries
@@ -273,8 +268,7 @@ abstract class CassandraSpec(
         readProfile = "akka-persistence-cassandra-profile",
         "test",
         extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
-      .toMat(Sink.seq)(Keep.right)
-      .run()
+      .runWith(Sink.seq)
       .futureValue
 
   def eventPayloadsWithTags(pid: String): immutable.Seq[(Any, Set[String])] =
@@ -291,8 +285,7 @@ abstract class CassandraSpec(
       .map { tpr =>
         (tpr.pr.payload, tpr.tags)
       }
-      .toMat(Sink.seq)(Keep.right)
-      .run()
+      .runWith(Sink.seq)
       .futureValue
 
   def eventsByTag(tag: String): TestSubscriber.Probe[Any] =

--- a/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
+++ b/core/src/test/scala/akka/persistence/cassandra/CassandraSpec.scala
@@ -13,7 +13,7 @@ import akka.event.Logging.{ LogEvent, StdOutLogger }
 import akka.persistence.cassandra.CassandraSpec._
 import akka.persistence.cassandra.query.scaladsl.CassandraReadJournal
 import akka.persistence.query.{ NoOffset, PersistenceQuery }
-import akka.stream.scaladsl.{ Keep, Sink }
+import akka.stream.scaladsl.Sink
 import akka.stream.testkit.TestSubscriber
 import akka.stream.testkit.scaladsl.TestSink
 import akka.testkit.{ EventFilter, ImplicitSender, SocketUtil, TestKitBase }
@@ -267,7 +267,8 @@ abstract class CassandraSpec(
         None,
         readProfile = "akka-persistence-cassandra-profile",
         "test",
-        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
+        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)),
+        system.dispatcher)
       .runWith(Sink.seq)
       .futureValue
 
@@ -281,7 +282,8 @@ abstract class CassandraSpec(
         None,
         readProfile = "akka-persistence-cassandra-profile",
         "test",
-        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)))
+        extractor = Extractors.taggedPersistentRepr(eventDeserializer, SerializationExtension(system)),
+        system.dispatcher)
       .map { tpr =>
         (tpr.pr.payload, tpr.tags)
       }


### PR DESCRIPTION
This is a forward port of https://github.com/akka/akka/pull/30007 and https://github.com/akka/akka-persistence-cassandra/pull/888, but also a few more dispatcher related things

Use journal plugin-dispatcher for recovery
* When eventsByPersistenceId is used for recovery it should use the journal.plugin-dispatcher
* Use plugin-dispatcher all the way for internal eventsByPersistenceId
* ExecutionContexts.parasitic for `.map(_ => ())`

ExecutionContext parameter to EventsByTagStage and EventsByPersistenceIdStage
* materializer.executionContext can be the default-dispatcher