### PR TITLE
fix: Buffer.addPending sets writeRequired

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/Buffer.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/Buffer.scala
@@ -107,7 +107,7 @@ private[akka] case class Buffer(
   }
 
   final def addPending(write: AwaitingWrite): Buffer = {
-    copy(size = size + write.events.size, pending = pending :+ write)
+    copy(size = size + write.events.size, pending = pending :+ write, writeRequired = true)
   }
 
   def writeComplete(): Buffer = {


### PR DESCRIPTION
```scala
require(pending.isEmpty, "Pending should be empty if write not required")
```

suggests that an invariant of `journal.Buffer` is that `writeRequired || pending.nonEmpty`.  The `addPending` method, if called on a `Buffer` where `writeRequired` is `false` will break this invariant, which may cause subsequent adds to the buffer to throw, crashing the `TagWriter` and forcing an `ActorSystem` restart.