### PR TITLE
Don't publish release twice

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,8 +7,6 @@ on:
       - main
       - release-*
     tags: ["v*"]
-  release:
-    types: [published]
 
 jobs:
   release:


### PR DESCRIPTION
When tagging from the release page it should not try to publish twice.