### PR TITLE
fix: Ask/wait for TagWrite in sendMissingTagWrite

### DIFF
--- a/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
+++ b/core/src/main/scala/akka/persistence/cassandra/journal/CassandraJournal.scala
@@ -449,7 +449,7 @@ import akka.stream.scaladsl.Source
         val persistentActor = sender()
         for {
           seqNr <- highestSequenceNr
-          _ <- tagRecovery.get.sendPersistentActorStarting(persistenceId, persistentActor)
+          _ <- tr.sendPersistentActorStarting(persistenceId, persistentActor)
           _ <- if (seqNr == fromSequenceNr && seqNr != 0) {
             log.debug(
               "[{}] snapshot is current so replay won't be required. Calculating tag progress now",

--- a/docs/src/main/paradox/events-by-tag.md
+++ b/docs/src/main/paradox/events-by-tag.md
@@ -251,7 +251,7 @@ imposed with new implementation but it is advised to keep it small i.e. less tha
 for each persistenceId.
 
 ```
-CREATE TABLE akka.tag_views_progress (                              
+CREATE TABLE akka.tag_write_progress (                              
     peristence_id text,           
     tag text,                     
     sequence_nr bigint,           


### PR DESCRIPTION
* used in recovery
* intention is to slow down or fail recovery if tag writing isn't responsive
* the existing tests `akka.persistence.cassandra.EventsByTag*Spec` are covering this code path 