### PR TITLE
doc: Documented what max-message-batch-size means (even if it is weird)

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -138,8 +138,9 @@ akka.persistence.cassandra {
     # enabled and the keyspace doesn't exist already.
     data-center-replication-factors = []
 
-    # Maximum number of messages that will be batched when using `persistAsync`.
-    # Also used as the max batch size for deletes.
+    # Maximum total size in bytes of serialized messages that will be grouped in one batch when writing multiple
+    # events persisted with multiple calls to 'persist' or 'persistAsync' for one command.
+    # Also used as the max batch size in number of events for deletes.
     max-message-batch-size = 100
 
     # Target number of entries per partition (= columns per row).


### PR DESCRIPTION
Discovered that the current explanation does not match what is means for persisting.

Probably better to make it two separate settings or something. The default 100 bytes seems very low when referring to bytes as well? Also super confusing that it is used for bytes in one places and number of events in another.