### PR TITLE
Fix broken Cassandra2 testing in CI

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -77,11 +77,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { jdk: 'adopt:8',  container: "cassandra-latest",  scalaVersion: "++2.13.8" }
-          - { jdk: 'adopt:11', container: "cassandra-latest",  scalaVersion: "++2.12.14" }
-          - { jdk: 'adopt:11', container: "cassandra-latest",  scalaVersion: "++2.13.8" }
-          - { jdk: 'adopt:11', container: "cassandra2",        scalaVersion: "++2.13.8" }
-          - { jdk: 'adopt:11', container: "cassandra3",        scalaVersion: "++2.13.8" }
+          - { jdk: 'adopt:8',  container: "cassandra-latest",  scalaVersion: "++2.13.8", test: "test" }
+          - { jdk: 'adopt:11', container: "cassandra-latest",  scalaVersion: "++2.12.14", test: "test" }
+          - { jdk: 'adopt:11', container: "cassandra-latest",  scalaVersion: "++2.13.8", test: "test" }
+          - { jdk: 'adopt:11', container: "cassandra2",        scalaVersion: "++2.13.8", test: "'testOnly -- -l RequiresCassandraThree'"}
+          - { jdk: 'adopt:11', container: "cassandra3",        scalaVersion: "++2.13.8", test: "test" }
 
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
@@ -108,4 +108,4 @@ jobs:
 
       - name: Test against ${{ matrix.container }}
         run: |-
-          docker-compose up -d ${{ matrix.container }} && sbt ${{ matrix.scalaVersion }} test
+          docker-compose up -d ${{ matrix.container }} && sbt ${{ matrix.scalaVersion }} ${{matrix.test}}


### PR DESCRIPTION
Has been broken since the switch to Github Actions: https://github.com/akka/akka-persistence-cassandra/pull/953/files#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485L67