### PR TITLE
bump: Akka Paradox, Paradox Dependencies; remove old refs from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,7 @@ Cassandra Plugins for Akka Persistence
 
 Replicated [Akka Persistence](https://doc.akka.io/docs/akka/current/scala/persistence.html) journal and snapshot store backed by [Apache Cassandra](https://cassandra.apache.org/).
 
-For questions please use the [discuss.akka.io](https://discuss.lightbend.com/c/akka/) or [![gitter: akka/akka](https://img.shields.io/badge/gitter%3A-akka%2Fakka-blue.svg?style=flat-square)](https://gitter.im/akka/akka).
-
-Implementation in the `main` branch is currently `1.0.x` release.
+For questions please use the [discuss.akka.io](https://discuss.lightbend.com/c/akka/).
 
 
 ## Documentation
@@ -22,14 +20,6 @@ For versions earlier than 1.0.0, check this README.md file for the corresponding
 This [Apache Cassandra](https://cassandra.apache.org/) plugin to Akka Persistence was initiated [originally](https://github.com/krasserm/akka-persistence-cassandra) by Martin Krasser, [@krasserm](https://github.com/krasserm) in 2014.
 
 It moved to the [Akka](https://github.com/akka/) organisation in 2016 and the first release after that move was 0.7 in January 2016.
-
-## Branches and versions
-
-There are three branches of development:
-
-* 1.0 -> `main` - current active development and stable 1.0.x patch releases
-* 0.80+ (currently 0.100) -> `release-0.x`  - removed use of Cassandra Materialized Views after they were marked as not to be used in production. 
-* 0.50+ (currently 0.62) -> `release-0.50`- first release under this organisation, previously under krasserm. No planned releases for this version.
 
 ## License
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -5,8 +5,8 @@ addSbtPlugin("com.dwijnand" % "sbt-dynver" % "4.1.1")
 addSbtPlugin("com.github.sbt" % "sbt-ci-release" % "1.5.12")
 
 // Documentation
-addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.51")
-addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.2")
+addSbtPlugin("com.lightbend.akka" % "sbt-paradox-akka" % "0.53")
+addSbtPlugin("com.lightbend.paradox" % "sbt-paradox-dependencies" % "0.2.4")
 addSbtPlugin("com.lightbend.sbt" % "sbt-publish-rsync" % "0.2")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.github.sbt" % "sbt-site-paradox" % "1.5.0")


### PR DESCRIPTION
Even remove references to Gitter and stale information about branches from the Readme.

References
- https://github.com/akka/akka-paradox/releases/tag/v0.53
- https://github.com/lightbend/sbt-paradox-dependencies/releases/tag/v0.2.4