### PR TITLE
Update to java-driver 4.15.0

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -10,8 +10,8 @@ object Dependencies {
   val AkkaVersionInDocs = AkkaVersion.take(3)
   val CassandraVersionInDocs = "4.0"
   // Should be sync with the version of the driver in Alpakka Cassandra
-  val CassandraDriverVersion = "4.14.1"
-  val DriverVersionInDocs = "4.14"
+  val CassandraDriverVersion = "4.15.0"
+  val DriverVersionInDocs = "4.15"
 
   val AlpakkaVersion = "5.0.0-M2"
   val AlpakkaVersionInDocs = AlpakkaVersion.take(3)


### PR DESCRIPTION
Trying this update while we are at it. Solves a transitive dependency to Netty 4.1.75, which has CVE-2022-24823

If this is successful I will update in Alpakka.