### PR TITLE
build: use global action step

### DIFF
--- a/.github/workflows/check-build-test.yml
+++ b/.github/workflows/check-build-test.yml
@@ -42,6 +42,9 @@ jobs:
         # v6.4.5
         uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: "Code style, compile tests"
         run: sbt "verifyCodeStyle; +Test/compile"
 
@@ -87,6 +90,9 @@ jobs:
         # https://github.com/coursier/cache-action/releases
         # v6.4.5
         uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Test against ${{ matrix.container }} / ${{ matrix.jdk }}
         run: |-

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -40,6 +40,9 @@ jobs:
         # v6.4.5
         uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: "Create all API docs and create site with Paradox"
         run: sbt "unidoc; docs/makeSite"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -40,6 +40,9 @@ jobs:
         # v6.4.5
         uses: coursier/cache-action@1ff273bff02a8787bc9f1877d347948af647956d
 
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
+
       - name: Publish artifacts for all Scala versions
         env:
           PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
@@ -67,6 +70,9 @@ jobs:
         uses: coursier/setup-action@7bde40eee928896f074dbb76d22dd772eed5c65f
         with:
           jvm: temurin:1.25
+
+      - name: Run akka/github-actions-scripts
+        uses: akka/github-actions-scripts/setup_global_resolver@main
 
       - name: Publish
         run: |-

--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ The current versions of all Akka libraries are listed on the [Akka Dependencies]
 
 
 
+## Build Token
+
+To build locally, you need to fetch a token at https://account.akka.io/token that you have to place into `~/.sbt/1.0/akka-commercial.sbt` file like this:
+```
+ThisBuild / resolvers += "lightbend-akka".at("your token resolver here")
+```
+
 ## History
 
 This [Apache Cassandra](https://cassandra.apache.org/) plugin to Akka Persistence was initiated [originally](https://github.com/krasserm/akka-persistence-cassandra) by Martin Krasser, [@krasserm](https://github.com/krasserm) in 2014.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,6 @@
 import com.typesafe.sbt.packager.docker._
 import com.geirsson.CiReleasePlugin
 
-ThisBuild / resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
 ThisBuild / resolvers ++= {
   if (System.getProperty("override.akka.version") != null)
     Seq("Akka library snapshot repository".at("https://repo.akka.io/snapshots"))

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,3 @@
-resolvers += "Akka library repository".at("https://repo.akka.io/maven/github_actions")
-
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.10.0")
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.5.5")
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")


### PR DESCRIPTION
## Summary
- Add `akka/github-actions-scripts/setup_global_resolver@main` step to all build workflows (check-build-test, publish, link-validator)
- Remove `https://repo.akka.io/maven/github_actions` resolver from `build.sbt` and `project/plugins.sbt`
- Add `## Build Token` section to README.md with local build instructions

## Test plan
- [ ] CI workflows pass with the new global resolver step
- [ ] README Build Token section renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)