### PR TITLE
chore: Enable Dependency Submission to GitHub

### DIFF
--- a/.github/workflows/dependency-submission.yml
+++ b/.github/workflows/dependency-submission.yml
@@ -1,0 +1,20 @@
+name: Update Dependency Graph
+
+on:
+  workflow_dispatch:
+
+jobs:
+  dependency-submission:
+    name: Update Dependency Graph
+    runs-on: ubuntu-latest
+    if: github.event.repository.fork == false
+    steps:
+      - name: Checkout
+        # https://github.com/actions/checkout/releases
+        # v3.3.0
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c
+      - name: Submit sbt dependencies
+        # https://github.com/scalacenter/sbt-dependency-submission/releases
+        # v2.2.2
+        uses: scalacenter/sbt-dependency-submission@6807cf91e9dc7af7c314b988d56d928d5828605b
+        configs-ignore: test


### PR DESCRIPTION
Use https://github.com/scalacenter/sbt-dependency-submission to report dependencies to GitHub's dependency analysis and vulnerability checking.