### PR TITLE
ci: current GH actions versions and security tightening

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -9,17 +9,22 @@ on:
     tags-ignore:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   style-compile:
     name: Compile, Code Style
-    if: github.repository == 'akka/akka-persistence-cassandra'
-    runs-on: ubuntu-20.04
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 0
 
@@ -27,9 +32,11 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.1.2
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.0
+        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11
 
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6.3
@@ -40,14 +47,16 @@ jobs:
 
   documentation:
     name: ScalaDoc, Documentation with Paradox
-    if: github.repository == 'akka/akka-persistence-cassandra'
-    runs-on: ubuntu-20.04
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with: # https://github.com/olafurpg/setup-scala#faster-checkout-of-big-repos
           fetch-depth: 100
 
@@ -55,39 +64,45 @@ jobs:
         run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
 
       - name: Set up JDK 11
-        uses: coursier/setup-action@v1.1.2
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.0
+        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
-          jvm: adopt:11
+          jvm: temurin:1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.3
+        # https://github.com/coursier/cache-action/releases/
+        # v6.4.3
+        uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
 
       - name: "Create all API docs and create site with Paradox"
         run: sbt "unidoc; docs/makeSite"
 
       - name: Run Link Validator
-        run: cs launch net.runne::site-link-validator:0.2.2 -- project/link-validator.conf
+        run: cs launch net.runne::site-link-validator:0.2.3 -- project/link-validator.conf
 
   test:
     name: Test
-    if: github.repository == 'akka/akka-persistence-cassandra'
-    runs-on: ubuntu-20.04
+    if: github.event.repository.fork == false
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
         include:
-          - { jdk: 'adopt:8',  container: "cassandra-latest", test: "test" }
-          - { jdk: 'adopt:11', container: "cassandra-latest", test: "test" }
-          - { jdk: 'adopt:11', container: "cassandra2",       test: "'testOnly -- -l RequiresCassandraThree'"}
-          - { jdk: 'adopt:11', container: "cassandra3",       test: "test" }
+          - { jdk: 'adopt:8',           container: "cassandra-latest", test: "test" }
+          - { jdk: 'temurin:1.11.0.17', container: "cassandra-latest", test: "test" }
+          - { jdk: 'temurin:1.11.0.17', container: "cassandra2",       test: "'testOnly -- -l RequiresCassandraThree'"}
+          - { jdk: 'temurin:1.11.0.17', container: "cassandra3",       test: "test" }
 
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           fetch-depth: 0
 
@@ -98,12 +113,16 @@ jobs:
           git checkout scratch
 
       - name: Set up JDK ${{ matrix.jdk }}
-        uses: coursier/setup-action@v1.1.2
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.0
+        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
           jvm: ${{ matrix.jdk }}
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.3
+        # https://github.com/coursier/cache-action/releases/
+        # v6.4.3
+        uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
 
       - name: Test against ${{ matrix.container }}
         run: |-

--- a/.github/workflows/fossa.yml
+++ b/.github/workflows/fossa.yml
@@ -5,29 +5,38 @@ on:
   schedule:
     - cron: '0 0 * * 0' # At 00:00 on Sunday
 
+permissions:
+  contents: read
+
 jobs:
   fossa:
     name: Fossa
     runs-on: ubuntu-latest
-    if: github.repository == 'akka/akka-persistence-cassandra'
+    if: github.event.repository.fork == false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
       - name: Set up JDK 11
-        uses: olafurpg/setup-scala@v13
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.0
+        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
-          java-version: adopt@1.11
+          jvm: temurin:1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v6.2
+        # https://github.com/coursier/cache-action/releases/
+        # v6.4.3
+        uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
 
       - name: FOSSA policy check
         run: |-
-          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/spectrometer/master/install.sh | bash
-          fossa analyze && fossa test
+          curl -H 'Cache-Control: no-cache' https://raw.githubusercontent.com/fossas/fossa-cli/master/install-latest.sh | bash
+          fossa analyze
         env:
           FOSSA_API_KEY: "${{secrets.FOSSA_API_KEY}}"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,29 +8,38 @@ on:
       - release-*
     tags: ["v*"]
 
+permissions:
+  contents: read
+
 jobs:
   release:
     # runs on main repo only
-    if: github.repository == 'akka/akka-persistence-cassandra'
+    if: github.event.repository.fork == false
     name: Release
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Setup Scala with JDK 8
-        uses: olafurpg/setup-scala@v10
+      - name: Setup JDK 8
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.0
+        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
-          java-version: adopt@1.8.0-275
+          java-version: adopt:1.8.0-275
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        # https://github.com/coursier/cache-action/releases/
+        # v6.4.3
+        uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
 
       - name: Publish artifacts for all Scala versions
         env:
@@ -42,26 +51,32 @@ jobs:
 
   documentation:
     # runs on main repo only
-    if: github.repository == 'akka/akka-persistence-cassandra'
+    if: github.event.repository.fork == false
     name: Documentation
     environment: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
 
-      - name: Setup Scala with JDK 11
-        uses: olafurpg/setup-scala@v10
+      - name: Setup JDK 11
+        # https://github.com/coursier/setup-action/releases
+        # v1.3.0
+        uses: coursier/setup-action@70323223454ac2a9eb2de46f389b4d045cbcdea5
         with:
-          java-version: adopt@1.11.0-9
+          jvm: temurin:1.11
 
       - name: Cache Coursier cache
-        uses: coursier/cache-action@v5
+        # https://github.com/coursier/cache-action/releases/
+        # v6.4.3
+        uses: coursier/cache-action@d1039466d0812d6370649b9afb02bbf5f646bacf
 
       - name: Publish API and reference documentation
         env:

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -2,17 +2,22 @@ name: Release Drafter
 
 on:
   push:
-    # branches to consider in the event; optional, defaults to all
     branches:
       - master
+      - main
+
+permissions:
+  contents: read
 
 jobs:
   update_release_draft:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: write
     steps:
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        with:
-          config-name: release-drafter.yml # located in .github/ in default branch
+      # Drafts your next Release notes as Pull Requests are merged
+      # https://github.com/release-drafter/release-drafter/releases
+      # v5.22.0
+      - uses: release-drafter/release-drafter@cfc5540ebc9d65a8731f02032e3d44db5e449fb6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/docs/release-train-issue-template.md
+++ b/docs/release-train-issue-template.md
@@ -14,7 +14,7 @@ Variables to be expanded in this template:
 ### Cutting the release
 
 - [ ] Check that open PRs and issues assigned to the milestone are reasonable
-- [ ] For minor or major versions, update the Change date in the LICENSE file and update the `licenses` url in the build.
+- [ ] For minor or major versions, update the Change date in the LICENSE file
 - [ ] Create a new milestone for the [next version](https://github.com/akka/akka-persistence-cassandra/milestones)
 - [ ] Close the [$VERSION$ milestone](https://github.com/akka/akka-persistence-cassandra/milestones?direction=asc&sort=due_date)
 - [ ] Make sure all important PRs have been merged

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -35,46 +35,6 @@ The table below shows Akka Persistence Cassandra’s direct dependencies and the
 
 To use the plugin with **Akka 2.5.x** you must use @extref:[version 0.103](apc-0.x:) or later in the 0.x series. 
 
-## Snapshots
-
-[bintray-badge]:  https://api.bintray.com/packages/akka/snapshots/akka-persistence-cassandra/images/download.svg
-[bintray]:        https://bintray.com/akka/snapshots/akka-persistence-cassandra/_latestVersion
-
-Snapshots are published to a snapshot repository in Sonatype after every successful build on master. Add the following to your project build definition to resolve snapshots:
-
-sbt
-:   ```scala
-    resolvers += Resolver.bintrayRepo("akka", "snapshots")
-    ```
-
-Maven
-:   ```xml
-    <project>
-    ...
-      <repositories>
-        <repository>
-          <id>akka-snapshots</id>
-          <name>Akka Snapshots</name>
-          <url>https://dl.bintray.com/akka/snapshots</url>
-        </repository>
-      </repositories>
-    ...
-    </project>
-    ```
-
-Gradle
-:   ```gradle
-    repositories {
-      maven {
-        url  "https://dl.bintray.com/akka/snapshots"
-      }
-    }
-    ```
-
-Latest published snapshot version is [![bintray-badge][]][bintray]
-
-The [snapshot documentation](https://doc.akka.io/docs/akka-persistence-cassandra/snapshot/) is updated with every snapshot build.
-
 ## History
 
 This [Apache Cassandra](https://cassandra.apache.org/) plugin to Akka Persistence was initiated [originally](https://github.com/krasserm/akka-persistence-cassandra) by Martin Krasser, [@krasserm](https://github.com/krasserm) in 2014.

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -30,8 +30,15 @@ object Common extends AutoPlugin {
           "Contributors",
           "https://gitter.im/akka/dev",
           url("https://github.com/akka/akka-persistence-cassandra/graphs/contributors")),
-      licenses := Seq(
-          ("BUSL-1.1", url("https://raw.githubusercontent.com/akka/akka-persistence-cassandra/master/LICENSE"))), // FIXME change s/master/v1.1.1/ when released
+      licenses := {
+        val tagOrBranch =
+          if (version.value.endsWith("SNAPSHOT")) "master"
+          else "v" + version.value
+        Seq(
+          (
+            "BUSL-1.1",
+            url(s"https://raw.githubusercontent.com/akka/akka-persistence-cassandra/${tagOrBranch}/LICENSE")))
+      },
       description := "A Cassandra plugin for Akka Persistence.")
 
   override lazy val projectSettings = Seq(

--- a/project/project-info.conf
+++ b/project/project-info.conf
@@ -2,11 +2,10 @@ project-info {
   version: "current"
   shared-info {
     jdk-versions: ["Adopt OpenJDK 8", "Adopt OpenJDK 11"]
-//    snapshots: {
-//      url: "other-docs/snapshots.html"
-//      text: "Snapshots are available"
-//      new-tab: false
-//    }
+    snapshots: {
+      url: "https://oss.sonatype.org/content/repositories/snapshots/com/typesafe/akka/akka-persistence-cassandra_2.13/"
+      text: "Snapshots are available from Sonatype"
+    }
     issues: {
       url: "https://github.com/akka/akka-persistence-cassandra/issues"
       text: "GitHub issues"


### PR DESCRIPTION
- Bump GH action versions to current released versions specified by their full hash.
- Use `permissions` restriction
- Run on Ubuntu 22.02
- Use Eclipse Temurin JDK for 11