### PR TITLE
Adapt all prepared statement usages to keep a reference to the prepar…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea*
+.bloop
 *.env
 *.log
 *.iml

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraEventUpdate.scala
@@ -27,10 +27,11 @@ import akka.stream.alpakka.cassandra.scaladsl.CassandraSession
 
   private def journalSettings = settings.journalSettings
   private lazy val journalStatements = new CassandraJournalStatements(settings)
-  def psUpdateMessage: Future[PreparedStatement] = session.prepare(journalStatements.updateMessagePayloadAndTags)
-  def psSelectTagPidSequenceNr: Future[PreparedStatement] = session.prepare(journalStatements.selectTagPidSequenceNr)
-  def psUpdateTagView: Future[PreparedStatement] = session.prepare(journalStatements.updateMessagePayloadInTagView)
-  def psSelectMessages: Future[PreparedStatement] = session.prepare(journalStatements.selectMessages)
+  lazy val psUpdateMessage: Future[PreparedStatement] = session.prepare(journalStatements.updateMessagePayloadAndTags)
+  lazy val psSelectTagPidSequenceNr: Future[PreparedStatement] =
+    session.prepare(journalStatements.selectTagPidSequenceNr)
+  lazy val psUpdateTagView: Future[PreparedStatement] = session.prepare(journalStatements.updateMessagePayloadInTagView)
+  lazy val psSelectMessages: Future[PreparedStatement] = session.prepare(journalStatements.selectMessages)
 
   /**
    * Update the given event in the messages table and the tag_views table.

--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -107,27 +107,27 @@ import akka.stream.scaladsl.Source
   private val tagRecovery: Option[CassandraTagRecovery] =
     tagWrites.map(ref => new CassandraTagRecovery(context.system, session, settings, taggedPreparedStatements, ref))
 
-  private def preparedWriteMessage =
+  private lazy val preparedWriteMessage =
     session.prepare(statements.journalStatements.writeMessage(withMeta = false))
-  private def preparedSelectDeletedTo: Option[Future[PreparedStatement]] = {
+  private lazy val preparedSelectDeletedTo: Option[Future[PreparedStatement]] = {
     if (settings.journalSettings.supportDeletes)
       Some(session.prepare(statements.journalStatements.selectDeletedTo))
     else
       None
   }
-  private def preparedSelectHighestSequenceNr: Future[PreparedStatement] =
+  private lazy val preparedSelectHighestSequenceNr: Future[PreparedStatement] =
     session.prepare(statements.journalStatements.selectHighestSequenceNr)
 
   private def deletesNotSupportedException: Future[PreparedStatement] =
     Future.failed(new IllegalArgumentException(s"Deletes not supported because config support-deletes=off"))
 
-  private def preparedInsertDeletedTo: Future[PreparedStatement] = {
+  private lazy val preparedInsertDeletedTo: Future[PreparedStatement] = {
     if (settings.journalSettings.supportDeletes)
       session.prepare(statements.journalStatements.insertDeletedTo)
     else
       deletesNotSupportedException
   }
-  private def preparedDeleteMessages: Future[PreparedStatement] = {
+  private lazy val preparedDeleteMessages: Future[PreparedStatement] = {
     if (settings.journalSettings.supportDeletes) {
       session.serverMetaData.flatMap { meta =>
         session.prepare(statements.journalStatements.deleteMessages(meta.isVersion2 || settings.cosmosDb))
@@ -135,13 +135,13 @@ import akka.stream.scaladsl.Source
     } else
       deletesNotSupportedException
   }
-  private def preparedInsertIntoAllPersistenceIds: Future[PreparedStatement] = {
+  private lazy val preparedInsertIntoAllPersistenceIds: Future[PreparedStatement] = {
     session.prepare(statements.journalStatements.insertIntoAllPersistenceIds)
   }
 
-  private def preparedWriteMessageWithMeta =
+  private lazy val preparedWriteMessageWithMeta =
     session.prepare(statements.journalStatements.writeMessage(withMeta = true))
-  private def preparedSelectMessages =
+  private lazy val preparedSelectMessages =
     session.prepare(statements.journalStatements.selectMessages)
 
   private lazy val queries: CassandraReadJournal =

--- a/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/query/scaladsl/CassandraReadJournal.scala
@@ -173,25 +173,25 @@ class CassandraReadJournal protected (
           preparedSelectTagSequenceNrs))
       .map(_ => Done)
 
-  private def preparedSelectEventsByPersistenceId: Future[PreparedStatement] =
+  private lazy val preparedSelectEventsByPersistenceId: Future[PreparedStatement] =
     session.prepare(statements.journalStatements.selectMessages)
 
-  private def preparedSelectDeletedTo: Future[PreparedStatement] =
+  private lazy val preparedSelectDeletedTo: Future[PreparedStatement] =
     session.prepare(statements.journalStatements.selectDeletedTo)
 
-  private def preparedSelectAllPersistenceIds: Future[PreparedStatement] =
+  private lazy val preparedSelectAllPersistenceIds: Future[PreparedStatement] =
     session.prepare(queryStatements.selectAllPersistenceIds)
 
-  private def preparedSelectDistinctPersistenceIds: Future[PreparedStatement] =
+  private lazy val preparedSelectDistinctPersistenceIds: Future[PreparedStatement] =
     session.prepare(queryStatements.selectDistinctPersistenceIds)
 
-  private def preparedSelectFromTagViewWithUpperBound: Future[PreparedStatement] =
+  private lazy val preparedSelectFromTagViewWithUpperBound: Future[PreparedStatement] =
     session.prepare(queryStatements.selectEventsFromTagViewWithUpperBound)
 
-  private def preparedSelectTagSequenceNrs: Future[PreparedStatement] =
+  private lazy val preparedSelectTagSequenceNrs: Future[PreparedStatement] =
     session.prepare(queryStatements.selectTagSequenceNrs)
 
-  private def preparedSelectHighestSequenceNr: Future[PreparedStatement] =
+  private lazy val preparedSelectHighestSequenceNr: Future[PreparedStatement] =
     session.prepare(statements.journalStatements.selectHighestSequenceNr)
 
   /**

--- a/example/src/main/scala/akka/persistence/cassandra/example/EventProcessorStream.scala
+++ b/example/src/main/scala/akka/persistence/cassandra/example/EventProcessorStream.scala
@@ -100,14 +100,14 @@ class EventProcessorStream[Event: ClassTag](
     query.timeBasedUUIDFrom(System.currentTimeMillis() - (7 * 24 * 60 * 60 * 1000))
   }
 
-  private def prepareWriteOffset(): Future[PreparedStatement] = {
+  private lazy val prepareWriteOffset: Future[PreparedStatement] = {
     session.prepare("INSERT INTO akka.offsetStore (eventProcessorId, tag, timeUuidOffset) VALUES (?, ?, ?)")
   }
 
   private def writeOffset(offset: Offset)(implicit ec: ExecutionContext): Future[Done] = {
     offset match {
       case t: TimeBasedUUID =>
-        prepareWriteOffset().map(stmt => stmt.bind(eventProcessorId, tag, t.value)).flatMap { boundStmt =>
+        prepareWriteOffset.map(stmt => stmt.bind(eventProcessorId, tag, t.value)).flatMap { boundStmt =>
           session.executeWrite(boundStmt)
         }
 


### PR DESCRIPTION
…ed statements since otherwise the prepared statement will be garbage collected (kept in weak ref in the driver) which will then crash once new cassandra nodes join the cluster (or get restarted).

See https://datastax-oss.atlassian.net/browse/JAVA-2910?focusedCommentId=53878 for more details.

References #816
